### PR TITLE
Don't build the peg binary when benchmarking

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ A parser generator built on the Parsing Expression Grammar (PEG) formalism.
 name = "peg"
 path = "src/peg.rs"
 test = false
+bench = false
 
 [lib]
 plugin = true


### PR DESCRIPTION
Prevents "dead code" warnings