### PR TITLE
Fix arithmetic example to use macro semi-colon terminator

### DIFF
--- a/examples/test_arithmetic.rs
+++ b/examples/test_arithmetic.rs
@@ -24,7 +24,7 @@ atom -> int
 
 number -> int
 	= [0-9]+ { from_str::<int>(match_str).unwrap() }
-"#)
+"#);
 
 fn main() {
 	assert_eq!(expression("1+1"), Ok(2));


### PR DESCRIPTION
Current rustc fails the build without the semi-colon
