### PR TITLE
Allow caching 'input-bounded results

### DIFF
--- a/src/grammar.rs
+++ b/src/grammar.rs
@@ -117,7 +117,7 @@ impl <'input> ParseState<'input> {
         Failed
     }
 }
-fn parse_grammar<'input>(input: &'input str, state: &mut ParseState,
+fn parse_grammar<'input>(input: &'input str, state: &mut ParseState<'input>,
                          pos: usize) -> RuleResult<Grammar> {
     {
         let start_pos = pos;
@@ -194,8 +194,8 @@ fn parse_grammar<'input>(input: &'input str, state: &mut ParseState,
         }
     }
 }
-fn parse_rule<'input>(input: &'input str, state: &mut ParseState, pos: usize)
- -> RuleResult<Rule> {
+fn parse_rule<'input>(input: &'input str, state: &mut ParseState<'input>,
+                      pos: usize) -> RuleResult<Rule> {
     {
         let start_pos = pos;
         {
@@ -316,8 +316,9 @@ fn parse_rule<'input>(input: &'input str, state: &mut ParseState, pos: usize)
         }
     }
 }
-fn parse_exportflag<'input>(input: &'input str, state: &mut ParseState,
-                            pos: usize) -> RuleResult<bool> {
+fn parse_exportflag<'input>(input: &'input str,
+                            state: &mut ParseState<'input>, pos: usize)
+ -> RuleResult<bool> {
     {
         let choice_res =
             {
@@ -373,7 +374,7 @@ fn parse_exportflag<'input>(input: &'input str, state: &mut ParseState,
         }
     }
 }
-fn parse_cacheflag<'input>(input: &'input str, state: &mut ParseState,
+fn parse_cacheflag<'input>(input: &'input str, state: &mut ParseState<'input>,
                            pos: usize) -> RuleResult<bool> {
     {
         let choice_res =
@@ -413,8 +414,9 @@ fn parse_cacheflag<'input>(input: &'input str, state: &mut ParseState,
         }
     }
 }
-fn parse_returntype<'input>(input: &'input str, state: &mut ParseState,
-                            pos: usize) -> RuleResult<String> {
+fn parse_returntype<'input>(input: &'input str,
+                            state: &mut ParseState<'input>, pos: usize)
+ -> RuleResult<String> {
     {
         let choice_res =
             {
@@ -474,7 +476,7 @@ fn parse_returntype<'input>(input: &'input str, state: &mut ParseState,
         }
     }
 }
-fn parse_rust_use<'input>(input: &'input str, state: &mut ParseState,
+fn parse_rust_use<'input>(input: &'input str, state: &mut ParseState<'input>,
                           pos: usize) -> RuleResult<RustUse> {
     {
         let start_pos = pos;
@@ -923,7 +925,7 @@ fn parse_rust_use<'input>(input: &'input str, state: &mut ParseState,
         }
     }
 }
-fn parse_rust_path<'input>(input: &'input str, state: &mut ParseState,
+fn parse_rust_path<'input>(input: &'input str, state: &mut ParseState<'input>,
                            pos: usize) -> RuleResult<String> {
     {
         let start_pos = pos;
@@ -977,7 +979,7 @@ fn parse_rust_path<'input>(input: &'input str, state: &mut ParseState,
         }
     }
 }
-fn parse_rust_type<'input>(input: &'input str, state: &mut ParseState,
+fn parse_rust_type<'input>(input: &'input str, state: &mut ParseState<'input>,
                            pos: usize) -> RuleResult<()> {
     {
         let choice_res =
@@ -1495,11 +1497,12 @@ fn parse_rust_type<'input>(input: &'input str, state: &mut ParseState,
         }
     }
 }
-fn parse_expression<'input>(input: &'input str, state: &mut ParseState,
-                            pos: usize) -> RuleResult<Expr> {
+fn parse_expression<'input>(input: &'input str,
+                            state: &mut ParseState<'input>, pos: usize)
+ -> RuleResult<Expr> {
     parse_choice(input, state, pos)
 }
-fn parse_choice<'input>(input: &'input str, state: &mut ParseState,
+fn parse_choice<'input>(input: &'input str, state: &mut ParseState<'input>,
                         pos: usize) -> RuleResult<Expr> {
     {
         let start_pos = pos;
@@ -1583,7 +1586,7 @@ fn parse_choice<'input>(input: &'input str, state: &mut ParseState,
         }
     }
 }
