### PR TITLE
Allow multiline doc-comments

### DIFF
--- a/peg-macros/grammar.rs
+++ b/peg-macros/grammar.rs
@@ -826,74 +826,95 @@ pub mod peg {
         match {
             let str_start = __pos;
             match {
-                let __seq_res = match ::peg::ParseLiteral::parse_string_literal(__input, __pos, "#")
-                {
-                    ::peg::RuleResult::Matched(__pos, __val) => {
-                        ::peg::RuleResult::Matched(__pos, __val)
-                    }
-                    ::peg::RuleResult::Failed => __err_state.mark_failure(__pos, "\"#\""),
-                };
-                match __seq_res {
-                    ::peg::RuleResult::Matched(__pos, _) => {
+                let mut __repeat_pos = __pos;
+                loop {
+                    let __pos = __repeat_pos;
+                    let __step_res = {
                         let __seq_res =
-                            match ::peg::ParseLiteral::parse_string_literal(__input, __pos, "[") {
+                            match ::peg::ParseLiteral::parse_string_literal(__input, __pos, "#") {
                                 ::peg::RuleResult::Matched(__pos, __val) => {
                                     ::peg::RuleResult::Matched(__pos, __val)
                                 }
                                 ::peg::RuleResult::Failed => {
-                                    __err_state.mark_failure(__pos, "\"[\"")
+                                    __err_state.mark_failure(__pos, "\"#\"")
                                 }
                             };
                         match __seq_res {
                             ::peg::RuleResult::Matched(__pos, _) => {
                                 let __seq_res = match ::peg::ParseLiteral::parse_string_literal(
-                                    __input, __pos, "doc",
+                                    __input, __pos, "[",
                                 ) {
                                     ::peg::RuleResult::Matched(__pos, __val) => {
                                         ::peg::RuleResult::Matched(__pos, __val)
                                     }
                                     ::peg::RuleResult::Failed => {
-                                        __err_state.mark_failure(__pos, "\"doc\"")
+                                        __err_state.mark_failure(__pos, "\"[\"")
                                     }
                                 };
                                 match __seq_res {
                                     ::peg::RuleResult::Matched(__pos, _) => {
                                         let __seq_res =
                                             match ::peg::ParseLiteral::parse_string_literal(
-                                                __input, __pos, "=",
+                                                __input, __pos, "doc",
                                             ) {
                                                 ::peg::RuleResult::Matched(__pos, __val) => {
                                                     ::peg::RuleResult::Matched(__pos, __val)
                                                 }
                                                 ::peg::RuleResult::Failed => {
-                                                    __err_state.mark_failure(__pos, "\"=\"")
+                                                    __err_state.mark_failure(__pos, "\"doc\"")
                                                 }
                                             };
                                         match __seq_res {
                                             ::peg::RuleResult::Matched(__pos, _) => {
-                                                let __seq_res = match __parse_LITERAL(
-                                                    __input,
-                                                    __state,
-                                                    __err_state,
-                                                    __pos,
-                                                ) {
-                                                    ::peg::RuleResult::Matched(pos, _) => {
-                                                        ::peg::RuleResult::Matched(pos, ())
-                                                    }
-                                                    ::peg::RuleResult::Failed => {
-                                                        ::peg::RuleResult::Failed
-                                                    }
-                                                };
+                                                let __seq_res =
+                                                    match ::peg::ParseLiteral::parse_string_literal(
+                                                        __input, __pos, "=",
+                                                    ) {
+                                                        ::peg::RuleResult::Matched(
+                                                            __pos,
+                                                            __val,
+                                                        ) => {
+                                                            ::peg::RuleResult::Matched(__pos, __val)
+                                                        }
+                                                        ::peg::RuleResult::Failed => {
+                                                            __err_state.mark_failure(__pos, "\"=\"")
+                                                        }
+                                                    };
                                                 match __seq_res {
                                                     ::peg::RuleResult::Matched(__pos, _) => {
-                                                        let __seq_res = match :: peg :: ParseLiteral :: parse_string_literal ( __input , __pos , "]" ) { :: peg :: RuleResult :: Matched ( __pos , __val ) => :: peg :: RuleResult :: Matched ( __pos , __val ) , :: peg :: RuleResult :: Failed => __err_state . mark_failure ( __pos , "\"]\"" ) } ;
+                                                        let __seq_res = match __parse_LITERAL(
+                                                            __input,
+                                                            __state,
+                                                            __err_state,
+                                                            __pos,
+                                                        ) {
+                                                            ::peg::RuleResult::Matched(pos, _) => {
+                                                                ::peg::RuleResult::Matched(pos, ())
+                                                            }
+                                                            ::peg::RuleResult::Failed => {
+                                                                ::peg::RuleResult::Failed
+                                                            }
+                                                        };
                                                         match __seq_res {
                                                             ::peg::RuleResult::Matched(
                                                                 __pos,
                                                                 _,
                                                             ) => {
-                                                                ::peg::RuleResult::Matched(__pos, {
-                                                                })
+                                                                let __seq_res = match :: peg :: ParseLiteral :: parse_string_literal ( __input , __pos , "]" ) { :: peg :: RuleResult :: Matched ( __pos , __val ) => :: peg :: RuleResult :: Matched ( __pos , __val ) , :: peg :: RuleResult :: Failed => __err_state . mark_failure ( __pos , "\"]\"" ) } ;
+                                                                match __seq_res {
+                                                                    ::peg::RuleResult::Matched(
+                                                                        __pos,
+                                                                        _,
+                                                                    ) => {
+                                                                        ::peg::RuleResult::Matched(
+                                                                            __pos,
+                                                                            {},
+                                                                        )
+                                                                    }
+                                                                    ::peg::RuleResult::Failed => {
+                                                                        ::peg::RuleResult::Failed
+                                                                    }
+                                                                }
                                                             }
                                                             ::peg::RuleResult::Failed => {
                                                                 ::peg::RuleResult::Failed
@@ -913,9 +934,17 @@ pub mod peg {
                             }
                             ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
                         }
+                    };
+                    match __step_res {
+                        ::peg::RuleResult::Matched(__newpos, __value) => {
+                            __repeat_pos = __newpos;
+                        }
+                        ::peg::RuleResult::Failed => {
+                            break;
+                        }
                     }
-                    ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
                 }
+                ::peg::RuleResult::Matched(__repeat_pos, ())
             } {
                 ::peg::RuleResult::Matched(__newpos, _) => ::peg::RuleResult::Matched(
                     __newpos,

--- a/peg-macros/grammar.rustpeg
+++ b/peg-macros/grammar.rustpeg
@@ -32,7 +32,7 @@ rule item() -> Item
     = u:rust_use()     { Item::Use(u) }
     / r:peg_rule()     { Item::Rule(r) }
 
-rule rust_doc_comment() -> Option<TokenStream> = $("#" "[" "doc" "=" LITERAL() "]")?
+rule rust_doc_comment() -> Option<TokenStream> = $(("#" "[" "doc" "=" LITERAL() "]")*)?
 
 rule rust_visibility() -> Option<TokenStream> = $("pub" PAREN_GROUP()? / "crate")?
 

--- a/tests/run-pass/arithmetic_ast.rs
+++ b/tests/run-pass/arithmetic_ast.rs
@@ -12,6 +12,7 @@ parser!{
 /// Doc comment
 grammar arithmetic() for str {
     /// Top level parser rule
+    /// This doc comment has multiple lines to test support for that as well
     pub rule expression() -> Expression
         = sum()
 


### PR DESCRIPTION
Those seem to generate multiple `#[doc = "..."]` attributes, which are
only later concatenated into a single string.