### PR TITLE
Add about Vim syntax highlight for .rustpeg file

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ number -> int
   * **start_pos** - the byte index into the string at which the match starts, inclusive
   * **pos** - the byte index into the string at which the match ends, exclusive
 
+If you're using Vim, [rhysd](https://github.com/rhysd) has created a [syntax highlighting plugin](https://github.com/rhysd/vim-rustpeg).
+
 ## Tracing
 
 If you pass the `peg/trace` feature to Cargo when building your project, a trace of the parsing will be output to stdout when running the binary. For example,


### PR DESCRIPTION
Hi, thank you for nice parser library.

I wanted syntax highlight for .rustpeg files so I created it for Vim.  I added a note for that.
