### PR TITLE
Add left recursion detection - Closes #164

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ readme = "README.md"
 quote = "0.3"
 codemap = "0.1"
 codemap-diagnostic = "0.1"
-rustfmt-nightly = {version = "0.3.7", optional = true}
+rustfmt-nightly = {version = "0.6", optional = true}
 
 [[bin]]
 name = "rust-peg"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,9 @@ use codemap_diagnostic::{ Diagnostic, Level, SpanLabel, SpanStyle, Emitter, Colo
 mod translate;
 mod grammar;
 
+#[cfg(test)]
+mod test;
+
 struct PegCompiler {
     codemap: CodeMap,
     diagnostics: Vec<codemap_diagnostic::Diagnostic>

--- a/src/test.rs
+++ b/src/test.rs
@@ -1,0 +1,39 @@
+use ::{ grammar, translate, PegCompiler };
+
+fn compile(src: &str) -> PegCompiler {
+	let mut compiler = PegCompiler::new();
+	let file = compiler.codemap.add_file("input.test".into(), src.into());
+
+	let ast_items = grammar::items(&file.source(), file.span).unwrap();
+	translate::Grammar::from_ast(&mut compiler, ast_items).unwrap();
+
+    compiler
+}
+
+#[test]
+fn test_finds_left_recursion() {
+	let compiler = compile(r#"
+foo
+	= "foo" foo
+	/ bar
+
+bar
+	= "bar" bar
+	/ foo
+"#);
+
+	assert_eq!(compiler.diagnostics[0].message, "Found illegal left recursion for rule foo: foo -> bar -> foo");
+	assert_eq!(compiler.diagnostics[1].message, "Found illegal left recursion for rule bar: bar -> foo -> bar");
+	assert_eq!(compiler.diagnostics.len(), 2);
+}
+
+#[test]
+fn test_finds_direct_left_recursion() {
+	let compiler = compile(r#"
+foo
+	= foo
+"#);
+
+	assert_eq!(compiler.diagnostics[0].message, "Found illegal left recursion for rule foo: foo -> foo");
+	assert_eq!(compiler.diagnostics.len(), 1);
+}

--- a/src/translate.rs
+++ b/src/translate.rs
@@ -98,7 +98,7 @@ impl Grammar {
 	fn check_for_left_recursion(rules: &Vec<Rule>) -> Vec<LeftRecursion> {
 		let mut recursions = Vec::new();
 
-		let rule_map: HashMap<String, &Rule> = rules.iter().map(|rule| (rule.name.clone(), rule)).collect();
+		let rule_map: HashMap<&str, &Rule> = rules.iter().map(|rule| (&rule.name[..], rule)).collect();
 		for rule in rules.iter() {
 			LeftRecursionChecker::new(&rule.name, &rule_map).check(rule, &mut recursions)
 		}
@@ -108,14 +108,14 @@ impl Grammar {
 }
 
 struct LeftRecursionChecker<'a> {
-	rule_map: &'a HashMap<String, &'a Rule>,
+	rule_map: &'a HashMap<&'a str, &'a Rule>,
 	rule_name: &'a str,
 	rule_stack: VecDeque<&'a str>,
 	visited_rules: HashSet<&'a str>,
 }
 
 impl <'a> LeftRecursionChecker<'a> {
-	fn new(rule_name: &'a str, rule_map: &'a HashMap<String, &'a Rule>) -> LeftRecursionChecker<'a> {
+	fn new(rule_name: &'a str, rule_map: &'a HashMap<&'a str, &'a Rule>) -> LeftRecursionChecker<'a> {
 		let mut rule_stack = VecDeque::new();
 		rule_stack.push_back(rule_name);
 		LeftRecursionChecker {

--- a/src/translate.rs
+++ b/src/translate.rs
@@ -229,8 +229,8 @@ impl Expr {
 			},
             SequenceExpr(ref exprs)
 			| TemplateInvoke(_, ref exprs) => {
-                if exprs.len() > 0 {
-                    exprs[0].left_rules_recurse(rules, &exprs[0].span);
+                if let Some(expr) = exprs.first() {
+                    exprs[0].left_rules_recurse(rules, &expr.span);
                 }
             }
             ChoiceExpr(ref choices) => {
@@ -246,8 +246,8 @@ impl Expr {
             | NegAssertExpr(ref expr) => expr.left_rules_recurse(rules, &expr.span),
 			InfixExpr{ ref atom, .. } => atom.left_rules_recurse(rules, &atom.span),
             ActionExpr(ref tagged_actions, _, _) => {
-                if tagged_actions.len() > 0 {
-                    tagged_actions[0].expr.left_rules_recurse(rules, &tagged_actions[0].expr.span);
+                if let Some(action) = tagged_actions.first() {
+                    action.expr.left_rules_recurse(rules, &action.expr.span);
                 }
             }
             _ => {}

--- a/src/translate.rs
+++ b/src/translate.rs
@@ -157,19 +157,7 @@ struct LeftRecursion {
 
 impl LeftRecursion {
 	fn format_path(&self) -> String {
-		let mut result = String::new();
-		let mut first = true;
-
-		for rule in self.path.iter() {
-			if !first {
-				result.push_str(" -> ");
-			} else {
-				first = false;
-			}
-			result.push_str(rule);
-		}
-
-		result
+		self.path.join(" -> ")
 	}
 }
 

--- a/src/translate.rs
+++ b/src/translate.rs
@@ -1,5 +1,5 @@
 use std::borrow::ToOwned;
-use std::collections::{ HashMap, VecDeque, HashSet };
+use std::collections::{ HashMap, HashSet };
 use quote::Tokens;
 pub use self::Expr::*;
 use codemap::{ Spanned, Span };
@@ -110,14 +110,14 @@ impl Grammar {
 struct LeftRecursionChecker<'a> {
 	rule_map: &'a HashMap<&'a str, &'a Rule>,
 	rule_name: &'a str,
-	rule_stack: VecDeque<&'a str>,
+	rule_stack: Vec<&'a str>,
 	visited_rules: HashSet<&'a str>,
 }
 
 impl <'a> LeftRecursionChecker<'a> {
 	fn new(rule_name: &'a str, rule_map: &'a HashMap<&'a str, &'a Rule>) -> LeftRecursionChecker<'a> {
-		let mut rule_stack = VecDeque::new();
-		rule_stack.push_back(rule_name);
+		let mut rule_stack = Vec::new();
+		rule_stack.push(rule_name);
 		LeftRecursionChecker {
 			rule_map,
 			rule_name,
@@ -131,18 +131,18 @@ impl <'a> LeftRecursionChecker<'a> {
 
 		for left_rule in left_rules {
 			if self.rule_name == left_rule.node {
-				self.rule_stack.push_back(left_rule.node);
+				self.rule_stack.push(left_rule.node);
 				recursions.push(LeftRecursion{
 					rule_name: self.rule_name.into(),
 					span: left_rule.span,
 					path: self.rule_stack.iter().map(|x| (*x).into()).collect(),
 				});
-				self.rule_stack.pop_back();
+				self.rule_stack.pop();
 			} else if let Some(rule) = self.rule_map.get(left_rule.node) {
 				if self.visited_rules.insert(&rule.name) {
-					self.rule_stack.push_back(&rule.name);
+					self.rule_stack.push(&rule.name);
 					self.check(rule, recursions);
-					self.rule_stack.pop_back();
+					self.rule_stack.pop();
 				}
             }
 		}


### PR DESCRIPTION
This should close isssue #164, left recursion is now detected - both direct and indirect. An error message will be printed in the format `Found illegal left recursion for rule foo: foo -> bar -> foo`. The spans will also be underlined similarly to other errors, and the compilation will fail.