### PR TITLE
Make Cargo rebuild when a peg_file! source file is modified.

### DIFF
--- a/src/peg_syntax_ext.rs
+++ b/src/peg_syntax_ext.rs
@@ -58,6 +58,8 @@ fn expand_peg_file<'s>(cx: &'s mut ExtCtxt, sp: codemap::Span, ident: ast::Ident
 
     let source = str::from_utf8(source_utf8.as_slice()).unwrap();
 
+    cx.codemap().new_filemap(path.as_str().unwrap().to_string(), "".to_string());
+
     expand_peg(cx, sp, ident, source.as_slice())
 }
 


### PR DESCRIPTION
Have the `peg_file!` macro register the file in the compiler’s codemap. Cargo only looks at the modification date of files in this map to decide whether to rebuild something.

Thanks @tomaka for the tip!
