### PR TITLE
Print '^' in inverted char set matches

### DIFF
--- a/src/grammar.rs
+++ b/src/grammar.rs
@@ -2767,10 +2767,10 @@ fn parse_nonBraceCharacter<'input>(input: &'input str, state: &mut ParseState,
     if input.len() > pos {
         let ::std::str::CharRange { ch, next } = input.char_range_at(pos);
         match ch {
-            '{' | '}' => state.mark_failure(pos, "[{}]"),
+            '{' | '}' => state.mark_failure(pos, "[^{}]"),
             _ => Matched(next, ()),
         }
-    } else { state.mark_failure(pos, "[{}]") }
+    } else { state.mark_failure(pos, "[^{}]") }
 }
 fn parse_equals<'input>(input: &'input str, state: &mut ParseState,
                         pos: usize) -> RuleResult<()> {

--- a/src/translate.rs
+++ b/src/translate.rs
@@ -292,8 +292,12 @@ fn cond_swap<T>(swap: bool, tup: (T, T)) -> (T, T) {
 	}
 }
 
-fn format_char_set(cases: &[CharSetCase]) -> String {
+fn format_char_set(invert: bool, cases: &[CharSetCase]) -> String {
 	let mut r = "[".to_owned();
+
+    if invert {
+        r.push('^');
+    }
 
 	for &CharSetCase{start, end} in cases.iter() {
 		r.push(start);
@@ -324,7 +328,7 @@ fn compile_expr(ctxt: &rustast::ExtCtxt, e: &Expr, result_used: bool) -> rustast
 		}
 
 		CharSetExpr(invert, ref cases) => {
-			let expected_set = format_char_set(&cases);
+			let expected_set = format_char_set(invert, &cases);
 			let expected_str: &str = &expected_set;
 
 			let (in_set, not_in_set) = cond_swap(invert, (
@@ -549,4 +553,14 @@ fn compile_expr(ctxt: &rustast::ExtCtxt, e: &Expr, result_used: bool) -> rustast
 			})
 		}
 	}
+}
+
+#[test]
+fn test_format_char_set() {
+    assert_eq!(format_char_set(false,
+                               &[CharSetCase{start: 'a', end: 'z'},
+                                 CharSetCase{start: '0', end: '9'}]),
+               "[a-z0-9]");
+    assert_eq!(format_char_set(true, &[CharSetCase{start: 'A', end: 'Z'}]),
+               "[^A-Z]");
 }


### PR DESCRIPTION
I noticed that the '^' was missing from error messages for character matches that are inverted. I've added a test and passed the invert bool to the format_char_set function to fix this. Let me know if this can be added or needs to be modified. Thanks for the great project!