-fn parse_sequence<'input>(input: &'input str, state: &mut ParseState,
+fn parse_sequence<'input>(input: &'input str, state: &mut ParseState<'input>,
                           pos: usize) -> RuleResult<Expr> {
     {
         let choice_res =
@@ -1677,7 +1680,7 @@ fn parse_sequence<'input>(input: &'input str, state: &mut ParseState,
         }
     }
 }
-fn parse_labeled<'input>(input: &'input str, state: &mut ParseState,
+fn parse_labeled<'input>(input: &'input str, state: &mut ParseState<'input>,
                          pos: usize) -> RuleResult<TaggedExpr> {
     {
         let choice_res =
@@ -1745,7 +1748,7 @@ fn parse_labeled<'input>(input: &'input str, state: &mut ParseState,
         }
     }
 }
-fn parse_prefixed<'input>(input: &'input str, state: &mut ParseState,
+fn parse_prefixed<'input>(input: &'input str, state: &mut ParseState<'input>,
                           pos: usize) -> RuleResult<Expr> {
     {
         let choice_res =
@@ -1852,7 +1855,7 @@ fn parse_prefixed<'input>(input: &'input str, state: &mut ParseState,
         }
     }
 }
-fn parse_suffixed<'input>(input: &'input str, state: &mut ParseState,
+fn parse_suffixed<'input>(input: &'input str, state: &mut ParseState<'input>,
                           pos: usize) -> RuleResult<Expr> {
     {
         let choice_res =
@@ -2492,7 +2495,7 @@ fn parse_suffixed<'input>(input: &'input str, state: &mut ParseState,
         }
     }
 }
-fn parse_primary<'input>(input: &'input str, state: &mut ParseState,
+fn parse_primary<'input>(input: &'input str, state: &mut ParseState<'input>,
                          pos: usize) -> RuleResult<Expr> {
     let rule_result =
         {
@@ -2669,7 +2672,7 @@ fn parse_primary<'input>(input: &'input str, state: &mut ParseState,
     state.primary_cache.insert(pos, rule_result.clone());
     rule_result
 }
-fn parse_action<'input>(input: &'input str, state: &mut ParseState,
+fn parse_action<'input>(input: &'input str, state: &mut ParseState<'input>,
                         pos: usize) -> RuleResult<(String, bool)> {
     {
         let start_pos = pos;
@@ -2802,7 +2805,7 @@ fn parse_action<'input>(input: &'input str, state: &mut ParseState,
         }
     }
 }
-fn parse_braced<'input>(input: &'input str, state: &mut ParseState,
+fn parse_braced<'input>(input: &'input str, state: &mut ParseState<'input>,
                         pos: usize) -> RuleResult<String> {
     {
         let start_pos = pos;
@@ -2881,8 +2884,8 @@ fn parse_braced<'input>(input: &'input str, state: &mut ParseState,
     }
 }
 fn parse_nonBraceCharacters<'input>(input: &'input str,
-                                    state: &mut ParseState, pos: usize)
- -> RuleResult<()> {
+                                    state: &mut ParseState<'input>,
+                                    pos: usize) -> RuleResult<()> {
     {
         let mut repeat_pos = pos;
         let mut repeat_value = vec!();
@@ -2902,8 +2905,9 @@ fn parse_nonBraceCharacters<'input>(input: &'input str,
         } else { Failed }
     }
 }
-fn parse_nonBraceCharacter<'input>(input: &'input str, state: &mut ParseState,
-                                   pos: usize) -> RuleResult<()> {
+fn parse_nonBraceCharacter<'input>(input: &'input str,
+                                   state: &mut ParseState<'input>, pos: usize)
+ -> RuleResult<()> {
     if input.len() > pos {
         let (ch, next) = char_range_at(input, pos);
         match ch {
@@ -2912,7 +2916,7 @@ fn parse_nonBraceCharacter<'input>(input: &'input str, state: &mut ParseState,
         }
     } else { state.mark_failure(pos, "[^{}]") }
 }
-fn parse_equals<'input>(input: &'input str, state: &mut ParseState,
+fn parse_equals<'input>(input: &'input str, state: &mut ParseState<'input>,
                         pos: usize) -> RuleResult<()> {
     {
         let seq_res = slice_eq(input, state, pos, "=");
@@ -2922,8 +2926,8 @@ fn parse_equals<'input>(input: &'input str, state: &mut ParseState,
         }
     }
 }
