### PR TITLE
Fixes bug where error's display panics when nothing more is expected from the input

### DIFF
--- a/src/grammar.rs
+++ b/src/grammar.rs
@@ -28,7 +28,7 @@ impl ::std::fmt::Display for ParseError {
              fmt , "error at {}:{}: expected " , self . line , self . column
              ));
         if self.expected.len() == 0 {
-            try!(write ! ( fmt , "nothing here" ));
+            try!(write ! ( fmt , "EOF" ));
         } else if self.expected.len() == 1 {
             try!(write ! (
                  fmt , "`{}`" , escape_default (

--- a/src/grammar.rs
+++ b/src/grammar.rs
@@ -27,7 +27,9 @@ impl ::std::fmt::Display for ParseError {
         try!(write ! (
              fmt , "error at {}:{}: expected " , self . line , self . column
              ));
-        if self.expected.len() == 1 {
+        if self.expected.len() == 0 {
+            try!(write ! ( fmt , "nothing here" ));
+        } else if self.expected.len() == 1 {
             try!(write ! (
                  fmt , "`{}`" , escape_default (
                  self . expected . iter (  ) . next (  ) . unwrap (  ) ) ));

--- a/src/translate.rs
+++ b/src/translate.rs
@@ -182,7 +182,7 @@ pub fn header_items(ctxt: &rustast::ExtCtxt) -> Vec<rustast::P<rustast::Item>> {
 			fn fmt(&self, fmt: &mut ::std::fmt::Formatter) -> ::std::result::Result<(), ::std::fmt::Error> {
 				try!(write!(fmt, "error at {}:{}: expected ", self.line, self.column));
 				if self.expected.len() == 0 {
-					try!(write!(fmt, "nothing here"));
+					try!(write!(fmt, "EOF"));
 				} else if self.expected.len() == 1 {
 					try!(write!(fmt, "`{}`", escape_default(self.expected.iter().next().unwrap())));
 				} else {

--- a/src/translate.rs
+++ b/src/translate.rs
@@ -181,7 +181,9 @@ pub fn header_items(ctxt: &rustast::ExtCtxt) -> Vec<rustast::P<rustast::Item>> {
 		impl ::std::fmt::Display for ParseError {
 			fn fmt(&self, fmt: &mut ::std::fmt::Formatter) -> ::std::result::Result<(), ::std::fmt::Error> {
 				try!(write!(fmt, "error at {}:{}: expected ", self.line, self.column));
-				if self.expected.len() == 1 {
+				if self.expected.len() == 0 {
+					try!(write!(fmt, "nothing here"));
+				} else if self.expected.len() == 1 {
 					try!(write!(fmt, "`{}`", escape_default(self.expected.iter().next().unwrap())));
 				} else {
 					let mut iter = self.expected.iter();

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -14,7 +14,10 @@ fn test_neg_assert() {
 #[test]
 fn test_eof() {
 	assert_eq!(expect_nothing("t"), Ok(()));
-	assert!(expect_nothing("tt").is_err());
+	match expect_nothing("tt") {
+		Err(e) => println!("{}", e),
+		Ok(_) => panic!("should not happen")
+	};
 }
 
 #[test]

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -12,6 +12,12 @@ fn test_neg_assert() {
 }
 
 #[test]
+fn test_eof() {
+	assert_eq!(expect_nothing("t"), Ok(()));
+	assert!(expect_nothing("tt").is_err());
+}
+
+#[test]
 fn test_optional() {
 	assert_eq!(options("abc"), Ok(None));
 	assert_eq!(options("abcdef"), Ok(Some(())));

--- a/tests/tests.rustpeg
+++ b/tests/tests.rustpeg
@@ -71,3 +71,7 @@ keyvals -> HashMap<i64, i64>
 
 keyval -> (i64, i64)
     = k:number ":" + v:number { (k, v) }
+
+#[export]
+expect_nothing -> ()
+	= [a-zA-Z]


### PR DESCRIPTION
A grammar like [a-zA-Z] ran with an input like "tt" would panic if the error was printed out.