### PR TITLE
Conditional matching

### DIFF
--- a/src/grammar.rustpeg
+++ b/src/grammar.rustpeg
@@ -56,7 +56,7 @@ choice -> Expr
 
 sequence -> Expr
   = elements:labeled* code:action {
-      ActionExpr(elements, code)
+      ActionExpr(elements, code.0, code.1)
     }
   / elements:prefixed* {
       if elements.len() != 1 {
@@ -130,8 +130,18 @@ primary -> Expr
 
 /* "Lexical" elements */
 
-action -> String
-  = braced:braced __ { braced }
+action -> (String, /*is conditional match?*/ bool)
+  = "{" cond:"?"? (((braced "") / nonBraceCharacters)*) "}" __ {
+    match cond {
+        Some(_) => {
+            let mut cond = String::with_capacity(match_str.len()-1);
+            cond.push_str("{"); // }
+            cond.push_str(&match_str[2..]);
+            (cond, true)
+        }
+        None => (match_str.to_string(), false)
+    }
+  }
 
 braced -> String
   = "{" (((braced "") / nonBraceCharacters)*) "}" {match_str.to_string()}

--- a/tests/test_conditional.rs
+++ b/tests/test_conditional.rs
@@ -1,0 +1,51 @@
+#![feature(plugin, collections, str_char)]
+#![plugin(peg_syntax_ext)]
+
+peg! parse(r#"
+
+#[pub]
+dec_byte -> u8
+    = [0-9]{,3} {?
+        let val: u64 = match_str.parse().unwrap();
+
+        // only let this rule match if the value is in range 0..255
+        if val <= 255 {
+            Ok(val as u8)
+        } else {
+            // the message explains what the rule expected and is used in the parse error
+            Err("decimal byte")
+        }
+    }
+
+tag -> &'input str
+    = [a-z]+ {match_str}
+
+#[pub]
+xml
+    = "<" open:tag ">" xml* "</" close:tag ">" {?
+        if open == close {
+            Ok(())
+        } else {
+            // TODO this has to be a `&'static str`, so we can't use a dynamic string
+            Err("matching close tag")
+        }
+    }
+
+"#);
+
+#[test]
+fn dec_byte() {
+    assert_eq!(parse::dec_byte("0"), Ok(0));
+    assert_eq!(parse::dec_byte("255"), Ok(255));
+    assert_eq!(parse::dec_byte("1"), Ok(1));
+    assert!(parse::dec_byte("256").is_err());
+    assert!(parse::dec_byte("1234").is_err());
+}
+
+#[test]
+fn xml() {
+    assert!(parse::xml("<a></a>").is_ok());
+    assert!(parse::xml("<a><b></b><c></c></a>").is_ok());
+    assert!(parse::xml("<a><b><c></b></c></a>").is_err());
+    assert!(parse::xml("<a><b></c><c></b></a>").is_err());
+}


### PR DESCRIPTION
Adds special code blocks introduced with `{?`. They can cause the rule to fail by returning `Err(message)` and may be used to evaluate arbitrary constraints at match-time.

The conditional match block can also be used as a (very) awkward way of defining custom error messages:
```rust
_binop
    = "+" / "-" / "*" / "/" / ">=" / "<=" / "==" / "!=" / ">" / "<"

binop
    = op:_binop? {? match op {
        Some(op) => Ok(op),
        None => Err("binary operator"),
    }}
```
When a parse error occurs at some place that expects a `binop`, only the string "binary operator" will be added to the expected set, instead of adding every single binary operator. Ideally, this would be properly supported (not requiring another rule and optional match) and have some syntax sugar to make it less verbose.