### PR TITLE
Smarter error collecting

### DIFF
--- a/src/grammar.rs
+++ b/src/grammar.rs
@@ -4857,6 +4857,7 @@ pub fn grammar<'input>(input: &'input str) -> ParseResult<Grammar> {
         Matched(pos, value) => { if pos == input.len() { return Ok(value) } }
         _ => { }
     }
+    state = ParseState::new();
     state.failing = true;
     parse_grammar(input, &mut state, 0);
     let (line, col) = pos_to_line(input, state.max_err_pos);

--- a/src/translate.rs
+++ b/src/translate.rs
@@ -333,6 +333,7 @@ fn compile_rule_export(ctxt: &rustast::ExtCtxt, rule: &Rule) -> rustast::P<rusta
 				_ => {}
 			}
 
+			state = ParseState::new();
 			state.failing = true;
 			$parse_fn(input, &mut state, 0);
 

--- a/src/translate.rs
+++ b/src/translate.rs
@@ -107,6 +107,7 @@ fn make_parse_state(ctxt: &rustast::ExtCtxt, rules: &[Rule]) -> Vec<rustast::P<r
 		struct ParseState {
 			max_err_pos: usize,
 			expected: ::std::collections::HashSet<&'static str>,
+			failing: bool,
 			$cache_fields
 		}
 	).unwrap());
@@ -117,17 +118,15 @@ fn make_parse_state(ctxt: &rustast::ExtCtxt, rules: &[Rule]) -> Vec<rustast::P<r
 				ParseState {
 					max_err_pos: 0,
 					expected: ::std::collections::HashSet::new(),
+					failing: false,
 					$cache_init
 				}
 			}
 			fn mark_failure(&mut self, pos: usize, expected: &'static str) -> RuleResult<()> {
-				if pos > self.max_err_pos {
-					self.max_err_pos = pos;
-					self.expected.clear();
-				}
-
-				if pos == self.max_err_pos {
+				if self.failing && pos == self.max_err_pos {
 					self.expected.insert(expected);
+				} else if pos > self.max_err_pos {
+					self.max_err_pos = pos;
 				}
 
 				Failed
@@ -333,8 +332,11 @@ fn compile_rule_export(ctxt: &rustast::ExtCtxt, rule: &Rule) -> rustast::P<rusta
 				}
 				_ => {}
 			}
-			let (line, col) = pos_to_line(input, state.max_err_pos);
 
+			state.failing = true;
+			$parse_fn(input, &mut state, 0);
+
+			let (line, col) = pos_to_line(input, state.max_err_pos);
 			Err(ParseError {
 				line: line,
 				column: col,


### PR DESCRIPTION
Only populate the `expected` HashSet when we know that parsing will
fail. This results in impressive speedups in the non-failing case:

```
Before:
test expr ... bench:      5926 ns/iter (+/- 621) = 4 MB/s
test json ... bench:     24909 ns/iter (+/- 575) = 10 MB/s

After:
test expr ... bench:      4415 ns/iter (+/- 220) = 5 MB/s
test json ... bench:      6565 ns/iter (+/- 526) = 41 MB/s
```

Note that this will make parsing slower if it fails, since it basically parses the input twice (both parser invocations individually are faster, though). I don't think this is an issue, since when a program fails to parse something, it will usually report an error and abort (ie. its a slow path anyway).

I also experimented with replacing the default `SipHasher` used for HashMaps and HashSets with the faster Murmurhash2, which brought the `expr` benchmark up to 16 MB/s (while completely commenting out `expected` handling, so actual gains will be a bit lower). This has a few tradeoffs, since hasher replacement is still experimental in Rust, so I don't know if I'll go in that direction any further.