-fn parse_colon<'input>(input: &'input str, state: &mut ParseState, pos: usize)
- -> RuleResult<()> {
+fn parse_colon<'input>(input: &'input str, state: &mut ParseState<'input>,
+                       pos: usize) -> RuleResult<()> {
     {
         let seq_res = slice_eq(input, state, pos, ":");
         match seq_res {
@@ -2932,7 +2936,7 @@ fn parse_colon<'input>(input: &'input str, state: &mut ParseState, pos: usize)
         }
     }
 }
-fn parse_semicolon<'input>(input: &'input str, state: &mut ParseState,
+fn parse_semicolon<'input>(input: &'input str, state: &mut ParseState<'input>,
                            pos: usize) -> RuleResult<()> {
     {
         let seq_res = slice_eq(input, state, pos, ";");
@@ -2942,8 +2946,8 @@ fn parse_semicolon<'input>(input: &'input str, state: &mut ParseState,
         }
     }
 }
-fn parse_slash<'input>(input: &'input str, state: &mut ParseState, pos: usize)
- -> RuleResult<()> {
+fn parse_slash<'input>(input: &'input str, state: &mut ParseState<'input>,
+                       pos: usize) -> RuleResult<()> {
     {
         let seq_res = slice_eq(input, state, pos, "/");
         match seq_res {
@@ -2952,8 +2956,8 @@ fn parse_slash<'input>(input: &'input str, state: &mut ParseState, pos: usize)
         }
     }
 }
-fn parse_and<'input>(input: &'input str, state: &mut ParseState, pos: usize)
- -> RuleResult<()> {
+fn parse_and<'input>(input: &'input str, state: &mut ParseState<'input>,
+                     pos: usize) -> RuleResult<()> {
     {
         let seq_res = slice_eq(input, state, pos, "&");
         match seq_res {
@@ -2962,8 +2966,8 @@ fn parse_and<'input>(input: &'input str, state: &mut ParseState, pos: usize)
         }
     }
 }
-fn parse_not<'input>(input: &'input str, state: &mut ParseState, pos: usize)
- -> RuleResult<()> {
+fn parse_not<'input>(input: &'input str, state: &mut ParseState<'input>,
+                     pos: usize) -> RuleResult<()> {
     {
         let seq_res = slice_eq(input, state, pos, "!");
         match seq_res {
@@ -2972,7 +2976,7 @@ fn parse_not<'input>(input: &'input str, state: &mut ParseState, pos: usize)
         }
     }
 }
-fn parse_dollar<'input>(input: &'input str, state: &mut ParseState,
+fn parse_dollar<'input>(input: &'input str, state: &mut ParseState<'input>,
                         pos: usize) -> RuleResult<()> {
     {
         let seq_res = slice_eq(input, state, pos, "$");
@@ -2982,7 +2986,7 @@ fn parse_dollar<'input>(input: &'input str, state: &mut ParseState,
         }
     }
 }
-fn parse_question<'input>(input: &'input str, state: &mut ParseState,
+fn parse_question<'input>(input: &'input str, state: &mut ParseState<'input>,
                           pos: usize) -> RuleResult<()> {
     {
         let seq_res = slice_eq(input, state, pos, "?");
@@ -2992,8 +2996,8 @@ fn parse_question<'input>(input: &'input str, state: &mut ParseState,
         }
     }
 }
-fn parse_star<'input>(input: &'input str, state: &mut ParseState, pos: usize)
- -> RuleResult<()> {
+fn parse_star<'input>(input: &'input str, state: &mut ParseState<'input>,
+                      pos: usize) -> RuleResult<()> {
     {
         let seq_res = slice_eq(input, state, pos, "*");
         match seq_res {
@@ -3002,7 +3006,7 @@ fn parse_star<'input>(input: &'input str, state: &mut ParseState, pos: usize)
         }
     }
 }
-fn parse_starstar<'input>(input: &'input str, state: &mut ParseState,
+fn parse_starstar<'input>(input: &'input str, state: &mut ParseState<'input>,
                           pos: usize) -> RuleResult<()> {
     {
         let seq_res = slice_eq(input, state, pos, "**");
@@ -3012,8 +3016,8 @@ fn parse_starstar<'input>(input: &'input str, state: &mut ParseState,
         }
     }
 }
