### PR TITLE
Rustup

### DIFF
--- a/examples/tests.rustpeg
+++ b/examples/tests.rustpeg
@@ -1,6 +1,5 @@
 use std::collections::HashMap;
-use std::borrow::{IntoCow, ToOwned};
-use std::string::CowString;
+use std::borrow::{IntoCow, ToOwned, Cow};
 
 #[export]
 consonants
@@ -49,7 +48,7 @@ borrowed -> &'input str
 	= [a-z]+ { match_str }
 
 #[export]
-lifetime_parameter -> CowString<'input>
+lifetime_parameter -> Cow<'input, str>
 	= [a-z]+ { match_str.into_cow() }
 	/ "COW"  { "cow".to_owned().into_cow() }
 

--- a/src/grammar.rs
+++ b/src/grammar.rs
@@ -38,7 +38,7 @@ fn slice_eq_case_insensitive(input: &str, state: &mut ParseState, pos: usize,
                              m: &'static str) -> ParseResult<()> {
     #![inline]
     #![allow(dead_code)]
-    let mut used = 0us;
+    let mut used = 0usize;
     let mut input_iter = input[pos..].chars();
     for m_char in m.chars() {
         let m_char_upper = m_char.to_uppercase();
@@ -614,7 +614,7 @@ fn parse_rust_use<'input>(input: &'input str, state: &mut ParseState,
                                                                                                                                                 }
                                                                                                                                                 if repeat_value.len()
                                                                                                                                                        >=
-                                                                                                                                                       1us
+                                                                                                                                                       1usize
                                                                                                                                                    {
                                                                                                                                                     Matched(repeat_pos,
                                                                                                                                                             repeat_value)
@@ -854,7 +854,7 @@ fn parse_rust_path<'input>(input: &'input str, state: &mut ParseState,
                             Failed => { break ; }
                         }
                     }
-                    if repeat_value.len() >= 1us {
+                    if repeat_value.len() >= 1usize {
                         Matched(repeat_pos, ())
                     } else { Failed }
                 };
@@ -1312,7 +1312,7 @@ fn parse_rust_type<'input>(input: &'input str, state: &mut ParseState,
                                                                             }
                                                                             if repeat_value.len()
                                                                                    >=
-                                                                                   1us
+                                                                                   1usize
                                                                                {
                                                                                 Matched(repeat_pos,
                                                                                         ())
@@ -2618,7 +2618,7 @@ fn parse_nonBraceCharacters<'input>(input: &'input str,
                 Failed => { break ; }
             }
         }
-        if repeat_value.len() >= 1us {
+        if repeat_value.len() >= 1usize {
             Matched(repeat_pos, ())
         } else { Failed }
     }
@@ -2861,7 +2861,7 @@ fn parse_integer<'input>(input: &'input str, state: &mut ParseState,
                                         Failed => { break ; }
                                     }
                                 }
-                                if repeat_value.len() >= 1us {
+                                if repeat_value.len() >= 1usize {
                                     Matched(repeat_pos, ())
                                 } else { Failed }
                             };
@@ -4002,7 +4002,7 @@ fn parse_unicodeEscapeSequence<'input>(input: &'input str,
                                                     Failed => { break ; }
                                                 }
                                             }
-                                            if repeat_value.len() >= 1us {
+                                            if repeat_value.len() >= 1usize {
                                                 Matched(repeat_pos, ())
                                             } else { Failed }
                                         };

--- a/src/peg.rs
+++ b/src/peg.rs
@@ -1,4 +1,4 @@
-#![feature(quote, box_syntax, core, collections, rustc_private, io, path, unicode, os, env, box_patterns)]
+#![feature(quote, box_syntax, core, collections, rustc_private, old_io, old_path, unicode, os, env, box_patterns)]
 extern crate syntax;
 
 use std::str;

--- a/src/peg_syntax_ext.rs
+++ b/src/peg_syntax_ext.rs
@@ -1,4 +1,4 @@
-#![feature(plugin_registrar, quote, box_syntax, core, collections, rustc_private, io, unicode, path, box_patterns)]
+#![feature(plugin_registrar, quote, box_syntax, core, collections, rustc_private, unicode, box_patterns, old_path, old_io)]
 
 extern crate rustc;
 extern crate syntax;

--- a/src/translate.rs
+++ b/src/translate.rs
@@ -135,7 +135,7 @@ pub fn header_items(ctxt: &rustast::ExtCtxt) -> Vec<rustast::P<rustast::Item>> {
 			#![inline]
 			#![allow(dead_code)]
 
-			let mut used = 0us;
+			let mut used = 0usize;
 			let mut input_iter = input[pos..].chars();
 
 			for m_char in m.chars() {


### PR DESCRIPTION
Fixes the following:
* `us` integer suffix to `usize`
* `io` & `path` features were renamed to `old_io` & `old_path`
* `CowString` was removed from the std. Convert usage to `Cow<'a, str>` 