### PR TITLE
Add benchmarks

### DIFF
--- a/benches/expr.rs
+++ b/benches/expr.rs
@@ -1,0 +1,18 @@
+#![feature(plugin, test)]
+#![plugin(peg_syntax_ext)]
+
+extern crate test;
+
+use test::Bencher;
+
+peg_file! parser("expr.rustpeg");
+
+#[bench]
+fn expr(b: &mut Bencher) {
+	let bench_str = "1+2+3+4*5*6^7^8^(0^1*2+1)";
+
+	b.bytes = bench_str.len() as u64;
+	b.iter(|| {
+		parser::expr(bench_str).unwrap();
+	});
+}

--- a/benches/expr.rustpeg
+++ b/benches/expr.rustpeg
@@ -1,0 +1,11 @@
+// A grammar for simple arithmetic expression with operator precedences and braces
+
+#[pub]
+expr = eq
+
+eq = additive "=" eq / additive
+additive = multitive "+" additive / multitive
+multitive = pow "*" multitive / pow
+pow = atom "^" pow / atom
+
+atom = [0-9]+ / "(" expr ")"

--- a/benches/json.rs
+++ b/benches/json.rs
@@ -1,0 +1,40 @@
+#![feature(plugin, test)]
+#![plugin(peg_syntax_ext)]
+
+extern crate test;
+
+use test::Bencher;
+
+peg_file! parser("json.rustpeg");
+
+#[bench]
+fn json(b: &mut Bencher) {
+	let bench_str = r#"
+{
+	"X": 0.6e2,
+	"Y": 5,
+	"Z": -5.312344,
+	"Bool": false,
+	"Bool": true,
+	"Null": null,
+	"Attr": {
+		"Name": "bla",
+		"Siblings": [6, 1, 2, {}, {}, {}]
+	},
+	"Nested Array": [[[[[[[[[]]]]]]]]],
+	"Obj": {
+		"Child": {
+			"A": [],
+			"Child": {
+				"Child": {}
+			}
+		}
+	}
+}
+"#;
+
+	b.bytes = bench_str.len() as u64;
+	b.iter(|| {
+		parser::json(bench_str).unwrap();
+	});
+}

--- a/benches/json.rustpeg
+++ b/benches/json.rustpeg
@@ -1,0 +1,42 @@
+// JSON grammar (RFC 4627). Note that this only checks for valid JSON and does not build a syntax
+// tree.
+
+
+#[pub]
+json = object / array
+
+ws = [ \t\r\n]*
+begin_array = ws "[" ws
+begin_object = ws "{" ws
+end_array = ws "]" ws
+end_object = ws "}" ws
+name_separator = ws ":" ws
+value_separator = ws "," ws
+
+value
+    = "false" / "true" / "null" / object / array / number / string
+
+object
+    = begin_object (member (value_separator member)*)? end_object
+
+member
+    = string name_separator value
+
+array
+    = begin_array (value (value_separator value)*)? end_array
+
+number
+    = "-"? int frac? exp? {}
+
+int
+    = "0" / [1-9][0-9]*
+
+exp
+    = ("e" / "E") ("-" / "+")? [0-9]{1,}
+
+frac
+    = "." [0-9]{1,}
+
+// note: escaped chars not handled
+string
+    = "\"" (!"\"" .)* "\""


### PR DESCRIPTION
I've added two simple benchmarks for performance testing: One is a JSON parser (might also make a decent example grammar), the other one parses arithmetic expressions with 4 operator precedence levels.

I hope this will prove useful when evaluating performance optimizations (memoization being the obvious one).

Benchmark results on my machine:
```
test expr ... bench:     15229 ns/iter (+/- 649) = 1 MB/s
test json ... bench:     25062 ns/iter (+/- 694) = 10 MB/s
```
Note that cargo does not show speeds below 1 MB/s, so a lower-end machine won't display them.