### PR TITLE
Memoization!

### DIFF
--- a/benches/expr.rustpeg
+++ b/benches/expr.rustpeg
@@ -3,9 +3,14 @@
 #[pub]
 expr = eq
 
+#[cache]
 eq = additive "=" eq / additive
+#[cache]
 additive = multitive "+" additive / multitive
+#[cache]
 multitive = pow "*" multitive / pow
+#[cache]
 pow = atom "^" pow / atom
 
+#[cache]
 atom = [0-9]+ / "(" expr ")"

--- a/src/grammar.rustpeg
+++ b/src/grammar.rustpeg
@@ -7,11 +7,12 @@ grammar -> Grammar
   { Grammar{ imports:imports, rules:rules } }
 
 rule -> Rule
-  = exported:exportflag name:identifier returns: returntype equals expression:expression semicolon? {
-      Rule{ name: name, expr: box expression, ret_type: returns, exported: exported }
+  = exported:exportflag cached:cacheflag name:identifier returns: returntype equals expression:expression semicolon? {
+      Rule{ name: name, expr: box expression, ret_type: returns, exported: exported, cached: cached }
     }
 
     exportflag -> bool = ("#[export]"/"#[pub]") __ {true} / "" {false}
+    cacheflag -> bool = "#[cache]" __ {true} / {false}
 
 returntype -> String
   = returns tp:(rust_type {match_str.trim().to_string()}) { tp }
@@ -118,6 +119,7 @@ suffixed -> Expr
     }
   / primary
 
+#[cache]
 primary -> Expr
   = name:identifier !(string? returntype equals) {
       RuleExpr(name)

--- a/src/rustast.rs
+++ b/src/rustast.rs
@@ -4,7 +4,7 @@ pub use syntax::ast;
 pub use syntax::ptr::P;
 pub use syntax::codemap::DUMMY_SP;
 pub use syntax::ext::base::ExtCtxt;
-pub use syntax::ast::{Mod, Item, Expr};
+pub use syntax::ast::{Mod, Item, Expr, TokenTree};
 pub use syntax::parse::token::str_to_ident;
 pub use syntax::ext::build::AstBuilder;
 pub use syntax::print::pprust::{expr_to_string, item_to_string};

--- a/src/translate.rs
+++ b/src/translate.rs
@@ -12,13 +12,7 @@ pub struct Grammar {
 
 impl Grammar {
 	fn find_rule(&self, name: &str) -> Option<&Rule> {
-		for rule in &self.rules {
-			if rule.name == name {
-				return Some(rule);
-			}
-		}
-
-		None
+		self.rules.iter().find(|rule| rule.name == name)
 	}
 }
 

--- a/tests/tests.rustpeg
+++ b/tests/tests.rustpeg
@@ -38,7 +38,7 @@ repeat_min_max -> Vec<i64>
 #[export]
 boundaries -> String
 	= "foo" { match_str.to_string() }
-	
+
 #[export]
 case_insensitive -> String
 	= "foo"i { match_str.to_string() }


### PR DESCRIPTION
It's a bit of a mess because I had to thread the `Grammar` through all `compile_*` functions, but it seems to kinda work :tada: 

Before:
```
test expr ... bench:     26765 ns/iter (+/- 9674)
```
After:
```
test expr ... bench:      8582 ns/iter (+/- 2050) = 2 MB/s
```

I also added `#[cache]` to rust-peg's own grammar (only the `primary` rule), but haven't tested the effect (it's probably not very big until other rules are annotated as well).