### PR TITLE
include LICENSE file with peg-macros and peg-runtime crates

### DIFF
--- a/peg-macros/Cargo.toml
+++ b/peg-macros/Cargo.toml
@@ -6,6 +6,7 @@ license = "MIT"
 repository = "https://github.com/kevinmehall/rust-peg"
 description = "Procedural macros for rust-peg. To use rust-peg, see the `peg` crate."
 edition = "2018"
+include = [ "../LICENSE" ]
 
 [dependencies]
 quote = "1.0"

--- a/peg-runtime/Cargo.toml
+++ b/peg-runtime/Cargo.toml
@@ -6,6 +6,7 @@ license = "MIT"
 repository = "https://github.com/kevinmehall/rust-peg"
 description = "Runtime support for rust-peg grammars. To use rust-peg, see the `peg` crate."
 edition = "2018"
+include = [ "../LICENSE" ]
 
 [lib]
 path = "lib.rs"


### PR DESCRIPTION
Right now, the `peg-macros` and `peg-runtime` crates available from crates.io don't include the LICENSE text. However, the MIT license requires that the license text is distributed with the sources that are covered by the license, see "Conditions" here:
https://choosealicense.com/licenses/mit/

Including the "LICENSE" file with `include = ["../LICENSE"]` in the `[package]` sections of both `peg-macros` and `peg-runtime` should do the trick. See: https://doc.rust-lang.org/cargo/reference/manifest.html#the-exclude-and-include-fields

I was, however, unable to test this, since I couldn't figure out how to make cargo aware of the workspace layout in this repo :(