### PR TITLE
fix to rust nightly 

### DIFF
--- a/src/fake_extctxt.rs
+++ b/src/fake_extctxt.rs
@@ -4,7 +4,7 @@ use syntax::ext::base::ExtCtxt;
 
 /// Create a fake ExtCtxt to perform macro quasiquotes outside of rustc plugins
 pub fn with_fake_extctxt<T, F: Fn(&ExtCtxt) -> T>(f: F) -> T {
-  let ps = syntax::parse::new_parse_sess();
+  let ps = syntax::parse::ParseSess::new();
 
   let mut cx = syntax::ext::base::ExtCtxt::new(&ps, Vec::new(),
     syntax::ext::expand::ExpansionConfig::default("rust-peg".to_string())

--- a/src/rustast.rs
+++ b/src/rustast.rs
@@ -17,7 +17,7 @@ pub fn module(items: Vec<P<Item>>) -> P<Mod> {
 }
 
 pub fn parse_path(e: &str) -> ast::Path {
-	let ps = syntax::parse::new_parse_sess();
+	let ps = syntax::parse::ParseSess::new();
 	let mut p = syntax::parse::new_parser_from_source_str(&ps, Vec::new(), "file".to_string(), e.to_string());
 	let r = p.parse_path(syntax::parse::parser::NoTypesAllowed);
 	p.abort_if_errors();
@@ -29,7 +29,7 @@ pub fn parse_path_vec(s: &str) -> Vec<ast::Ident> {
 }
 
 pub fn parse_block(e: &str) -> P<ast::Block> {
-	let ps = syntax::parse::new_parse_sess();
+	let ps = syntax::parse::ParseSess::new();
 	let mut p = syntax::parse::new_parser_from_source_str(&ps, Vec::new(), "file".to_string(), e.to_string());
 	let r = p.parse_block();
 	p.abort_if_errors();
@@ -37,7 +37,7 @@ pub fn parse_block(e: &str) -> P<ast::Block> {
 }
 
 pub fn parse_type(e: &str) -> P<ast::Ty> {
-	let ps = syntax::parse::new_parse_sess();
+	let ps = syntax::parse::ParseSess::new();
 	let mut p = syntax::parse::new_parser_from_source_str(&ps, Vec::new(), "file".to_string(), e.to_string());
 	let r = p.parse_ty();
 	p.abort_if_errors();


### PR DESCRIPTION
the syntax crate was refactored on nightly as per https://github.com/rust-lang/rust/commit/f786437bd223740d9767345731d458d10936f8d7

this makes rust-peg work again