### PR TITLE
Derive more Implementations for RuleResult

### DIFF
--- a/peg-runtime/lib.rs
+++ b/peg-runtime/lib.rs
@@ -8,7 +8,7 @@ pub mod error;
 /// 
 /// You'll only need this if implementing the `Parse*` traits for a custom input
 /// type. The public API of a parser adapts errors to `std::result::Result`.
-#[derive(Clone)]
+#[derive(Clone, PartialEq, PartialOrd, Eq, Ord, Debug, Hash)]
 pub enum RuleResult<T> {
     Matched(usize, T),
     Failed,


### PR DESCRIPTION
This makes e.g. testing custom helpers returning `RuleResult`s easier,
as we can just
`assert_eq!(helper("foo"), RuleResult::Matched(3, expected))`.