### PR TITLE
Make generated code build on beta

### DIFF
--- a/src/grammar.rustpeg
+++ b/src/grammar.rustpeg
@@ -221,7 +221,7 @@ doubleQuotedCharacter -> char
   / eolEscapeSequence
 
 simpleDoubleQuotedCharacter -> char
-  = !('"' / "\\" / eolChar) . { match_str.char_at(0) }
+  = !('"' / "\\" / eolChar) . { match_str.chars().next().unwrap() }
 
 singleQuotedString -> String
   = "'" s:singleQuotedCharacter* "'" { s.into_iter().collect() }
@@ -237,7 +237,7 @@ singleQuotedCharacter -> char
   / eolEscapeSequence
 
 simpleSingleQuotedCharacter -> char
-  = !("'" / "\\" / eolChar) . { match_str.char_at(0) }
+  = !("'" / "\\" / eolChar) . { match_str.chars().next().unwrap() }
 
 class -> Expr
   = "[" inverted:"^"? parts:(classCharacterRange / classCharacter)* "]" flags:"i"? __ {
@@ -266,11 +266,11 @@ bracketDelimitedCharacter -> char
   / eolEscapeSequence
 
 simpleBracketDelimitedCharacter -> char
-  = !("]" / "\\" / eolChar) . { match_str.char_at(0) }
+  = !("]" / "\\" / eolChar) . { match_str.chars().next().unwrap() }
 
 simpleEscapeSequence -> char
   = "\\" !(digit / "x" / "u" / "U" / eolChar) . {
-      match match_str.char_at(1) {
+      match match_str[1..].chars().next().unwrap() {
         //'b' => '\b',
         //'f' => '\f',
         'n' => '\n',

--- a/src/peg.rs
+++ b/src/peg.rs
@@ -1,4 +1,4 @@
-#![feature(quote, box_syntax, collections, rustc_private, box_patterns, exit_status, str_char, slice_patterns)]
+#![feature(quote, box_syntax, collections, rustc_private, box_patterns, exit_status, slice_patterns)]
 extern crate syntax;
 
 use std::env;

--- a/src/peg_syntax_ext.rs
+++ b/src/peg_syntax_ext.rs
@@ -1,4 +1,4 @@
-#![feature(plugin_registrar, quote, box_syntax, collections, rustc_private, box_patterns, str_char)]
+#![feature(plugin_registrar, quote, box_syntax, collections, rustc_private, box_patterns)]
 
 extern crate rustc;
 extern crate syntax;

--- a/src/translate.rs
+++ b/src/translate.rs
@@ -89,6 +89,14 @@ pub fn header_items(ctxt: &rustast::ExtCtxt) -> Vec<rustast::P<rustast::Item>> {
 	).unwrap());
 
 	items.push(quote_item!(ctxt,
+		fn char_range_at(s: &str, pos: usize) -> (char, usize) {
+			let c = &s[pos..].chars().next().unwrap();
+			let next_pos = pos + c.len_utf8();
+			(*c, next_pos)
+		}
+	).unwrap());
+
+	items.push(quote_item!(ctxt,
 		enum RuleResult<T> {
 			Matched(usize, T),
 			Failed,
@@ -207,7 +215,8 @@ pub fn header_items(ctxt: &rustast::ExtCtxt) -> Vec<rustast::P<rustast::Item>> {
 			#![allow(dead_code)]
 
 			if input.len() > pos {
-				Matched(input.char_range_at(pos).next, ())
+				let (_, next) = char_range_at(input, pos);
+				Matched(next, ())
 			} else {
 				state.mark_failure(pos, "<character>")
 			}
@@ -357,7 +366,7 @@ fn compile_expr(ctxt: &rustast::ExtCtxt, e: &Expr, result_used: bool) -> rustast
 			));
 
 			quote_expr!(ctxt, if input.len() > pos {
-				let ::std::str::CharRange {ch, next} = input.char_range_at(pos);
+				let (ch, next) = char_range_at(input, pos);
 				$m
 			} else {
 				state.mark_failure(pos, $expected_str)

--- a/src/translate.rs
+++ b/src/translate.rs
@@ -83,6 +83,12 @@ pub fn header_items(ctxt: &rustast::ExtCtxt) -> Vec<rustast::P<rustast::Item>> {
 	let mut items = Vec::new();
 
 	items.push(quote_item!(ctxt,
+		fn escape_default(s: &str) -> String {
+			s.chars().flat_map(|c| c.escape_default()).collect()
+		}
+	).unwrap());
+
+	items.push(quote_item!(ctxt,
 		enum RuleResult<T> {
 			Matched(usize, T),
 			Failed,
@@ -115,13 +121,13 @@ pub fn header_items(ctxt: &rustast::ExtCtxt) -> Vec<rustast::P<rustast::Item>> {
 			fn fmt(&self, fmt: &mut ::std::fmt::Formatter) -> ::std::result::Result<(), ::std::fmt::Error> {
 				try!(write!(fmt, "error at {}:{}: expected ", self.line, self.column));
 				if self.expected.len() == 1 {
-					try!(write!(fmt, "`{}`", self.expected.iter().next().unwrap().escape_default()));
+					try!(write!(fmt, "`{}`", escape_default(self.expected.iter().next().unwrap())));
 				} else {
 					let mut iter = self.expected.iter();
 
-					try!(write!(fmt, "one of `{}`", iter.next().unwrap().escape_default()));
+					try!(write!(fmt, "one of `{}`", escape_default(iter.next().unwrap())));
 					for elem in iter {
-						try!(write!(fmt, ", `{}`", elem.escape_default()));
+						try!(write!(fmt, ", `{}`", escape_default(elem)));
 					}
 				}
 

--- a/tests/test_arithmetic.rs
+++ b/tests/test_arithmetic.rs
@@ -1,4 +1,4 @@
-#![feature(plugin, collections, str_char)]
+#![feature(plugin)]
 #![plugin(peg_syntax_ext)]
 use arithmetic::expression;
 

--- a/tests/test_conditional.rs
+++ b/tests/test_conditional.rs
@@ -1,4 +1,4 @@
-#![feature(plugin, collections, str_char)]
+#![feature(plugin)]
 #![plugin(peg_syntax_ext)]
 
 peg! parse(r#"

--- a/tests/test_errors.rs
+++ b/tests/test_errors.rs
@@ -1,4 +1,4 @@
-#![feature(plugin, collections, str_char)]
+#![feature(plugin)]
 #![plugin(peg_syntax_ext)]
 
 use parser::parse;

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,4 +1,4 @@
-#![feature(plugin, collections, str_char, into_cow)]
+#![feature(plugin, into_cow)]
 #![plugin(peg_syntax_ext)]
 use std::collections::HashMap;
 


### PR DESCRIPTION
Code generated by `rust-peg` no longer depends on the `collections` or `str_char` features, so it can be used on the beta.