### PR TITLE
Add character boundary check

### DIFF
--- a/examples/tests.rs
+++ b/examples/tests.rs
@@ -1,4 +1,4 @@
-use test_grammar::{consonants, options, list};
+use test_grammar::{consonants, options, list, boundaries};
 mod test_grammar;
 
 #[test]
@@ -18,4 +18,12 @@ fn test_optional() {
 fn test_list() {
 	assert_eq!(list("5"), Ok(vec![5]));
 	assert_eq!(list("1,2,3,4"), Ok(vec![1,2,3,4]));
+}
+
+#[test]
+// before we were testing string matches using .slice(), which
+// threw an ugly fail!() when we compared unequal character
+// boundaries.. this popped up while parsing unicode
+fn test_boundaries() {
+	assert!(boundaries("f↙↙↙↙").is_err());
 }

--- a/examples/tests.rustpeg
+++ b/examples/tests.rustpeg
@@ -16,3 +16,7 @@ number -> int
 #[export]
 list -> Vec<int>
 	= number ** ","
+
+#[export]
+boundaries -> String
+	= "foo" { match_str.to_string() }

--- a/src/grammar.rs
+++ b/src/grammar.rs
@@ -8,7 +8,8 @@
 fn slice_eq(input: &str, pos: uint, m: &str) -> Result<(uint, ()), uint> {
     #![inline]
     let l = m.len();
-    if input.len() >= pos + l && input.slice(pos, pos + l) == m {
+    if input.len() >= pos + l &&
+           input.as_bytes().slice(pos, pos + l) == m.as_bytes() {
         Ok((pos + l, ()))
     } else { Err(pos) }
 }

--- a/src/translate.rs
+++ b/src/translate.rs
@@ -80,7 +80,7 @@ pub fn header_items(ctxt: &rustast::ExtCtxt) -> Vec<rustast::P<rustast::Item>> {
 		fn slice_eq(input: &str, pos: uint, m: &str) -> Result<(uint, ()), uint> {
 			#![inline]
 	    let l = m.len();
-	    if input.len() >= pos + l && input.slice(pos, pos+l) == m {
+	    if input.len() >= pos + l && input.as_bytes().slice(pos, pos+l) == m.as_bytes() {
 	        Ok((pos+l, ()))
 	    } else {
 	        Err(pos)


### PR DESCRIPTION
Fixes a bug when parsing unicode.