-fn parse_plus<'input>(input: &'input str, state: &mut ParseState, pos: usize)
- -> RuleResult<()> {
+fn parse_plus<'input>(input: &'input str, state: &mut ParseState<'input>,
+                      pos: usize) -> RuleResult<()> {
     {
         let seq_res = slice_eq(input, state, pos, "+");
         match seq_res {
@@ -3022,7 +3026,7 @@ fn parse_plus<'input>(input: &'input str, state: &mut ParseState, pos: usize)
         }
     }
 }
-fn parse_plusplus<'input>(input: &'input str, state: &mut ParseState,
+fn parse_plusplus<'input>(input: &'input str, state: &mut ParseState<'input>,
                           pos: usize) -> RuleResult<()> {
     {
         let seq_res = slice_eq(input, state, pos, "++");
@@ -3032,7 +3036,7 @@ fn parse_plusplus<'input>(input: &'input str, state: &mut ParseState,
         }
     }
 }
-fn parse_lparen<'input>(input: &'input str, state: &mut ParseState,
+fn parse_lparen<'input>(input: &'input str, state: &mut ParseState<'input>,
                         pos: usize) -> RuleResult<()> {
     {
         let seq_res = slice_eq(input, state, pos, "(");
@@ -3042,7 +3046,7 @@ fn parse_lparen<'input>(input: &'input str, state: &mut ParseState,
         }
     }
 }
-fn parse_rparen<'input>(input: &'input str, state: &mut ParseState,
+fn parse_rparen<'input>(input: &'input str, state: &mut ParseState<'input>,
                         pos: usize) -> RuleResult<()> {
     {
         let seq_res = slice_eq(input, state, pos, ")");
@@ -3052,8 +3056,8 @@ fn parse_rparen<'input>(input: &'input str, state: &mut ParseState,
         }
     }
 }
-fn parse_dot<'input>(input: &'input str, state: &mut ParseState, pos: usize)
- -> RuleResult<()> {
+fn parse_dot<'input>(input: &'input str, state: &mut ParseState<'input>,
+                     pos: usize) -> RuleResult<()> {
     {
         let seq_res = slice_eq(input, state, pos, ".");
         match seq_res {
@@ -3062,7 +3066,7 @@ fn parse_dot<'input>(input: &'input str, state: &mut ParseState, pos: usize)
         }
     }
 }
-fn parse_returns<'input>(input: &'input str, state: &mut ParseState,
+fn parse_returns<'input>(input: &'input str, state: &mut ParseState<'input>,
                          pos: usize) -> RuleResult<()> {
     {
         let seq_res = slice_eq(input, state, pos, "->");
@@ -3072,7 +3076,7 @@ fn parse_returns<'input>(input: &'input str, state: &mut ParseState,
         }
     }
 }
-fn parse_lbrace<'input>(input: &'input str, state: &mut ParseState,
+fn parse_lbrace<'input>(input: &'input str, state: &mut ParseState<'input>,
                         pos: usize) -> RuleResult<()> {
     {
         let seq_res = slice_eq(input, state, pos, "{");
@@ -3082,7 +3086,7 @@ fn parse_lbrace<'input>(input: &'input str, state: &mut ParseState,
         }
     }
 }
-fn parse_rbrace<'input>(input: &'input str, state: &mut ParseState,
+fn parse_rbrace<'input>(input: &'input str, state: &mut ParseState<'input>,
                         pos: usize) -> RuleResult<()> {
     {
         let seq_res = slice_eq(input, state, pos, "}");
@@ -3092,8 +3096,8 @@ fn parse_rbrace<'input>(input: &'input str, state: &mut ParseState,
         }
     }
 }
-fn parse_comma<'input>(input: &'input str, state: &mut ParseState, pos: usize)
- -> RuleResult<()> {
+fn parse_comma<'input>(input: &'input str, state: &mut ParseState<'input>,
+                       pos: usize) -> RuleResult<()> {
     {
         let seq_res = slice_eq(input, state, pos, ",");
         match seq_res {
@@ -3102,7 +3106,7 @@ fn parse_comma<'input>(input: &'input str, state: &mut ParseState, pos: usize)
         }
     }
 }
-fn parse_integer<'input>(input: &'input str, state: &mut ParseState,
+fn parse_integer<'input>(input: &'input str, state: &mut ParseState<'input>,
                          pos: usize) -> RuleResult<usize> {
     {
         let start_pos = pos;
@@ -3175,8 +3179,9 @@ fn parse_integer<'input>(input: &'input str, state: &mut ParseState,
         }
     }
 }
