### PR TITLE
Fix error spans in PEG grammars

### DIFF
--- a/src/rustast.rs
+++ b/src/rustast.rs
@@ -28,9 +28,8 @@ pub fn parse_path_vec(s: &str) -> Vec<ast::Ident> {
 	s.split("::").map(|i| str_to_ident(i)).collect()
 }
 
-pub fn parse_block(e: &str) -> P<ast::Block> {
-	let ps = syntax::parse::ParseSess::new();
-	let mut p = syntax::parse::new_parser_from_source_str(&ps, Vec::new(), "file".to_string(), e.to_string());
+pub fn parse_block(ctxt: &ExtCtxt, e: &str) -> P<ast::Block> {
+	let mut p = syntax::parse::new_parser_from_source_str(&ctxt.parse_sess, Vec::new(), "file".to_string(), e.to_string());
 	let r = p.parse_block();
 	p.abort_if_errors();
 	r.unwrap_or_else(|e| panic!(e))

--- a/src/rustast.rs
+++ b/src/rustast.rs
@@ -16,9 +16,8 @@ pub fn module(items: Vec<P<Item>>) -> P<Mod> {
 	})
 }
 
-pub fn parse_path(e: &str) -> ast::Path {
-	let ps = syntax::parse::ParseSess::new();
-	let mut p = syntax::parse::new_parser_from_source_str(&ps, Vec::new(), "file".to_string(), e.to_string());
+pub fn parse_path(ctxt: &ExtCtxt, e: &str) -> ast::Path {
+	let mut p = syntax::parse::new_parser_from_source_str(&ctxt.parse_sess, Vec::new(), "file".to_string(), e.to_string());
 	let r = p.parse_path(syntax::parse::parser::NoTypesAllowed);
 	p.abort_if_errors();
 	r.unwrap_or_else(|_|panic!())
@@ -35,9 +34,8 @@ pub fn parse_block(ctxt: &ExtCtxt, e: &str) -> P<ast::Block> {
 	r.unwrap_or_else(|e| panic!(e))
 }
 
-pub fn parse_type(e: &str) -> P<ast::Ty> {
-	let ps = syntax::parse::ParseSess::new();
-	let mut p = syntax::parse::new_parser_from_source_str(&ps, Vec::new(), "file".to_string(), e.to_string());
+pub fn parse_type(ctxt: &ExtCtxt, e: &str) -> P<ast::Ty> {
+	let mut p = syntax::parse::new_parser_from_source_str(&ctxt.parse_sess, Vec::new(), "file".to_string(), e.to_string());
 	let r = p.parse_ty();
 	p.abort_if_errors();
 	r

--- a/src/translate.rs
+++ b/src/translate.rs
@@ -626,7 +626,7 @@ fn compile_expr(ctxt: &rustast::ExtCtxt, grammar: &Grammar, e: &Expr, result_use
 						)
 					}
 					None => {
-						let code_block = rustast::parse_block(code);
+						let code_block = rustast::parse_block(ctxt, code);
 
 						if is_cond {
 							quote_expr!(ctxt, {


### PR DESCRIPTION
Before:
```
tests/test_errors.rs:1:5: 1:11 error: no method named `len_` found for type `collections::vec::Vec<()>` in the current scope
tests/test_errors.rs:1 #![feature(plugin)]
                           ^~~~~~
tests/test_errors.rs:1:1: 27:1 note: in expansion of peg!
tests/test_errors.rs:7:1: 11:5 note: expansion site
error: aborting due to previous error
tests/tests.rs:1:21: 1:28 error: no method named `uwrap` found for type `core::result::Result<_, _>` in the current scope
tests/tests.rs:1 #![feature(plugin, into_cow)]
                                     ^~~~~~~
tests/tests.rs:1:1: 92:1 note: in expansion of peg_file!
tests/tests.rs:6:1: 6:41 note: expansion site
```
(this was broken in other ways before, such as printing `name_123,ctxt_123` instead of identifiers)

After this change:
```
file:1:5: 1:11 error: no method named `len_` found for type `collections::vec::Vec<()>` in the current scope
file:1 { v.len_() }
           ^~~~~~
tests/test_errors.rs:1:1: 27:1 note: in expansion of peg!
tests/test_errors.rs:7:1: 11:5 note: expansion site
error: aborting due to previous error
file:1:21: 1:28 error: no method named `uwrap` found for type `core::result::Result<_, _>` in the current scope
file:1 { match_str.parse().uwrap() }
                           ^~~~~~~
tests/tests.rs:1:1: 92:1 note: in expansion of peg_file!
tests/tests.rs:6:1: 6:41 note: expansion site
```
