### PR TITLE
Implement case insensitivity via the "i" flag for quoted literals

### DIFF
--- a/examples/tests.rs
+++ b/examples/tests.rs
@@ -47,10 +47,11 @@ fn test_repeat() {
 
 #[test]
 // before we were testing string matches using .slice(), which
-// threw an ugly fail!() when we compared unequal character
+// threw an ugly panic!() when we compared unequal character
 // boundaries.. this popped up while parsing unicode
 fn test_boundaries() {
 	assert!(boundaries("f↙↙↙↙").is_err());
+	assert!(case_insensitive("f↙↙↙↙").is_err());
 }
 
 #[test]
@@ -75,4 +76,15 @@ fn test_keyval() {
     expected.insert(1, 3);
     expected.insert(2, 4);
     assert_eq!(keyvals("1:3\n2:4"), Ok(expected));
+}
+
+#[test]
+fn test_case_insensitive() {
+	assert_eq!(case_insensitive("foo").unwrap(), "foo");
+	assert_eq!(case_insensitive("FoO").unwrap(), "FoO");
+	assert_eq!(case_insensitive("fOo").unwrap(), "fOo");
+	assert_eq!(case_insensitive("FOO").unwrap(), "FOO");
+	assert!(case_insensitive("boo").is_err());
+	assert!(case_insensitive(" foo").is_err());
+	assert!(case_insensitive("foo ").is_err());
 }

--- a/examples/tests.rustpeg
+++ b/examples/tests.rustpeg
@@ -39,6 +39,10 @@ repeat_min_max -> Vec<i64>
 #[export]
 boundaries -> String
 	= "foo" { match_str.to_string() }
+	
+#[export]
+case_insensitive -> String
+	= "foo"i { match_str.to_string() }
 
 #[export]
 borrowed -> &'input str

--- a/src/grammar.rustpeg
+++ b/src/grammar.rustpeg
@@ -191,8 +191,8 @@ identifier -> String
  * vaguely).
  */
 literal -> Expr
-  = value:(doubleQuotedString / singleQuotedString) flags:"i"? __ {
-      LiteralExpr(value)
+  = value:(doubleQuotedString / singleQuotedString) case_insensitive:"i"? __ {
+      LiteralExpr(value,case_insensitive.is_some())
     }
 
 string -> String


### PR DESCRIPTION
Implements case insensitivity via the "i" flag after a quoted literal. e.g. "foo"i will match FOO,foo,FoO...etc.

Care was taken to ensure comparisons were utf8 safe.

Test cases created & tests all pass.