-fn parse_identifier<'input>(input: &'input str, state: &mut ParseState,
-                            pos: usize) -> RuleResult<String> {
+fn parse_identifier<'input>(input: &'input str,
+                            state: &mut ParseState<'input>, pos: usize)
+ -> RuleResult<String> {
     {
         let start_pos = pos;
         {
@@ -3284,7 +3289,7 @@ fn parse_identifier<'input>(input: &'input str, state: &mut ParseState,
         }
     }
 }
-fn parse_literal<'input>(input: &'input str, state: &mut ParseState,
+fn parse_literal<'input>(input: &'input str, state: &mut ParseState<'input>,
                          pos: usize) -> RuleResult<Expr> {
     {
         let start_pos = pos;
@@ -3337,7 +3342,7 @@ fn parse_literal<'input>(input: &'input str, state: &mut ParseState,
         }
     }
 }
-fn parse_string<'input>(input: &'input str, state: &mut ParseState,
+fn parse_string<'input>(input: &'input str, state: &mut ParseState<'input>,
                         pos: usize) -> RuleResult<String> {
     {
         let start_pos = pos;
@@ -3372,8 +3377,8 @@ fn parse_string<'input>(input: &'input str, state: &mut ParseState,
     }
 }
 fn parse_doubleQuotedString<'input>(input: &'input str,
-                                    state: &mut ParseState, pos: usize)
- -> RuleResult<String> {
+                                    state: &mut ParseState<'input>,
+                                    pos: usize) -> RuleResult<String> {
     {
         let start_pos = pos;
         {
@@ -3431,8 +3436,8 @@ fn parse_doubleQuotedString<'input>(input: &'input str,
     }
 }
 fn parse_doubleQuotedCharacter<'input>(input: &'input str,
-                                       state: &mut ParseState, pos: usize)
- -> RuleResult<char> {
+                                       state: &mut ParseState<'input>,
+                                       pos: usize) -> RuleResult<char> {
     {
         let choice_res = parse_simpleDoubleQuotedCharacter(input, state, pos);
         match choice_res {
@@ -3500,7 +3505,7 @@ fn parse_doubleQuotedCharacter<'input>(input: &'input str,
     }
 }
 fn parse_simpleDoubleQuotedCharacter<'input>(input: &'input str,
-                                             state: &mut ParseState,
+                                             state: &mut ParseState<'input>,
                                              pos: usize) -> RuleResult<char> {
     {
         let start_pos = pos;
@@ -3554,8 +3559,8 @@ fn parse_simpleDoubleQuotedCharacter<'input>(input: &'input str,
     }
 }
 fn parse_singleQuotedString<'input>(input: &'input str,
-                                    state: &mut ParseState, pos: usize)
- -> RuleResult<String> {
+                                    state: &mut ParseState<'input>,
+                                    pos: usize) -> RuleResult<String> {
     {
         let start_pos = pos;
         {
@@ -3613,8 +3618,8 @@ fn parse_singleQuotedString<'input>(input: &'input str,
     }
 }
 fn parse_singleQuotedCharacter<'input>(input: &'input str,
-                                       state: &mut ParseState, pos: usize)
- -> RuleResult<char> {
+                                       state: &mut ParseState<'input>,
+                                       pos: usize) -> RuleResult<char> {
     {
         let choice_res = parse_simpleSingleQuotedCharacter(input, state, pos);
         match choice_res {
@@ -3682,7 +3687,7 @@ fn parse_singleQuotedCharacter<'input>(input: &'input str,
     }
 }
 fn parse_simpleSingleQuotedCharacter<'input>(input: &'input str,
-                                             state: &mut ParseState,
+                                             state: &mut ParseState<'input>,
                                              pos: usize) -> RuleResult<char> {
     {
         let start_pos = pos;
@@ -3735,8 +3740,8 @@ fn parse_simpleSingleQuotedCharacter<'input>(input: &'input str,
         }
     }
 }
