### PR TITLE
Support latest nightly

### DIFF
--- a/src/fake_extctxt.rs
+++ b/src/fake_extctxt.rs
@@ -5,12 +5,10 @@ use syntax::ext::base::{ ExtCtxt, DummyMacroLoader };
 /// Create a fake ExtCtxt to perform macro quasiquotes outside of rustc plugins
 pub fn with_fake_extctxt<T, F: Fn(&ExtCtxt) -> T>(f: F) -> T {
   let ps = syntax::parse::ParseSess::new();
-  let mut fg_cfg = Vec::new();
   let mut loader = DummyMacroLoader;
 
   let mut cx = syntax::ext::base::ExtCtxt::new(&ps, Vec::new(),
     syntax::ext::expand::ExpansionConfig::default("rust-peg".to_string()),
-    &mut fg_cfg,
     &mut loader,
   );
 

--- a/src/peg_syntax_ext.rs
+++ b/src/peg_syntax_ext.rs
@@ -55,7 +55,7 @@ fn expand_peg_file<'s>(cx: &'s mut ExtCtxt, sp: codemap::Span, ident: ast::Ident
         return DummyResult::any(sp);
     }
 
-    cx.codemap().new_filemap(format!("{}", path.display()), "".to_string());
+    cx.codemap().new_filemap(format!("{}", path.display()), None, "".to_string());
 
     expand_peg(cx, sp, ident, &source)
 }


### PR DESCRIPTION
Today's nightly build (June 20, 2016) shipped some libsyntax changes that broke this crate. Here's my stab at fixing the two compilation errors. 