### PR TITLE
Fixed compilation on newest nightly

### DIFF
--- a/src/peg_syntax_ext.rs
+++ b/src/peg_syntax_ext.rs
@@ -101,7 +101,7 @@ fn parse_arg(cx: &mut ExtCtxt, tts: &[ast::TokenTree]) -> Option<String> {
                                     "expected only one string literal");
                         return None
                     }
-                    return Some(n.get().to_string())
+                    return Some(n.to_string())
                 }
                 _ => {}
             }


### PR DESCRIPTION
InternedString dropped the `get()` method and now implements `Deref`, which allows us to access the methods of the underlying `&str` directly.