-fn parse_class<'input>(input: &'input str, state: &mut ParseState, pos: usize)
- -> RuleResult<Expr> {
+fn parse_class<'input>(input: &'input str, state: &mut ParseState<'input>,
+                       pos: usize) -> RuleResult<Expr> {
     {
         let start_pos = pos;
         {
@@ -3869,8 +3874,8 @@ fn parse_class<'input>(input: &'input str, state: &mut ParseState, pos: usize)
     }
 }
 fn parse_classCharacterRange<'input>(input: &'input str,
-                                     state: &mut ParseState, pos: usize)
- -> RuleResult<CharSetCase> {
+                                     state: &mut ParseState<'input>,
+                                     pos: usize) -> RuleResult<CharSetCase> {
     {
         let start_pos = pos;
         {
@@ -3913,8 +3918,9 @@ fn parse_classCharacterRange<'input>(input: &'input str,
         }
     }
 }
-fn parse_classCharacter<'input>(input: &'input str, state: &mut ParseState,
-                                pos: usize) -> RuleResult<CharSetCase> {
+fn parse_classCharacter<'input>(input: &'input str,
+                                state: &mut ParseState<'input>, pos: usize)
+ -> RuleResult<CharSetCase> {
     {
         let start_pos = pos;
         {
@@ -3933,8 +3939,8 @@ fn parse_classCharacter<'input>(input: &'input str, state: &mut ParseState,
     }
 }
 fn parse_bracketDelimitedCharacter<'input>(input: &'input str,
-                                           state: &mut ParseState, pos: usize)
- -> RuleResult<char> {
+                                           state: &mut ParseState<'input>,
+                                           pos: usize) -> RuleResult<char> {
     {
         let choice_res =
             parse_simpleBracketDelimitedCharacter(input, state, pos);
@@ -4003,7 +4009,8 @@ fn parse_bracketDelimitedCharacter<'input>(input: &'input str,
     }
 }
 fn parse_simpleBracketDelimitedCharacter<'input>(input: &'input str,
-                                                 state: &mut ParseState,
+                                                 state:
+                                                     &mut ParseState<'input>,
                                                  pos: usize)
  -> RuleResult<char> {
     {
@@ -4057,8 +4064,8 @@ fn parse_simpleBracketDelimitedCharacter<'input>(input: &'input str,
     }
 }
 fn parse_simpleEscapeSequence<'input>(input: &'input str,
-                                      state: &mut ParseState, pos: usize)
- -> RuleResult<char> {
+                                      state: &mut ParseState<'input>,
+                                      pos: usize) -> RuleResult<char> {
     {
         let start_pos = pos;
         {
@@ -4158,8 +4165,8 @@ fn parse_simpleEscapeSequence<'input>(input: &'input str,
     }
 }
 fn parse_zeroEscapeSequence<'input>(input: &'input str,
-                                    state: &mut ParseState, pos: usize)
- -> RuleResult<char> {
+                                    state: &mut ParseState<'input>,
+                                    pos: usize) -> RuleResult<char> {
     {
         let start_pos = pos;
         {
@@ -4193,8 +4200,8 @@ fn parse_zeroEscapeSequence<'input>(input: &'input str,
     }
 }
 fn parse_hex2EscapeSequence<'input>(input: &'input str,
-                                    state: &mut ParseState, pos: usize)
- -> RuleResult<char> {
+                                    state: &mut ParseState<'input>,
+                                    pos: usize) -> RuleResult<char> {
     {
         let start_pos = pos;
         {
@@ -4255,8 +4262,8 @@ fn parse_hex2EscapeSequence<'input>(input: &'input str,
     }
 }
 fn parse_unicodeEscapeSequence<'input>(input: &'input str,
-                                       state: &mut ParseState, pos: usize)
- -> RuleResult<char> {
+                                       state: &mut ParseState<'input>,
+                                       pos: usize) -> RuleResult<char> {
     {
         let start_pos = pos;
         {
@@ -4337,8 +4344,8 @@ fn parse_unicodeEscapeSequence<'input>(input: &'input str,
     }
 }
 fn parse_hex4EscapeSequence<'input>(input: &'input str,
-                                    state: &mut ParseState, pos: usize)
- -> RuleResult<char> {
+                                    state: &mut ParseState<'input>,
+                                    pos: usize) -> RuleResult<char> {
     {
         let start_pos = pos;
         {
@@ -4430,8 +4437,8 @@ fn parse_hex4EscapeSequence<'input>(input: &'input str,
     }
 }
 fn parse_hex8EscapeSequence<'input>(input: &'input str,
-                                    state: &mut ParseState, pos: usize)
- -> RuleResult<char> {
+                                    state: &mut ParseState<'input>,
+                                    pos: usize) -> RuleResult<char> {
     {
         let start_pos = pos;
         {
@@ -4590,8 +4597,9 @@ fn parse_hex8EscapeSequence<'input>(input: &'input str,
         }
     }
 }
