### PR TITLE
Use 0.1.0 as dependency range

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Add to your Cargo.toml:
 
 ```
 [dependencies]
-peg = "~0.1.0"
+peg = "0.1.0"
 ```
 
 Add to your crate root:

--- a/examples/tests.rustpeg
+++ b/examples/tests.rustpeg
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 use std::borrow::{IntoCow, ToOwned};
-use std::str::CowString;
+use std::string::CowString;
 
 #[export]
 consonants

--- a/src/fake_extctxt.rs
+++ b/src/fake_extctxt.rs
@@ -3,7 +3,7 @@ use syntax::codemap::DUMMY_SP;
 use syntax::ext::base::ExtCtxt;
 
 /// Create a fake ExtCtxt to perform macro quasiquotes outside of rustc plugins
-pub fn with_fake_extctxt<T>(f: |&ExtCtxt| -> T) -> T {
+pub fn with_fake_extctxt<T, F: Fn(&ExtCtxt) -> T>(f: F) -> T {
   let ps = syntax::parse::new_parse_sess();
 
   let mut cx = syntax::ext::base::ExtCtxt::new(&ps, Vec::new(),


### PR DESCRIPTION
This evaluates to ^0.1.0 which is the way to define "semver compatible
version to 0.1.0". This fixes some issues with ~ and unstable (0.*)
versions and allows breaking changes in 0.x steps.