### PR TITLE
Make any char rule return a char

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ rule_name -> type
 
 If a rule is marked with `#[pub]`, the generated module has a public function that begins parsing at that rule.
 
-  * `.` - match any single character
+  * `.` - match any single character and return it as a `char`
   * `"literal"` - match a literal string
   * `[a-z]`  - match a single character from a set
   * `[^a-z]` - match a single character not in a set

--- a/src/grammar.rs
+++ b/src/grammar.rs
@@ -3531,13 +3531,10 @@ fn parse_simpleDoubleQuotedCharacter<'input>(input: &'input str,
                     {
                         let seq_res = any_char(input, state, pos);
                         match seq_res {
-                            Matched(pos, _) => {
+                            Matched(pos, c) => {
                                 {
                                     let match_str = &input[start_pos..pos];
-                                    Matched(pos,
-                                            {
-                                                match_str.chars().next().unwrap()
-                                            })
+                                    Matched(pos, { c })
                                 }
                             }
                             Failed => Failed,
@@ -3713,13 +3710,10 @@ fn parse_simpleSingleQuotedCharacter<'input>(input: &'input str,
                     {
                         let seq_res = any_char(input, state, pos);
                         match seq_res {
-                            Matched(pos, _) => {
+                            Matched(pos, c) => {
                                 {
                                     let match_str = &input[start_pos..pos];
-                                    Matched(pos,
-                                            {
-                                                match_str.chars().next().unwrap()
-                                            })
+                                    Matched(pos, { c })
                                 }
                             }
                             Failed => Failed,
@@ -4034,13 +4028,10 @@ fn parse_simpleBracketDelimitedCharacter<'input>(input: &'input str,
                     {
                         let seq_res = any_char(input, state, pos);
                         match seq_res {
-                            Matched(pos, _) => {
+                            Matched(pos, c) => {
                                 {
                                     let match_str = &input[start_pos..pos];
-                                    Matched(pos,
-                                            {
-                                                match_str.chars().next().unwrap()
-                                            })
+                                    Matched(pos, { c })
                                 }
                             }
                             Failed => Failed,
@@ -4124,14 +4115,13 @@ fn parse_simpleEscapeSequence<'input>(input: &'input str,
                                 {
                                     let seq_res = any_char(input, state, pos);
                                     match seq_res {
-                                        Matched(pos, _) => {
+                                        Matched(pos, c) => {
                                             {
                                                 let match_str =
                                                     &input[start_pos..pos];
                                                 Matched(pos,
                                                         {
-                                                            match match_str[1..].chars().next().unwrap()
-                                                                {
+                                                            match c {
                                                                 'n' => '\n',
                                                                 'r' => '\r',
                                                                 't' => '\t',

--- a/src/grammar.rs
+++ b/src/grammar.rs
@@ -73,13 +73,13 @@ fn slice_eq_case_insensitive(input: &str, state: &mut ParseState, pos: usize,
     Matched(pos + used, ())
 }
 fn any_char(input: &str, state: &mut ParseState, pos: usize)
- -> RuleResult<()> {
+ -> RuleResult<char> {
     #![inline]
     #![allow(dead_code)]
     if input.len() > pos {
-        let (_, next) = char_range_at(input, pos);
-        Matched(next, ())
-    } else { state.mark_failure(pos, "<character>") }
+        let (c, next) = char_range_at(input, pos);
+        Matched(next, c)
+    } else { state.mark_failure(pos, "<character>"); Failed }
 }
 fn pos_to_line(input: &str, pos: usize) -> (usize, usize) {
     let mut remaining = pos;

--- a/src/grammar.rustpeg
+++ b/src/grammar.rustpeg
@@ -223,7 +223,7 @@ doubleQuotedCharacter -> char
   / eolEscapeSequence
 
 simpleDoubleQuotedCharacter -> char
-  = !('"' / "\\" / eolChar) . { match_str.chars().next().unwrap() }
+  = !('"' / "\\" / eolChar) c:. { c }
 
 singleQuotedString -> String
   = "'" s:singleQuotedCharacter* "'" { s.into_iter().collect() }
@@ -239,7 +239,7 @@ singleQuotedCharacter -> char
   / eolEscapeSequence
 
 simpleSingleQuotedCharacter -> char
-  = !("'" / "\\" / eolChar) . { match_str.chars().next().unwrap() }
+  = !("'" / "\\" / eolChar) c:. { c }
 
 class -> Expr
   = "[" inverted:"^"? parts:(classCharacterRange / classCharacter)* "]" flags:"i"? __ {
@@ -268,11 +268,11 @@ bracketDelimitedCharacter -> char
   / eolEscapeSequence
 
 simpleBracketDelimitedCharacter -> char
-  = !("]" / "\\" / eolChar) . { match_str.chars().next().unwrap() }
+  = !("]" / "\\" / eolChar) c:. { c }
 
 simpleEscapeSequence -> char
-  = "\\" !(digit / "x" / "u" / "U" / eolChar) . {
-      match match_str[1..].chars().next().unwrap() {
+  = "\\" !(digit / "x" / "u" / "U" / eolChar) c:. {
+      match c {
         //'b' => '\b',
         //'f' => '\f',
         'n' => '\n',

--- a/src/translate.rs
+++ b/src/translate.rs
@@ -243,15 +243,16 @@ pub fn header_items(ctxt: &rustast::ExtCtxt) -> Vec<rustast::P<rustast::Item>> {
 	).unwrap());
 
 	items.push(quote_item!(ctxt,
-		fn any_char(input: &str, state: &mut ParseState, pos: usize) -> RuleResult<()> {
+		fn any_char(input: &str, state: &mut ParseState, pos: usize) -> RuleResult<char> {
 			#![inline]
 			#![allow(dead_code)]
 
 			if input.len() > pos {
-				let (_, next) = char_range_at(input, pos);
-				Matched(next, ())
+				let (c, next) = char_range_at(input, pos);
+				Matched(next, c)
 			} else {
-				state.mark_failure(pos, "<character>")
+				state.mark_failure(pos, "<character>");
+                Failed
 			}
 		}
 	).unwrap());

--- a/src/translate.rs
+++ b/src/translate.rs
@@ -252,7 +252,7 @@ pub fn header_items(ctxt: &rustast::ExtCtxt) -> Vec<rustast::P<rustast::Item>> {
 				Matched(next, c)
 			} else {
 				state.mark_failure(pos, "<character>");
-                Failed
+				Failed
 			}
 		}
 	).unwrap());


### PR DESCRIPTION
This makes the `.` pattern return a `char`, so you can use

```rust
simpleDoubleQuotedCharacter -> char
  = !('"' / "\\" / eolChar) c:. { c }
```

instead of

```rust
simpleDoubleQuotedCharacter -> char
  = !('"' / "\\" / eolChar) . { match_str.chars().next().unwrap() }
```