### PR TITLE
Use deref instead of get on syntax::parse::token::InternedString

### DIFF
--- a/src/peg_syntax_ext.rs
+++ b/src/peg_syntax_ext.rs
@@ -101,7 +101,7 @@ fn parse_arg(cx: &mut ExtCtxt, tts: &[ast::TokenTree]) -> Option<String> {
                                     "expected only one string literal");
                         return None
                     }
-                    return Some(n.get().to_string())
+                    return Some(n.to_string())
                 }
                 _ => {}
             }


### PR DESCRIPTION
Fixes 
```
/peg_syntax_ext.rs:104:35: 104:40 error: type `&syntax::parse::token::InternedString` does not implement any method in scope named `get`
```