### PR TITLE
Use the new unstable features

### DIFF
--- a/src/peg.rs
+++ b/src/peg.rs
@@ -1,4 +1,4 @@
-#![feature(quote, box_syntax, collections, rustc_private, box_patterns, exit_status, slice_patterns)]
+#![feature(quote, box_syntax, rustc_private, box_patterns, slice_patterns, append)]
 extern crate syntax;
 
 use std::env;
@@ -6,6 +6,7 @@ use std::fs::File;
 use std::io::{Read, Write};
 use std::io::{stdin, stdout, stderr};
 use std::path::Path;
+use std::process;
 use translate::{compile_grammar};
 
 mod translate;
@@ -50,7 +51,7 @@ fn main() {
 		Err(msg) => {
 			let mut e = stderr();
 			(writeln!(&mut e, "Error parsing language specification: {}", msg)).unwrap();
-			env::set_exit_status(1);
+			process::exit(1);
 		}
 	}
 }

--- a/src/peg_syntax_ext.rs
+++ b/src/peg_syntax_ext.rs
@@ -1,4 +1,4 @@
-#![feature(plugin_registrar, quote, box_syntax, collections, rustc_private, box_patterns)]
+#![feature(plugin_registrar, quote, box_syntax, rustc_private, box_patterns, append)]
 
 extern crate rustc;
 extern crate syntax;

--- a/src/rustast.rs
+++ b/src/rustast.rs
@@ -17,7 +17,7 @@ pub fn module(items: Vec<P<Item>>) -> P<Mod> {
 }
 
 pub fn parse_path(ctxt: &ExtCtxt, e: &str) -> ast::Path {
-	let mut p = syntax::parse::new_parser_from_source_str(&ctxt.parse_sess, Vec::new(), "file".to_string(), e.to_string());
+	let mut p = syntax::parse::new_parser_from_source_str(&ctxt.parse_sess, Vec::new(), String::new(), e.to_string());
 	let r = p.parse_path(syntax::parse::parser::NoTypesAllowed);
 	p.abort_if_errors();
 	r.unwrap_or_else(|_|panic!())
@@ -28,14 +28,14 @@ pub fn parse_path_vec(s: &str) -> Vec<ast::Ident> {
 }
 
 pub fn parse_block(ctxt: &ExtCtxt, e: &str) -> P<ast::Block> {
-	let mut p = syntax::parse::new_parser_from_source_str(&ctxt.parse_sess, Vec::new(), "file".to_string(), e.to_string());
+	let mut p = syntax::parse::new_parser_from_source_str(&ctxt.parse_sess, Vec::new(), String::new(), e.to_string());
 	let r = p.parse_block();
 	p.abort_if_errors();
 	r.unwrap_or_else(|e| panic!(e))
 }
 
 pub fn parse_type(ctxt: &ExtCtxt, e: &str) -> P<ast::Ty> {
-	let mut p = syntax::parse::new_parser_from_source_str(&ctxt.parse_sess, Vec::new(), "file".to_string(), e.to_string());
+	let mut p = syntax::parse::new_parser_from_source_str(&ctxt.parse_sess, Vec::new(), String::new(), e.to_string());
 	let r = p.parse_ty();
 	p.abort_if_errors();
 	r

--- a/src/translate.rs
+++ b/src/translate.rs
@@ -472,7 +472,7 @@ fn compile_expr(ctxt: &rustast::ExtCtxt, grammar: &Grammar, e: &Expr, result_use
 				if exprs.len() == 1 {
 					compile_expr(ctxt, grammar, &exprs[0], false)
 				} else {
-					compile_match_and_then(ctxt, grammar, &exprs[0], None, write_seq(ctxt, grammar, exprs.tail()))
+					compile_match_and_then(ctxt, grammar, &exprs[0], None, write_seq(ctxt, grammar, &exprs[1..]))
 				}
 			}
 
@@ -489,7 +489,7 @@ fn compile_expr(ctxt: &rustast::ExtCtxt, grammar: &Grammar, e: &Expr, result_use
 					compile_expr(ctxt, grammar, &exprs[0], result_used)
 				} else {
 					let choice_res = compile_expr(ctxt, grammar, &exprs[0], result_used);
-					let next = write_choice(ctxt, grammar, exprs.tail(), result_used);
+					let next = write_choice(ctxt, grammar, &exprs[1..], result_used);
 
 					quote_expr!(ctxt, {
 						let choice_res = $choice_res;
@@ -622,7 +622,7 @@ fn compile_expr(ctxt: &rustast::ExtCtxt, grammar: &Grammar, e: &Expr, result_use
 					Some(ref first) => {
 						let name = first.name.as_ref().map(|s| &s[..]);
 						compile_match_and_then(ctxt, grammar, &*first.expr, name,
-							write_seq(ctxt, grammar, exprs.tail(), code, is_cond)
+							write_seq(ctxt, grammar, &exprs[1..], code, is_cond)
 						)
 					}
 					None => {


### PR DESCRIPTION
The `collections` feature was broken up into multiple finer-grained features. I've also replaced all uses of `.tail()` with `[1..]`, since `tail` might be renamed, and replaced `env::set_exit_status` with `process::exit`, since the former was deprecated.

This would break with the next nightly.