### PR TITLE
Replace try with carrier operator

### DIFF
--- a/src/translate.rs
+++ b/src/translate.rs
@@ -194,17 +194,17 @@ static HELPERS: &'static str = stringify! {
 	pub type ParseResult<T> = Result<T, ParseError>;
 	impl ::std::fmt::Display for ParseError {
 		fn fmt(&self, fmt: &mut ::std::fmt::Formatter) -> ::std::result::Result<(), ::std::fmt::Error> {
-			try!(write!(fmt, "error at {}:{}: expected ", self.line, self.column));
+			write!(fmt, "error at {}:{}: expected ", self.line, self.column)?;
 			if self.expected.len() == 0 {
-				try!(write!(fmt, "EOF"));
+				write!(fmt, "EOF")?;
 			} else if self.expected.len() == 1 {
-				try!(write!(fmt, "`{}`", escape_default(self.expected.iter().next().unwrap())));
+				write!(fmt, "`{}`", escape_default(self.expected.iter().next().unwrap()))?;
 			} else {
 				let mut iter = self.expected.iter();
 
-				try!(write!(fmt, "one of `{}`", escape_default(iter.next().unwrap())));
+				write!(fmt, "one of `{}`", escape_default(iter.next().unwrap()))?;
 				for elem in iter {
-					try!(write!(fmt, ", `{}`", escape_default(elem)));
+					write!(fmt, ", `{}`", escape_default(elem))?;
 				}
 			}
 


### PR DESCRIPTION
When trying to compile a simple grammar with the using rust-peg with the Rust 2018 edition, I hit an error message:

```rust
error: expected expression, found reserved keyword `try`
```

In the code generated by rust-peg, I saw expressions like the following:

```rust
try ! ( write ! ( fmt , "error at {}:{}: expected " , self . line , self . column ) )
```

This is using the `try!` macro, which itself is fine and still works. The problem is the space between `try` and `!`, because it then `try` gets interpreted separately. This leads to the error, because `try` is a reserved keyword in the 2018 edition](https://github.com/rust-lang/rfcs/blob/master/text/2388-try-expr.md).

One could trim the spaces between `try` and `!`, but I don't know if that would mean a bigger change and if it would break anything else.
Fortunately, we have another option: use the carrier operator (`?`) instead.
This is equivalent to `try` and arguably more idiomatic. It's also a non-invasive change that allows building the code on the 2018 edition.