### PR TITLE
Update NameAndSpan after rustc refactor

### DIFF
--- a/src/fake_extctxt.rs
+++ b/src/fake_extctxt.rs
@@ -16,8 +16,7 @@ pub fn with_fake_extctxt<T, F: Fn(&ExtCtxt) -> T>(f: F) -> T {
   cx.bt_push(syntax::codemap::ExpnInfo{
     call_site: DUMMY_SP,
     callee: syntax::codemap::NameAndSpan {
-      name: "".to_string(),
-      format: syntax::codemap::MacroBang,
+      format: syntax::codemap::MacroBang(syntax::parse::token::intern("")),
       span: None,
       allow_internal_unstable: false,
     }


### PR DESCRIPTION
hi! `rust-peg` no longer builds on rust nightly after [this commit](https://github.com/rust-lang/rust/commit/25cbb4385ee58804cb2483af56d1333fbee6e27d) rejiggered some rustc internals. I think this fixes it in a sane way, but I by no means know what I'm doing. `cargo test` still looks good, so I presume it's okay.

Is the goal to keep master building on nightly, or let them diverge and fix on new releases?