### PR TITLE
Make parsers return a custom error type

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,3 +20,7 @@ name = "peg_syntax_ext"
 [[bin]]
 name = "test_arithmetic"
 path = "examples/test_arithmetic.rs"
+
+[[bin]]
+name = "test_errors"
+path = "examples/test_errors.rs"

--- a/examples/test_errors.rs
+++ b/examples/test_errors.rs
@@ -1,4 +1,4 @@
-#![feature(plugin)]
+#![feature(core, plugin)]
 #![plugin(peg_syntax_ext)]
 
 use parser::parse;

--- a/examples/test_errors.rs
+++ b/examples/test_errors.rs
@@ -1,0 +1,26 @@
+#![feature(plugin)]
+#![plugin(peg_syntax_ext)]
+
+use parser::parse;
+use parser::ParseError;
+
+peg! parser(r#"
+#[pub]
+parse -> usize
+    = v:( "a" / "\n" )*   { v.len() }
+"#);
+
+fn main() {
+    assert_eq!(parse(r#"
+aaaa
+aaaaaa
+aaaabaaaa
+"#), Err(ParseError {
+        line: 4,
+        column: 5,
+        offset: 17,
+        expected: vec!["a", "\n"].into_iter().collect(),
+    }));
+
+    println!("Ok");
+}

--- a/src/grammar.rs
+++ b/src/grammar.rs
@@ -10,7 +10,7 @@ struct ParseState {
     expected: ::std::collections::HashSet<&'static str>,
 }
 #[derive(PartialEq, Eq, Debug)]
-struct ParseError {
+pub struct ParseError {
     pub line: usize,
     pub column: usize,
     pub offset: usize,

--- a/src/grammar.rs
+++ b/src/grammar.rs
@@ -19,23 +19,20 @@ pub struct ParseError {
 impl ::std::fmt::Display for ParseError {
     fn fmt(&self, fmt: &mut ::std::fmt::Formatter)
      -> ::std::result::Result<(), ::std::fmt::Error> {
-        fn quote_expect(s: &'static str) -> &'static str {
-            match s { "\n" => "\\n", "\t" => "\\t", _ => s, }
-        }
         try!(write ! (
              fmt , "error at {}:{}: expected " , self . line , self . column
              ));
         if self.expected.len() == 1 {
             try!(write ! (
-                 fmt , "`{}`" , quote_expect (
-                 self . expected . iter (  ) . next (  ) . unwrap (  ) ) ));
+                 fmt , "`{}`" , self . expected . iter (  ) . next (  ) .
+                 unwrap (  ) . escape_default (  ) ));
         } else {
             let mut iter = self.expected.iter();
             try!(write ! (
-                 fmt , "one of `{}`" , quote_expect (
-                 iter . next (  ) . unwrap (  ) ) ));
+                 fmt , "one of `{}`" , iter . next (  ) . unwrap (  ) .
+                 escape_default (  ) ));
             for elem in iter {
-                try!(write ! ( fmt , ", `{}`" , quote_expect ( elem ) ));
+                try!(write ! ( fmt , ", `{}`" , elem . escape_default (  ) ));
             }
         }
         Ok(())

--- a/src/grammar.rs
+++ b/src/grammar.rs
@@ -39,6 +39,9 @@ impl ::std::fmt::Display for ParseError {
         Ok(())
     }
 }
+impl ::std::error::Error for ParseError {
+    fn description(&self) -> &str { "parse error" }
+}
 impl ParseState {
     fn new() -> ParseState {
         ParseState{max_err_pos: 0,

--- a/src/peg_syntax_ext.rs
+++ b/src/peg_syntax_ext.rs
@@ -69,7 +69,7 @@ fn expand_peg(cx: &mut ExtCtxt, sp: codemap::Span, ident: ast::Ident, source: &s
     let grammar_def = match grammar_def {
       Ok(grammar_def) => grammar_def,
       Err(msg) => {
-        cx.span_err(sp, msg.as_slice());
+        cx.span_err(sp, format!("{}", msg).as_slice());
         return DummyResult::any(sp)
       }
     };

--- a/src/translate.rs
+++ b/src/translate.rs
@@ -105,7 +105,7 @@ pub fn header_items(ctxt: &rustast::ExtCtxt) -> Vec<rustast::P<rustast::Item>> {
 			pub expected: ::std::collections::HashSet<&'static str>,
 		}
 	).unwrap());
-	
+
 	items.push(quote_item!(ctxt,
 		pub type ParseResult<T> = Result<T, ParseError>;
 	).unwrap());
@@ -126,6 +126,14 @@ pub fn header_items(ctxt: &rustast::ExtCtxt) -> Vec<rustast::P<rustast::Item>> {
 				}
 
 				Ok(())
+			}
+		}
+	).unwrap());
+
+	items.push(quote_item!(ctxt,
+		impl ::std::error::Error for ParseError {
+			fn description(&self) -> &str {
+				"parse error"
 			}
 		}
 	).unwrap());

--- a/src/translate.rs
+++ b/src/translate.rs
@@ -109,23 +109,15 @@ pub fn header_items(ctxt: &rustast::ExtCtxt) -> Vec<rustast::P<rustast::Item>> {
 	items.push(quote_item!(ctxt,
 		impl ::std::fmt::Display for ParseError {
 			fn fmt(&self, fmt: &mut ::std::fmt::Formatter) -> ::std::result::Result<(), ::std::fmt::Error> {
-				fn quote_expect(s: &'static str) -> &'static str {
-					match s {
-						"\n" => "\\n",
-						"\t" => "\\t",
-						_ => s,
-					}
-				}
-
 				try!(write!(fmt, "error at {}:{}: expected ", self.line, self.column));
 				if self.expected.len() == 1 {
-					try!(write!(fmt, "`{}`", quote_expect(self.expected.iter().next().unwrap())));
+					try!(write!(fmt, "`{}`", self.expected.iter().next().unwrap().escape_default()));
 				} else {
 					let mut iter = self.expected.iter();
 
-					try!(write!(fmt, "one of `{}`", quote_expect(iter.next().unwrap())));
+					try!(write!(fmt, "one of `{}`", iter.next().unwrap().escape_default()));
 					for elem in iter {
-						try!(write!(fmt, ", `{}`", quote_expect(elem)));
+						try!(write!(fmt, ", `{}`", elem.escape_default()));
 					}
 				}
 

--- a/src/translate.rs
+++ b/src/translate.rs
@@ -98,7 +98,7 @@ pub fn header_items(ctxt: &rustast::ExtCtxt) -> Vec<rustast::P<rustast::Item>> {
 
 	items.push(quote_item!(ctxt,
 		#[derive(PartialEq, Eq, Debug)]
-		struct ParseError {
+		pub struct ParseError {
 			pub line: usize,
 			pub column: usize,
 			pub offset: usize,


### PR DESCRIPTION
A `ParseError` type is added to the generated parser module, containing the location in the input data that caused the error, as well as the set of expected items. If an error occurs, a `ParseError` is returned instead of a `String`. As a byproduct, parse errors now look nicer (since the `Display` implementation of `ParseError` does some custom formatting).

Note that the documentation wasn't yet updated to reflect this. Also, this is a breaking change (obviously), but since rust-peg is oriented towards the nightly builds, this should not be a big concern (this breakage can be easily fixed anyway).