### PR TITLE
Added a #[static] parse rule

### DIFF
--- a/src/grammar.rs
+++ b/src/grammar.rs
@@ -27,7 +27,9 @@ impl ::std::fmt::Display for ParseError {
         try!(write ! (
              fmt , "error at {}:{}: expected " , self . line , self . column
              ));
-        if self.expected.len() == 1 {
+        if self.expected.len() == 0 {
+            try!(write ! ( fmt , "EOF" ));
+        } else if self.expected.len() == 1 {
             try!(write ! (
                  fmt , "`{}`" , escape_default (
                  self . expected . iter (  ) . next (  ) . unwrap (  ) ) ));

--- a/src/grammar.rs
+++ b/src/grammar.rs
@@ -224,92 +224,128 @@ fn parse_rule<'input>(input: &'input str, state: &mut ParseState, pos: usize)
     {
         let start_pos = pos;
         {
-            let seq_res = parse_exportflag(input, state, pos);
+            let seq_res = parse_rule_attributes(input, state, pos);
             match seq_res {
-                Matched(pos, exported) => {
+                Matched(pos, attrs) => {
                     {
-                        let seq_res = parse_cacheflag(input, state, pos);
+                        let seq_res = parse_identifier(input, state, pos);
                         match seq_res {
-                            Matched(pos, cached) => {
+                            Matched(pos, name) => {
                                 {
                                     let seq_res =
-                                        parse_identifier(input, state, pos);
+                                        parse_returntype(input, state, pos);
                                     match seq_res {
-                                        Matched(pos, name) => {
+                                        Matched(pos, returns) => {
                                             {
                                                 let seq_res =
-                                                    parse_returntype(input,
-                                                                     state,
-                                                                     pos);
+                                                    parse_equals(input, state,
+                                                                 pos);
                                                 match seq_res {
-                                                    Matched(pos, returns) => {
+                                                    Matched(pos, _) => {
                                                         {
                                                             let seq_res =
-                                                                parse_equals(input,
-                                                                             state,
-                                                                             pos);
+                                                                parse_expression(input,
+                                                                                 state,
+                                                                                 pos);
                                                             match seq_res {
                                                                 Matched(pos,
-                                                                        _) =>
-                                                                {
+                                                                        expression)
+                                                                => {
                                                                     {
                                                                         let seq_res =
-                                                                            parse_expression(input,
-                                                                                             state,
-                                                                                             pos);
+                                                                            match parse_semicolon(input,
+                                                                                                  state,
+                                                                                                  pos)
+                                                                                {
+                                                                                Matched(newpos,
+                                                                                        value)
+                                                                                =>
+                                                                                {
+                                                                                    Matched(newpos,
+                                                                                            Some(value))
+                                                                                }
+                                                                                Failed
+                                                                                =>
+                                                                                {
+                                                                                    Matched(pos,
+                                                                                            None)
+                                                                                }
+                                                                            };
                                                                         match seq_res
                                                                             {
                                                                             Matched(pos,
-                                                                                    expression)
+                                                                                    _)
                                                                             =>
                                                                             {
                                                                                 {
-                                                                                    let seq_res =
-                                                                                        match parse_semicolon(input,
-                                                                                                              state,
-                                                                                                              pos)
-                                                                                            {
-                                                                                            Matched(newpos,
-                                                                                                    value)
-                                                                                            =>
-                                                                                            {
-                                                                                                Matched(newpos,
-                                                                                                        Some(value))
-                                                                                            }
-                                                                                            Failed
-                                                                                            =>
-                                                                                            {
-                                                                                                Matched(pos,
-                                                                                                        None)
-                                                                                            }
-                                                                                        };
-                                                                                    match seq_res
+                                                                                    let match_str =
+                                                                                        &input[start_pos..pos];
+                                                                                    match {
+                                                                                              match {
+                                                                                                        match expression
+                                                                                                            {
+                                                                                                            ActionExpr(ref exprs,
+                                                                                                                       _,
+                                                                                                                       _)
+                                                                                                            =>
+                                                                                                            {
+                                                                                                                if attrs.2
+                                                                                                                       &&
+                                                                                                                       exprs.len()
+                                                                                                                           >
+                                                                                                                           0
+                                                                                                                   {
+                                                                                                                    Err("code block")
+                                                                                                                } else {
+                                                                                                                    Ok(())
+                                                                                                                }
+                                                                                                            }
+                                                                                                            _
+                                                                                                            =>
+                                                                                                            {
+                                                                                                                if attrs.2
+                                                                                                                   {
+                                                                                                                    Err("code block")
+                                                                                                                } else {
+                                                                                                                    Ok(())
+                                                                                                                }
+                                                                                                            }
+                                                                                                        }
+                                                                                                    }
+                                                                                                  {
+                                                                                                  Ok(_)
+                                                                                                  =>
+                                                                                                  {
+                                                                                                      Ok(Rule{name:
+                                                                                                                  name,
+                                                                                                              expr:
+                                                                                                                  box() expression,
+                                                                                                              ret_type:
+                                                                                                                  returns,
+                                                                                                              exported:
+                                                                                                                  attrs.0,
+                                                                                                              cached:
+                                                                                                                  attrs.1,
+                                                                                                              is_static:
+                                                                                                                  attrs.2,})
+                                                                                                  }
+                                                                                                  Err(e)
+                                                                                                  =>
+                                                                                                  Err(e),
+                                                                                              }
+                                                                                          }
                                                                                         {
+                                                                                        Ok(res)
+                                                                                        =>
                                                                                         Matched(pos,
-                                                                                                _)
+                                                                                                res),
+                                                                                        Err(expected)
                                                                                         =>
                                                                                         {
-                                                                                            {
-                                                                                                let match_str =
-                                                                                                    &input[start_pos..pos];
-                                                                                                Matched(pos,
-                                                                                                        {
-                                                                                                            Rule{name:
-                                                                                                                     name,
-                                                                                                                 expr:
-                                                                                                                     box() expression,
-                                                                                                                 ret_type:
-                                                                                                                     returns,
-                                                                                                                 exported:
-                                                                                                                     exported,
-                                                                                                                 cached:
-                                                                                                                     cached,}
-                                                                                                        })
-                                                                                            }
+                                                                                            state.mark_failure(pos,
+                                                                                                               expected);
+                                                                                            Failed
                                                                                         }
-                                                                                        Failed
-                                                                                        =>
-                                                                                        Failed,
                                                                                     }
                                                                                 }
                                                                             }
@@ -434,6 +470,102 @@ fn parse_cacheflag<'input>(input: &'input str, state: &mut ParseState,
                     let match_str = &input[start_pos..pos];
                     Matched(pos, { false })
                 }
+            }
+        }
+    }
+}
+fn parse_staticflag<'input>(input: &'input str, state: &mut ParseState,
+                            pos: usize) -> RuleResult<bool> {
+    {
+        let choice_res =
+            {
+                let start_pos = pos;
+                {
+                    let seq_res = slice_eq(input, state, pos, "#[static]");
+                    match seq_res {
+                        Matched(pos, _) => {
+                            {
+                                let seq_res = parse___(input, state, pos);
+                                match seq_res {
+                                    Matched(pos, _) => {
+                                        {
+                                            let match_str =
+                                                &input[start_pos..pos];
+                                            Matched(pos, { true })
+                                        }
+                                    }
+                                    Failed => Failed,
+                                }
+                            }
+                        }
+                        Failed => Failed,
+                    }
+                }
+            };
+        match choice_res {
+            Matched(pos, value) => Matched(pos, value),
+            Failed => {
+                let start_pos = pos;
+                {
+                    let match_str = &input[start_pos..pos];
+                    Matched(pos, { false })
+                }
+            }
+        }
+    }
+}
+fn parse_rule_attributes<'input>(input: &'input str, state: &mut ParseState,
+                                 pos: usize)
+ -> RuleResult<(bool, bool, bool)> {
+    {
+        let start_pos = pos;
+        {
+            let seq_res = parse_staticflag(input, state, pos);
+            match seq_res {
+                Matched(pos, staticctx) => {
+                    {
+                        let seq_res = parse_exportflag(input, state, pos);
+                        match seq_res {
+                            Matched(pos, exported) => {
+                                {
+                                    let seq_res =
+                                        parse_cacheflag(input, state, pos);
+                                    match seq_res {
+                                        Matched(pos, cached) => {
+                                            {
+                                                let match_str =
+                                                    &input[start_pos..pos];
+                                                match {
+                                                          if staticctx &&
+                                                                 (exported ||
+                                                                      cached)
+                                                             {
+                                                              Err("attributes")
+                                                          } else {
+                                                              Ok((exported,
+                                                                  cached,
+                                                                  staticctx))
+                                                          }
+                                                      } {
+                                                    Ok(res) =>
+                                                    Matched(pos, res),
+                                                    Err(expected) => {
+                                                        state.mark_failure(pos,
+                                                                           expected);
+                                                        Failed
+                                                    }
+                                                }
+                                            }
+                                        }
+                                        Failed => Failed,
+                                    }
+                                }
+                            }
+                            Failed => Failed,
+                        }
+                    }
+                }
+                Failed => Failed,
             }
         }
     }

--- a/src/grammar.rustpeg
+++ b/src/grammar.rustpeg
@@ -7,12 +7,37 @@ grammar -> Grammar
   { Grammar{ imports:imports, rules:rules, context_type:context } }
 
 rule -> Rule
-  = exported:exportflag cached:cacheflag name:identifier returns: returntype equals expression:expression semicolon? {
-      Rule{ name: name, expr: box expression, ret_type: returns, exported: exported, cached: cached }
+  = attrs:rule_attributes name:identifier returns: returntype equals expression:expression semicolon? {?
+      match {match expression {
+          ActionExpr(ref exprs, _, _) => {
+            if attrs.2 && exprs.len() > 0 {
+              Err("code block")
+            } else {
+              Ok(())
+            }
+          },
+          _ => {
+            if attrs.2 {
+                // require static rules to be code blocks only
+                Err("code block")
+            } else {
+              Ok(())
+            }
+          }
+      }} {
+        Ok(_) => {
+          Ok(Rule{ name: name, expr: box expression, ret_type: returns, exported: attrs.0, cached: attrs.1, is_static: attrs.2 })
+        },
+        Err(e) => Err(e)
+      }
     }
 
     exportflag -> bool = ("#[export]"/"#[pub]") __ {true} / "" {false}
     cacheflag -> bool = "#[cache]" __ {true} / {false}
+    staticflag -> bool = "#[static]" __ {true} / {false}
+
+rule_attributes -> (bool, bool, bool)
+  = staticctx:staticflag exported:exportflag cached:cacheflag {? if staticctx && (exported || cached) {Err("attributes")} else {Ok((exported, cached, staticctx))}}
 
 returntype -> String
   = returns tp:(rust_type {match_str.trim().to_string()}) { tp }

--- a/src/peg.rs
+++ b/src/peg.rs
@@ -1,4 +1,4 @@
-#![feature(quote, box_syntax, collections, rustc_private, box_patterns, exit_status, slice_patterns)]
+#![feature(quote, box_syntax, rustc_private, box_patterns, slice_patterns, append)]
 extern crate syntax;
 
 use std::env;
@@ -6,6 +6,7 @@ use std::fs::File;
 use std::io::{Read, Write};
 use std::io::{stdin, stdout, stderr};
 use std::path::Path;
+use std::process;
 use translate::{compile_grammar};
 
 mod translate;
@@ -50,7 +51,7 @@ fn main() {
 		Err(msg) => {
 			let mut e = stderr();
 			(writeln!(&mut e, "Error parsing language specification: {}", msg)).unwrap();
-			env::set_exit_status(1);
+			process::exit(1);
 		}
 	}
 }

--- a/src/peg_syntax_ext.rs
+++ b/src/peg_syntax_ext.rs
@@ -1,4 +1,4 @@
-#![feature(plugin_registrar, quote, box_syntax, collections, rustc_private, box_patterns)]
+#![feature(plugin_registrar, quote, box_syntax, rustc_private, box_patterns, append)]
 
 extern crate rustc;
 extern crate syntax;

--- a/src/rustast.rs
+++ b/src/rustast.rs
@@ -17,7 +17,7 @@ pub fn module(items: Vec<P<Item>>) -> P<Mod> {
 }
 
 pub fn parse_path(ctxt: &ExtCtxt, e: &str) -> ast::Path {
-	let mut p = syntax::parse::new_parser_from_source_str(&ctxt.parse_sess, Vec::new(), "file".to_string(), e.to_string());
+	let mut p = syntax::parse::new_parser_from_source_str(&ctxt.parse_sess, Vec::new(), String::new(), e.to_string());
 	let r = p.parse_path(syntax::parse::parser::NoTypesAllowed);
 	p.abort_if_errors();
 	r.unwrap_or_else(|_|panic!())
@@ -28,14 +28,14 @@ pub fn parse_path_vec(s: &str) -> Vec<ast::Ident> {
 }
 
 pub fn parse_block(ctxt: &ExtCtxt, e: &str) -> P<ast::Block> {
-	let mut p = syntax::parse::new_parser_from_source_str(&ctxt.parse_sess, Vec::new(), "file".to_string(), e.to_string());
+	let mut p = syntax::parse::new_parser_from_source_str(&ctxt.parse_sess, Vec::new(), String::new(), e.to_string());
 	let r = p.parse_block();
 	p.abort_if_errors();
 	r.unwrap_or_else(|e| panic!(e))
 }
 
 pub fn parse_type(ctxt: &ExtCtxt, e: &str) -> P<ast::Ty> {
-	let mut p = syntax::parse::new_parser_from_source_str(&ctxt.parse_sess, Vec::new(), "file".to_string(), e.to_string());
+	let mut p = syntax::parse::new_parser_from_source_str(&ctxt.parse_sess, Vec::new(), String::new(), e.to_string());
 	let r = p.parse_ty();
 	p.abort_if_errors();
 	r

--- a/tests/test_static.rs
+++ b/tests/test_static.rs
@@ -1,0 +1,21 @@
+#![feature(plugin)]
+#![plugin(peg_syntax_ext)]
+
+use parser::parse;
+
+peg! parser(r#"
+#[static]
+test_static -> usize = {0}
+
+#[export]
+parse -> usize
+        = char+ { *test_static }
+
+char -> ()
+        = . { *test_static = *test_static + 1; () }
+"#);
+
+#[test]
+fn test_static() {
+    assert_eq!(parse("abcdef").unwrap(), 6);
+}

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -12,6 +12,15 @@ fn test_neg_assert() {
 }
 
 #[test]
+fn test_eof() {
+	assert_eq!(expect_nothing("t"), Ok(()));
+	match expect_nothing("tt") {
+		Err(e) => println!("{}", e),
+		Ok(_) => panic!("should not happen")
+	};
+}
+
+#[test]
 fn test_optional() {
 	assert_eq!(options("abc"), Ok(None));
 	assert_eq!(options("abcdef"), Ok(Some(())));

--- a/tests/tests.rustpeg
+++ b/tests/tests.rustpeg
@@ -71,3 +71,7 @@ keyvals -> HashMap<i64, i64>
 
 keyval -> (i64, i64)
     = k:number ":" + v:number { (k, v) }
+
+#[export]
+expect_nothing -> ()
+	= [a-zA-Z]


### PR DESCRIPTION
This PR builds on top of the `#![context(T)]` global context objects by adding an *additional* method for creating global context objects available to all parse rules. We allow users to annotate parse rules as `#[static]` which allows for context objects (names, initialization, etc.) to reside entirely within the grammar. This improves readability.

Here's an example which parses an indentation-scoped grammar:

```rust
use super::Statement;
use super::Line;
use std::char;

#[static]
indentation_level -> usize = {0}

#[pub]
parse -> Vec<Statement<'input>>
    = s:statements {s}

statements -> Vec<Statement<'input>>
    = s:statement+ {s}

statement -> Statement<'input>
    = l:line children:statement_children? {Statement{line: l, children: children}}

statement_children -> Vec<Statement<'input>>
    = INC_INDENT children:statements DEC_INDENT {children}
    / DEC_INDENT {? Err("children")}

line -> Line<'input>
    = SAME_INDENT line:line_expr __? EOL? {line}
    / SAME_INDENT EOL {Line{s: match_str}}

line_expr -> Line<'input>
    = ident:ident {Line{s: ident}}

ident -> &'input str
    = [a-z]+ {match_str}

EOL -> ()
    = "\r\n" / "\n" / "\r" {()}

INDENTATION -> usize
    = tabs:("    "/"\t")* { tabs.len() }

INC_INDENT -> ()
    = {*indentation_level = *indentation_level + 1; ()}

SAME_INDENT -> ()
    = i:INDENTATION {? if i == *indentation_level { Ok(()) } else {Err("same indentation")}}

DEC_INDENT -> ()
    = {*indentation_level = *indentation_level - 1; ()}

__ -> ()
    = (" "/"\t")+ {()}
```