### PR TITLE
Implement Backreferences

### DIFF
--- a/src/grammar.rs
+++ b/src/grammar.rs
@@ -1648,21 +1648,61 @@ fn parse_labeled<'input>(input: &'input str, state: &mut ParseState,
         match choice_res {
             Matched(pos, value) => Matched(pos, value),
             Failed => {
-                let start_pos = pos;
-                {
-                    let seq_res = parse_prefixed(input, state, pos);
-                    match seq_res {
-                        Matched(pos, expr) => {
-                            {
-                                let match_str = &input[start_pos..pos];
-                                Matched(pos,
-                                        {
-                                            TaggedExpr{name: None,
-                                                       expr: box() expr,}
-                                        })
+                let choice_res =
+                    {
+                        let start_pos = pos;
+                        {
+                            let seq_res = parse_prefixed(input, state, pos);
+                            match seq_res {
+                                Matched(pos, expr) => {
+                                    {
+                                        let match_str =
+                                            &input[start_pos..pos];
+                                        Matched(pos,
+                                                {
+                                                    TaggedExpr{name: None,
+                                                               expr:
+                                                                   box() expr,}
+                                                })
+                                    }
+                                }
+                                Failed => Failed,
                             }
                         }
-                        Failed => Failed,
+                    };
+                match choice_res {
+                    Matched(pos, value) => Matched(pos, value),
+                    Failed => {
+                        let start_pos = pos;
+                        {
+                            let seq_res = parse_tilde(input, state, pos);
+                            match seq_res {
+                                Matched(pos, _) => {
+                                    {
+                                        let seq_res =
+                                            parse_identifier(input, state,
+                                                             pos);
+                                        match seq_res {
+                                            Matched(pos, name) => {
+                                                {
+                                                    let match_str =
+                                                        &input[start_pos..pos];
+                                                    Matched(pos,
+                                                            {
+                                                                TaggedExpr{name:
+                                                                               None,
+                                                                           expr:
+                                                                               box() BackrefExpr(name),}
+                                                            })
+                                                }
+                                            }
+                                            Failed => Failed,
+                                        }
+                                    }
+                                }
+                                Failed => Failed,
+                            }
+                        }
                     }
                 }
             }
@@ -2849,6 +2889,16 @@ fn parse_comma<'input>(input: &'input str, state: &mut ParseState, pos: usize)
  -> RuleResult<()> {
     {
         let seq_res = slice_eq(input, state, pos, ",");
+        match seq_res {
+            Matched(pos, _) => { parse___(input, state, pos) }
+            Failed => Failed,
+        }
+    }
+}
+fn parse_tilde<'input>(input: &'input str, state: &mut ParseState, pos: usize)
+ -> RuleResult<()> {
+    {
+        let seq_res = slice_eq(input, state, pos, "~");
         match seq_res {
             Matched(pos, _) => { parse___(input, state, pos) }
             Failed => Failed,

--- a/src/grammar.rs
+++ b/src/grammar.rs
@@ -1658,61 +1658,21 @@ fn parse_labeled<'input>(input: &'input str, state: &mut ParseState,
         match choice_res {
             Matched(pos, value) => Matched(pos, value),
             Failed => {
-                let choice_res =
-                    {
-                        let start_pos = pos;
-                        {
-                            let seq_res = parse_prefixed(input, state, pos);
-                            match seq_res {
-                                Matched(pos, expr) => {
-                                    {
-                                        let match_str =
-                                            &input[start_pos..pos];
-                                        Matched(pos,
-                                                {
-                                                    TaggedExpr{name: None,
-                                                               expr:
-                                                                   box() expr,}
-                                                })
-                                    }
-                                }
-                                Failed => Failed,
+                let start_pos = pos;
+                {
+                    let seq_res = parse_prefixed(input, state, pos);
+                    match seq_res {
+                        Matched(pos, expr) => {
+                            {
+                                let match_str = &input[start_pos..pos];
+                                Matched(pos,
+                                        {
+                                            TaggedExpr{name: None,
+                                                       expr: box() expr,}
+                                        })
                             }
                         }
-                    };
-                match choice_res {
-                    Matched(pos, value) => Matched(pos, value),
-                    Failed => {
-                        let start_pos = pos;
-                        {
-                            let seq_res = parse_tilde(input, state, pos);
-                            match seq_res {
-                                Matched(pos, _) => {
-                                    {
-                                        let seq_res =
-                                            parse_identifier(input, state,
-                                                             pos);
-                                        match seq_res {
-                                            Matched(pos, name) => {
-                                                {
-                                                    let match_str =
-                                                        &input[start_pos..pos];
-                                                    Matched(pos,
-                                                            {
-                                                                TaggedExpr{name:
-                                                                               None,
-                                                                           expr:
-                                                                               box() BackrefExpr(name),}
-                                                            })
-                                                }
-                                            }
-                                            Failed => Failed,
-                                        }
-                                    }
-                                }
-                                Failed => Failed,
-                            }
-                        }
+                        Failed => Failed,
                     }
                 }
             }

--- a/src/grammar.rustpeg
+++ b/src/grammar.rustpeg
@@ -73,9 +73,6 @@ labeled -> TaggedExpr
   / expr: prefixed {
       TaggedExpr{ name: None, expr: box expr }
   }
-  / tilde name:identifier {
-      TaggedExpr{ name: None, expr: box BackrefExpr(name) }
-  }
 
 prefixed -> Expr
   = dollar expression:suffixed {

--- a/src/grammar.rustpeg
+++ b/src/grammar.rustpeg
@@ -73,6 +73,9 @@ labeled -> TaggedExpr
   / expr: prefixed {
       TaggedExpr{ name: None, expr: box expr }
   }
+  / tilde name:identifier {
+      TaggedExpr{ name: None, expr: box BackrefExpr(name) }
+  }
 
 prefixed -> Expr
   = dollar expression:suffixed {
@@ -161,6 +164,7 @@ returns   = "->" __
 lbrace    = "{"  __
 rbrace    = "}"  __
 comma     = ","  __
+tilde     = "~"  __
 
 integer -> usize
   = i:([0-9]+ { match_str.parse().unwrap() }) __ { i }

--- a/src/grammar.rustpeg
+++ b/src/grammar.rustpeg
@@ -130,6 +130,7 @@ primary -> Expr
   / class
   / dot { AnyCharExpr }
   / lparen expression:expression rparen { expression }
+  / tilde name:identifier { BackrefExpr(name) }
 
 /* "Lexical" elements */
 

--- a/tests/test_backref.rs
+++ b/tests/test_backref.rs
@@ -10,12 +10,16 @@ alist -> &'input str
 test -> &'input str
     = a0:alist "b" ~a0 {match_str}
 
-tag -> &'input str
-    = [a-z]+ {match_str}
+word -> &'input str
+    = [a-z]+ {println!("'{}'", match_str); match_str}
 
 #[pub]
-xml -> ()
-    = "<" name:tag ">" inner:xml* "</" ~name ">" {}
+xml
+    = "<" name:word ">" inner:xml* "</" ~name ">" {}
+
+#[pub]
+example
+    = start:word (!~start .)* ~start {}
 
 "#);
 
@@ -38,4 +42,9 @@ fn test() {
     assert!(parse::xml("<a><b></b></b>").is_err());
     assert!(parse::xml("<a><b></b></a></c>").is_err());
     assert!(parse::xml("<c><a><b></b></a>").is_err());
+
+    // matches anything between two delimiting words
+    assert!(parse::example("start some thing bla bla start").is_ok());
+    assert!(parse::example("stop_:+ä.stop").is_ok());
+    assert!(parse::example("stop_:+ä.stop-.-stop").is_err());
 }

--- a/tests/test_backref.rs
+++ b/tests/test_backref.rs
@@ -1,0 +1,41 @@
+#![feature(plugin, collections, str_char)]
+#![plugin(peg_syntax_ext)]
+
+peg! parse(r#"
+
+alist -> &'input str
+    = "a"+ {match_str}
+
+#[pub]
+test -> &'input str
+    = a0:alist "b" ~a0 {match_str}
+
+tag -> &'input str
+    = [a-z]+ {match_str}
+
+#[pub]
+xml -> ()
+    = "<" name:tag ">" inner:xml* "</" ~name ">" {}
+
+"#);
+
+#[test]
+fn test() {
+    // matches `"a"+ "b" "a"+` if there is an equal number of "a"s on both sides
+    assert_eq!(parse::test("aba"), Ok("aba"));
+    assert_eq!(parse::test("aabaa"), Ok("aabaa"));
+    assert!(parse::test("b").is_err());
+    assert!(parse::test("ab").is_err());
+    assert!(parse::test("aaabaa").is_err());
+
+    // matches correctly closed and balanced XML tags (note that no whitespace or non-tag data is
+    // supported)
+    assert!(parse::xml("<a></a>").is_ok());
+    assert!(parse::xml("<a><b></b></a>").is_ok());
+    assert!(parse::xml("<html><head><title></title></head><body></body></html>").is_ok());
+
+    assert!(parse::xml("<a><b></a></b>").is_err());
+    assert!(parse::xml("<a><b></b></b>").is_err());
+    assert!(parse::xml("<a><b></b></a></c>").is_err());
+    assert!(parse::xml("<c><a><b></b></a>").is_err());
+}

--- a/tests/test_backref.rs
+++ b/tests/test_backref.rs
@@ -11,7 +11,7 @@ test -> &'input str
     = a0:alist "b" ~a0 {match_str}
 
 word -> &'input str
-    = [a-z]+ {println!("'{}'", match_str); match_str}
+    = [a-z]+ {match_str}
 
 #[pub]
 xml

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,4 +1,4 @@
-#![feature(plugin, core, collections, str_char)]
+#![feature(plugin, core, collections, str_char, into_cow)]
 #![plugin(peg_syntax_ext)]
 use std::collections::HashMap;
 


### PR DESCRIPTION
This PR implements backreferences to any captured rule that returns a `&str`. This allows rust-peg to express several new grammars that weren't possible before (for example, Lua's long strings, as outlined in #68). The file `tests/test_backref.rs` contains some examples.

The syntax for backreferences is `~name` where `name` is the name of a captured result as in `name:rule`. This isn't the prettiest syntax, we could possibly use `\name` for a Regex-like syntax or something different.

Another caveat: When a parse error occurs, backreferences are just printed as `<capture>`. They should be resolved into their value here. This requires the HashMap to own the expected strings instead of using `&'static str` like it does now.