-fn parse_eolEscapeSequence<'input>(input: &'input str, state: &mut ParseState,
-                                   pos: usize) -> RuleResult<char> {
+fn parse_eolEscapeSequence<'input>(input: &'input str,
+                                   state: &mut ParseState<'input>, pos: usize)
+ -> RuleResult<char> {
     {
         let start_pos = pos;
         {
@@ -4616,8 +4624,8 @@ fn parse_eolEscapeSequence<'input>(input: &'input str, state: &mut ParseState,
         }
     }
 }
-fn parse_digit<'input>(input: &'input str, state: &mut ParseState, pos: usize)
- -> RuleResult<()> {
+fn parse_digit<'input>(input: &'input str, state: &mut ParseState<'input>,
+                       pos: usize) -> RuleResult<()> {
     if input.len() > pos {
         let (ch, next) = char_range_at(input, pos);
         match ch {
@@ -4626,7 +4634,7 @@ fn parse_digit<'input>(input: &'input str, state: &mut ParseState, pos: usize)
         }
     } else { state.mark_failure(pos, "[0-9]") }
 }
-fn parse_hexDigit<'input>(input: &'input str, state: &mut ParseState,
+fn parse_hexDigit<'input>(input: &'input str, state: &mut ParseState<'input>,
                           pos: usize) -> RuleResult<()> {
     if input.len() > pos {
         let (ch, next) = char_range_at(input, pos);
@@ -4636,7 +4644,7 @@ fn parse_hexDigit<'input>(input: &'input str, state: &mut ParseState,
         }
     } else { state.mark_failure(pos, "[0-9a-fA-F]") }
 }
-fn parse_letter<'input>(input: &'input str, state: &mut ParseState,
+fn parse_letter<'input>(input: &'input str, state: &mut ParseState<'input>,
                         pos: usize) -> RuleResult<()> {
     {
         let choice_res = parse_lowerCaseLetter(input, state, pos);
@@ -4646,8 +4654,9 @@ fn parse_letter<'input>(input: &'input str, state: &mut ParseState,
         }
     }
 }
-fn parse_lowerCaseLetter<'input>(input: &'input str, state: &mut ParseState,
-                                 pos: usize) -> RuleResult<()> {
+fn parse_lowerCaseLetter<'input>(input: &'input str,
+                                 state: &mut ParseState<'input>, pos: usize)
+ -> RuleResult<()> {
     if input.len() > pos {
         let (ch, next) = char_range_at(input, pos);
         match ch {
@@ -4656,8 +4665,9 @@ fn parse_lowerCaseLetter<'input>(input: &'input str, state: &mut ParseState,
         }
     } else { state.mark_failure(pos, "[a-z]") }
 }
-fn parse_upperCaseLetter<'input>(input: &'input str, state: &mut ParseState,
-                                 pos: usize) -> RuleResult<()> {
+fn parse_upperCaseLetter<'input>(input: &'input str,
+                                 state: &mut ParseState<'input>, pos: usize)
+ -> RuleResult<()> {
     if input.len() > pos {
         let (ch, next) = char_range_at(input, pos);
         match ch {
@@ -4666,8 +4676,8 @@ fn parse_upperCaseLetter<'input>(input: &'input str, state: &mut ParseState,
         }
     } else { state.mark_failure(pos, "[A-Z]") }
 }
-fn parse___<'input>(input: &'input str, state: &mut ParseState, pos: usize)
- -> RuleResult<()> {
+fn parse___<'input>(input: &'input str, state: &mut ParseState<'input>,
+                    pos: usize) -> RuleResult<()> {
     {
         let mut repeat_pos = pos;
         loop  {
@@ -4694,7 +4704,7 @@ fn parse___<'input>(input: &'input str, state: &mut ParseState, pos: usize)
         Matched(repeat_pos, ())
     }
 }
-fn parse_comment<'input>(input: &'input str, state: &mut ParseState,
+fn parse_comment<'input>(input: &'input str, state: &mut ParseState<'input>,
                          pos: usize) -> RuleResult<()> {
     {
         let choice_res = parse_singleLineComment(input, state, pos);
@@ -4704,8 +4714,9 @@ fn parse_comment<'input>(input: &'input str, state: &mut ParseState,
         }
     }
 }
