### PR TITLE
Update all uses of std::io to use new std::old_io module

### DIFF
--- a/src/peg.rs
+++ b/src/peg.rs
@@ -4,8 +4,8 @@
 extern crate syntax;
 
 use std::str;
-use std::io::{stdin,stdout,stderr};
-use std::io::fs::File;
+use std::old_io::{stdin,stdout,stderr};
+use std::old_io::fs::File;
 use std::os;
 use translate::{compile_grammar};
 

--- a/src/peg_syntax_ext.rs
+++ b/src/peg_syntax_ext.rs
@@ -12,7 +12,7 @@ use syntax::parse;
 use syntax::parse::token;
 use syntax::fold::Folder;
 use rustc::plugin::Registry;
-use std::io::fs::File;
+use std::old_io::fs::File;
 use std::str;
 
 use rustast::{AstBuilder, DUMMY_SP};


### PR DESCRIPTION
Rust is currently in the process of a complete overhaul of `std:io`. They moved the current `io` api to `std::old_io`. This pull request updates the three uses of `io` to `old_io` to keep rust-peg building on the nightly rustc.