-fn parse_singleLineComment<'input>(input: &'input str, state: &mut ParseState,
-                                   pos: usize) -> RuleResult<()> {
+fn parse_singleLineComment<'input>(input: &'input str,
+                                   state: &mut ParseState<'input>, pos: usize)
+ -> RuleResult<()> {
     {
         let seq_res = slice_eq(input, state, pos, "//");
         match seq_res {
@@ -4744,8 +4755,9 @@ fn parse_singleLineComment<'input>(input: &'input str, state: &mut ParseState,
         }
     }
 }
-fn parse_multiLineComment<'input>(input: &'input str, state: &mut ParseState,
-                                  pos: usize) -> RuleResult<()> {
+fn parse_multiLineComment<'input>(input: &'input str,
+                                  state: &mut ParseState<'input>, pos: usize)
+ -> RuleResult<()> {
     {
         let seq_res = slice_eq(input, state, pos, "/*");
         match seq_res {
@@ -4797,8 +4809,8 @@ fn parse_multiLineComment<'input>(input: &'input str, state: &mut ParseState,
         }
     }
 }
-fn parse_eol<'input>(input: &'input str, state: &mut ParseState, pos: usize)
- -> RuleResult<()> {
+fn parse_eol<'input>(input: &'input str, state: &mut ParseState<'input>,
+                     pos: usize) -> RuleResult<()> {
     {
         let choice_res = slice_eq(input, state, pos, "\n");
         match choice_res {
@@ -4828,7 +4840,7 @@ fn parse_eol<'input>(input: &'input str, state: &mut ParseState, pos: usize)
         }
     }
 }
-fn parse_eolChar<'input>(input: &'input str, state: &mut ParseState,
+fn parse_eolChar<'input>(input: &'input str, state: &mut ParseState<'input>,
                          pos: usize) -> RuleResult<()> {
     if input.len() > pos {
         let (ch, next) = char_range_at(input, pos);
@@ -4838,8 +4850,9 @@ fn parse_eolChar<'input>(input: &'input str, state: &mut ParseState,
         }
     } else { state.mark_failure(pos, "[\n\r\u{2028}\u{2029}]") }
 }
-fn parse_whitespace<'input>(input: &'input str, state: &mut ParseState,
-                            pos: usize) -> RuleResult<()> {
+fn parse_whitespace<'input>(input: &'input str,
+                            state: &mut ParseState<'input>, pos: usize)
+ -> RuleResult<()> {
     if input.len() > pos {
         let (ch, next) = char_range_at(input, pos);
         match ch {

--- a/src/grammar.rs
+++ b/src/grammar.rs
@@ -94,15 +94,17 @@ fn pos_to_line(input: &str, pos: usize) -> (usize, usize) {
     }
     return (lineno, remaining + 1);
 }
-struct ParseState {
+struct ParseState<'input> {
     max_err_pos: usize,
     expected: ::std::collections::HashSet<&'static str>,
+    _phantom: ::std::marker::PhantomData<&'input ()>,
     primary_cache: ::std::collections::HashMap<usize, RuleResult<Expr>>,
 }
-impl ParseState {
-    fn new() -> ParseState {
+impl <'input> ParseState<'input> {
+    fn new() -> ParseState<'input> {
         ParseState{max_err_pos: 0,
                    expected: ::std::collections::HashSet::new(),
+                   _phantom: ::std::marker::PhantomData,
                    primary_cache: ::std::collections::HashMap::new(),}
     }
     fn mark_failure(&mut self, pos: usize, expected: &'static str)

--- a/tests/test_memoization.rs
+++ b/tests/test_memoization.rs
@@ -1,0 +1,20 @@
+#![feature(plugin)]
+#![plugin(peg_syntax_ext)]
+
+peg! memo(r#"
+
+#[cache]
+rule -> &'input str
+    = [a-z]+ { match_str }
+
+#[pub]
+parse
+    = rule '+' rule { () }
+    / rule ' ' rule { () }
+
+"#);
+
+#[test]
+fn main() {
+	assert_eq!(memo::parse("abc zzz"), Ok(()));
+}


### PR DESCRIPTION
This didn't work before, since the `'input` lifetime wasn't declared