### PR TITLE
 Add support for capturing variables from pattern expressions

### DIFF
--- a/peg-macros/grammar.rs
+++ b/peg-macros/grammar.rs
@@ -76,18 +76,10 @@ pub mod peg {
                     let __seq_res = __parse_rust_visibility(__input, __state, __err_state, __pos);
                     match __seq_res {
                         ::peg::RuleResult::Matched(__pos, visibility) => {
-                            let __seq_res = match ::peg::ParseLiteral::parse_string_literal(
+                            match ::peg::ParseLiteral::parse_string_literal(
                                 __input, __pos, "grammar",
                             ) {
                                 ::peg::RuleResult::Matched(__pos, __val) => {
-                                    ::peg::RuleResult::Matched(__pos, __val)
-                                }
-                                ::peg::RuleResult::Failed => {
-                                    __err_state.mark_failure(__pos, "\"grammar\"")
-                                }
-                            };
-                            match __seq_res {
-                                ::peg::RuleResult::Matched(__pos, _) => {
                                     let __seq_res =
                                         __parse_IDENT(__input, __state, __err_state, __pos);
                                     match __seq_res {
@@ -100,27 +92,22 @@ pub mod peg {
                                             );
                                             match __seq_res {
                                                 ::peg::RuleResult::Matched(__pos, args) => {
-                                                    let __seq_res = match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "for") { :: peg :: RuleResult :: Matched (__pos , __val) => :: peg :: RuleResult :: Matched (__pos , __val) , :: peg :: RuleResult :: Failed => __err_state . mark_failure (__pos , "\"for\"") } ;
-                                                    match __seq_res {
-                                                        ::peg::RuleResult::Matched(__pos, _) => {
+                                                    match ::peg::ParseLiteral::parse_string_literal(
+                                                        __input, __pos, "for",
+                                                    ) {
+                                                        ::peg::RuleResult::Matched(
+                                                            __pos,
+                                                            __val,
+                                                        ) => {
                                                             let __seq_res = {
                                                                 let str_start = __pos;
                                                                 match match __parse_rust_type (__input , __state , __err_state , __pos) { :: peg :: RuleResult :: Matched (pos , _) => :: peg :: RuleResult :: Matched (pos , ()) , :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } { :: peg :: RuleResult :: Matched (__newpos , _) => { :: peg :: RuleResult :: Matched (__newpos , :: peg :: ParseSlice :: parse_slice (__input , str_start , __newpos)) } , :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , }
                                                             };
-                                                            match __seq_res {
-                                                                ::peg::RuleResult::Matched(
-                                                                    __pos,
-                                                                    input_type,
-                                                                ) => {
-                                                                    let __seq_res = match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "{") { :: peg :: RuleResult :: Matched (__pos , __val) => :: peg :: RuleResult :: Matched (__pos , __val) , :: peg :: RuleResult :: Failed => __err_state . mark_failure (__pos , "\"{\"") } ;
-                                                                    match __seq_res { :: peg :: RuleResult :: Matched (__pos , _) => { { let __seq_res = { let mut __repeat_pos = __pos ; let mut __repeat_value = vec ! () ; loop { let __pos = __repeat_pos ; let __step_res = __parse_item (__input , __state , __err_state , __pos) ; match __step_res { :: peg :: RuleResult :: Matched (__newpos , __value) => { __repeat_pos = __newpos ; __repeat_value . push (__value) ; } , :: peg :: RuleResult :: Failed => { break ; } } } :: peg :: RuleResult :: Matched (__repeat_pos , __repeat_value) } ; match __seq_res { :: peg :: RuleResult :: Matched (__pos , items) => { { let __seq_res = match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "}") { :: peg :: RuleResult :: Matched (__pos , __val) => :: peg :: RuleResult :: Matched (__pos , __val) , :: peg :: RuleResult :: Failed => __err_state . mark_failure (__pos , "\"}\"") } ; match __seq_res { :: peg :: RuleResult :: Matched (__pos , _) => { :: peg :: RuleResult :: Matched (__pos , (|| { Grammar { doc , visibility , name , args , input_type , items } }) ()) } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , }
-                                                                }
-                                                                ::peg::RuleResult::Failed => {
-                                                                    ::peg::RuleResult::Failed
-                                                                }
-                                                            }
+                                                            match __seq_res { :: peg :: RuleResult :: Matched (__pos , input_type) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "{") { :: peg :: RuleResult :: Matched (__pos , __val) => { { let __seq_res = { let mut __repeat_pos = __pos ; let mut __repeat_value = vec ! () ; loop { let __pos = __repeat_pos ; let __step_res = __parse_item (__input , __state , __err_state , __pos) ; match __step_res { :: peg :: RuleResult :: Matched (__newpos , __value) => { __repeat_pos = __newpos ; __repeat_value . push (__value) ; } , :: peg :: RuleResult :: Failed => { break ; } } } :: peg :: RuleResult :: Matched (__repeat_pos , __repeat_value) } ; match __seq_res { :: peg :: RuleResult :: Matched (__pos , items) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "}") { :: peg :: RuleResult :: Matched (__pos , __val) => { :: peg :: RuleResult :: Matched (__pos , (|| { Grammar { doc , visibility , name , args , input_type , items } }) ()) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"}\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"{\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , }
                                                         }
                                                         ::peg::RuleResult::Failed => {
+                                                            __err_state
+                                                                .mark_failure(__pos, "\"for\"");
                                                             ::peg::RuleResult::Failed
                                                         }
                                                     }
@@ -133,7 +120,10 @@ pub mod peg {
                                         ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
                                     }
                                 }
-                                ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
+                                ::peg::RuleResult::Failed => {
+                                    __err_state.mark_failure(__pos, "\"grammar\"");
+                                    ::peg::RuleResult::Failed
+                                }
                             }
                         }
                         ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
@@ -150,55 +140,388 @@ pub mod peg {
         __pos: usize,
     ) -> ::peg::RuleResult<Vec<(Ident, TokenStream)>> {
         #![allow(non_snake_case, unused)]
-        {
-            let __seq_res = match ::peg::ParseLiteral::parse_string_literal(__input, __pos, "(") {
-                ::peg::RuleResult::Matched(__pos, __val) => {
-                    ::peg::RuleResult::Matched(__pos, __val)
-                }
-                ::peg::RuleResult::Failed => __err_state.mark_failure(__pos, "\"(\""),
-            };
-            match __seq_res {
-                ::peg::RuleResult::Matched(__pos, _) => {
-                    let __seq_res = {
-                        let mut __repeat_pos = __pos;
-                        let mut __repeat_value = vec![];
-                        loop {
-                            let __pos = __repeat_pos;
-                            let __pos = if __repeat_value.is_empty() {
-                                __pos
-                            } else {
-                                let __sep_res = match ::peg::ParseLiteral::parse_string_literal(
-                                    __input, __pos, ",",
-                                ) {
-                                    ::peg::RuleResult::Matched(__pos, __val) => {
-                                        ::peg::RuleResult::Matched(__pos, __val)
-                                    }
-                                    ::peg::RuleResult::Failed => {
-                                        __err_state.mark_failure(__pos, "\",\"")
-                                    }
-                                };
-                                match __sep_res {
-                                    ::peg::RuleResult::Matched(__newpos, _) => __newpos,
-                                    ::peg::RuleResult::Failed => break,
+        match ::peg::ParseLiteral::parse_string_literal(__input, __pos, "(") {
+            ::peg::RuleResult::Matched(__pos, __val) => {
+                let __seq_res = {
+                    let mut __repeat_pos = __pos;
+                    let mut __repeat_value = vec![];
+                    loop {
+                        let __pos = __repeat_pos;
+                        let __pos = if __repeat_value.is_empty() {
+                            __pos
+                        } else {
+                            let __sep_res = match ::peg::ParseLiteral::parse_string_literal(
+                                __input, __pos, ",",
+                            ) {
+                                ::peg::RuleResult::Matched(__pos, __val) => {
+                                    ::peg::RuleResult::Matched(__pos, __val)
+                                }
+                                ::peg::RuleResult::Failed => {
+                                    __err_state.mark_failure(__pos, "\",\"");
+                                    ::peg::RuleResult::Failed
                                 }
                             };
-                            let __step_res = {
-                                let __seq_res = __parse_IDENT(__input, __state, __err_state, __pos);
-                                match __seq_res {
-                                    ::peg::RuleResult::Matched(__pos, i) => {
-                                        let __seq_res =
-                                            match ::peg::ParseLiteral::parse_string_literal(
-                                                __input, __pos, ":",
-                                            ) {
-                                                ::peg::RuleResult::Matched(__pos, __val) => {
-                                                    ::peg::RuleResult::Matched(__pos, __val)
-                                                }
-                                                ::peg::RuleResult::Failed => {
-                                                    __err_state.mark_failure(__pos, "\":\"")
+                            match __sep_res {
+                                ::peg::RuleResult::Matched(__newpos, _) => __newpos,
+                                ::peg::RuleResult::Failed => break,
+                            }
+                        };
+                        let __step_res = {
+                            let __seq_res = __parse_IDENT(__input, __state, __err_state, __pos);
+                            match __seq_res {
+                                ::peg::RuleResult::Matched(__pos, i) => {
+                                    match ::peg::ParseLiteral::parse_string_literal(
+                                        __input, __pos, ":",
+                                    ) {
+                                        ::peg::RuleResult::Matched(__pos, __val) => {
+                                            let __seq_res = {
+                                                let str_start = __pos;
+                                                match match __parse_rust_type(
+                                                    __input,
+                                                    __state,
+                                                    __err_state,
+                                                    __pos,
+                                                ) {
+                                                    ::peg::RuleResult::Matched(pos, _) => {
+                                                        ::peg::RuleResult::Matched(pos, ())
+                                                    }
+                                                    ::peg::RuleResult::Failed => {
+                                                        ::peg::RuleResult::Failed
+                                                    }
+                                                } {
+                                                    ::peg::RuleResult::Matched(__newpos, _) => {
+                                                        ::peg::RuleResult::Matched(
+                                                            __newpos,
+                                                            ::peg::ParseSlice::parse_slice(
+                                                                __input, str_start, __newpos,
+                                                            ),
+                                                        )
+                                                    }
+                                                    ::peg::RuleResult::Failed => {
+                                                        ::peg::RuleResult::Failed
+                                                    }
                                                 }
                                             };
-                                        match __seq_res {
-                                            ::peg::RuleResult::Matched(__pos, _) => {
+                                            match __seq_res {
+                                                ::peg::RuleResult::Matched(__pos, t) => {
+                                                    ::peg::RuleResult::Matched(__pos, (|| (i, t))())
+                                                }
+                                                ::peg::RuleResult::Failed => {
+                                                    ::peg::RuleResult::Failed
+                                                }
+                                            }
+                                        }
+                                        ::peg::RuleResult::Failed => {
+                                            __err_state.mark_failure(__pos, "\":\"");
+                                            ::peg::RuleResult::Failed
+                                        }
+                                    }
+                                }
+                                ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
+                            }
+                        };
+                        match __step_res {
+                            ::peg::RuleResult::Matched(__newpos, __value) => {
+                                __repeat_pos = __newpos;
+                                __repeat_value.push(__value);
+                            }
+                            ::peg::RuleResult::Failed => {
+                                break;
+                            }
+                        }
+                    }
+                    ::peg::RuleResult::Matched(__repeat_pos, __repeat_value)
+                };
+                match __seq_res {
+                    ::peg::RuleResult::Matched(__pos, args) => {
+                        let __seq_res = match match ::peg::ParseLiteral::parse_string_literal(
+                            __input, __pos, ",",
+                        ) {
+                            ::peg::RuleResult::Matched(__pos, __val) => {
+                                ::peg::RuleResult::Matched(__pos, __val)
+                            }
+                            ::peg::RuleResult::Failed => {
+                                __err_state.mark_failure(__pos, "\",\"");
+                                ::peg::RuleResult::Failed
+                            }
+                        } {
+                            ::peg::RuleResult::Matched(__newpos, _) => {
+                                ::peg::RuleResult::Matched(__newpos, ())
+                            }
+                            ::peg::RuleResult::Failed => ::peg::RuleResult::Matched(__pos, ()),
+                        };
+                        match __seq_res {
+                            ::peg::RuleResult::Matched(__pos, _) => {
+                                match ::peg::ParseLiteral::parse_string_literal(__input, __pos, ")")
+                                {
+                                    ::peg::RuleResult::Matched(__pos, __val) => {
+                                        ::peg::RuleResult::Matched(__pos, (|| args)())
+                                    }
+                                    ::peg::RuleResult::Failed => {
+                                        __err_state.mark_failure(__pos, "\")\"");
+                                        ::peg::RuleResult::Failed
+                                    }
+                                }
+                            }
+                            ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
+                        }
+                    }
+                    ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
+                }
+            }
+            ::peg::RuleResult::Failed => {
+                __err_state.mark_failure(__pos, "\"(\"");
+                ::peg::RuleResult::Failed
+            }
+        }
+    }
+    fn __parse_peg_rule<'input>(
+        __input: &'input Input,
+        __state: &mut ParseState<'input>,
+        __err_state: &mut ::peg::error::ErrorState,
+        __pos: usize,
+    ) -> ::peg::RuleResult<Rule> {
+        #![allow(non_snake_case, unused)]
+        {
+            let __seq_res = __parse_rust_doc_comment(__input, __state, __err_state, __pos);
+            match __seq_res {
+                ::peg::RuleResult::Matched(__pos, doc) => {
+                    let __seq_res = __parse_cacheflag(__input, __state, __err_state, __pos);
+                    match __seq_res {
+                        ::peg::RuleResult::Matched(__pos, cached) => {
+                            let __seq_res =
+                                __parse_rust_visibility(__input, __state, __err_state, __pos);
+                            match __seq_res {
+                                ::peg::RuleResult::Matched(__pos, visibility) => {
+                                    match ::peg::ParseLiteral::parse_string_literal(
+                                        __input, __pos, "rule",
+                                    ) {
+                                        ::peg::RuleResult::Matched(__pos, __val) => {
+                                            let __seq_res =
+                                                __parse_IDENT(__input, __state, __err_state, __pos);
+                                            match __seq_res {
+                                                ::peg::RuleResult::Matched(__pos, name) => {
+                                                    let __seq_res = match __parse_rust_ty_params(
+                                                        __input,
+                                                        __state,
+                                                        __err_state,
+                                                        __pos,
+                                                    ) {
+                                                        ::peg::RuleResult::Matched(
+                                                            __newpos,
+                                                            __value,
+                                                        ) => ::peg::RuleResult::Matched(
+                                                            __newpos,
+                                                            Some(__value),
+                                                        ),
+                                                        ::peg::RuleResult::Failed => {
+                                                            ::peg::RuleResult::Matched(__pos, None)
+                                                        }
+                                                    };
+                                                    match __seq_res { :: peg :: RuleResult :: Matched (__pos , ty_params) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "(") { :: peg :: RuleResult :: Matched (__pos , __val) => { { let __seq_res = { let mut __repeat_pos = __pos ; let mut __repeat_value = vec ! () ; loop { let __pos = __repeat_pos ; let __pos = if __repeat_value . is_empty () { __pos } else { let __sep_res = match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , ",") { :: peg :: RuleResult :: Matched (__pos , __val) => { :: peg :: RuleResult :: Matched (__pos , __val) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\",\"") ; :: peg :: RuleResult :: Failed } } ; match __sep_res { :: peg :: RuleResult :: Matched (__newpos , _) => { __newpos } , :: peg :: RuleResult :: Failed => break , } } ; let __step_res = __parse_rule_param (__input , __state , __err_state , __pos) ; match __step_res { :: peg :: RuleResult :: Matched (__newpos , __value) => { __repeat_pos = __newpos ; __repeat_value . push (__value) ; } , :: peg :: RuleResult :: Failed => { break ; } } } :: peg :: RuleResult :: Matched (__repeat_pos , __repeat_value) } ; match __seq_res { :: peg :: RuleResult :: Matched (__pos , params) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , ")") { :: peg :: RuleResult :: Matched (__pos , __val) => { { let __seq_res = match match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "->") { :: peg :: RuleResult :: Matched (__pos , __val) => { { let __seq_res = { let str_start = __pos ; match match __parse_rust_type (__input , __state , __err_state , __pos) { :: peg :: RuleResult :: Matched (pos , _) => :: peg :: RuleResult :: Matched (pos , ()) , :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } { :: peg :: RuleResult :: Matched (__newpos , _) => { :: peg :: RuleResult :: Matched (__newpos , :: peg :: ParseSlice :: parse_slice (__input , str_start , __newpos)) } , :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } ; match __seq_res { :: peg :: RuleResult :: Matched (__pos , t) => { :: peg :: RuleResult :: Matched (__pos , (|| { t }) ()) } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"->\"") ; :: peg :: RuleResult :: Failed } } { :: peg :: RuleResult :: Matched (__newpos , __value) => { :: peg :: RuleResult :: Matched (__newpos , Some (__value)) } , :: peg :: RuleResult :: Failed => { :: peg :: RuleResult :: Matched (__pos , None) } , } ; match __seq_res { :: peg :: RuleResult :: Matched (__pos , ret_type) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "=") { :: peg :: RuleResult :: Matched (__pos , __val) => { { let __seq_res = __parse_expression (__input , __state , __err_state , __pos) ; match __seq_res { :: peg :: RuleResult :: Matched (__pos , expr) => { { let __seq_res = match match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , ";") { :: peg :: RuleResult :: Matched (__pos , __val) => { :: peg :: RuleResult :: Matched (__pos , __val) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\";\"") ; :: peg :: RuleResult :: Failed } } { :: peg :: RuleResult :: Matched (__newpos , _) => { :: peg :: RuleResult :: Matched (__newpos , ()) } , :: peg :: RuleResult :: Failed => { :: peg :: RuleResult :: Matched (__pos , ()) } , } ; match __seq_res { :: peg :: RuleResult :: Matched (__pos , _) => { :: peg :: RuleResult :: Matched (__pos , (|| { Rule { doc , name , ty_params , params , expr , ret_type , visibility , cached } }) ()) } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"=\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\")\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"(\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , }
+                                                }
+                                                ::peg::RuleResult::Failed => {
+                                                    ::peg::RuleResult::Failed
+                                                }
+                                            }
+                                        }
+                                        ::peg::RuleResult::Failed => {
+                                            __err_state.mark_failure(__pos, "\"rule\"");
+                                            ::peg::RuleResult::Failed
+                                        }
+                                    }
+                                }
+                                ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
+                            }
+                        }
+                        ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
+                    }
+                }
+                ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
+            }
+        }
+    }
+    fn __parse_cacheflag<'input>(
+        __input: &'input Input,
+        __state: &mut ParseState<'input>,
+        __err_state: &mut ::peg::error::ErrorState,
+        __pos: usize,
+    ) -> ::peg::RuleResult<bool> {
+        #![allow(non_snake_case, unused)]
+        {
+            let __choice_res = match ::peg::ParseLiteral::parse_string_literal(__input, __pos, "#")
+            {
+                ::peg::RuleResult::Matched(__pos, __val) => {
+                    match ::peg::ParseLiteral::parse_string_literal(__input, __pos, "[") {
+                        ::peg::RuleResult::Matched(__pos, __val) => {
+                            match ::peg::ParseLiteral::parse_string_literal(__input, __pos, "cache")
+                            {
+                                ::peg::RuleResult::Matched(__pos, __val) => {
+                                    match ::peg::ParseLiteral::parse_string_literal(
+                                        __input, __pos, "]",
+                                    ) {
+                                        ::peg::RuleResult::Matched(__pos, __val) => {
+                                            ::peg::RuleResult::Matched(__pos, (|| true)())
+                                        }
+                                        ::peg::RuleResult::Failed => {
+                                            __err_state.mark_failure(__pos, "\"]\"");
+                                            ::peg::RuleResult::Failed
+                                        }
+                                    }
+                                }
+                                ::peg::RuleResult::Failed => {
+                                    __err_state.mark_failure(__pos, "\"cache\"");
+                                    ::peg::RuleResult::Failed
+                                }
+                            }
+                        }
+                        ::peg::RuleResult::Failed => {
+                            __err_state.mark_failure(__pos, "\"[\"");
+                            ::peg::RuleResult::Failed
+                        }
+                    }
+                }
+                ::peg::RuleResult::Failed => {
+                    __err_state.mark_failure(__pos, "\"#\"");
+                    ::peg::RuleResult::Failed
+                }
+            };
+            match __choice_res {
+                ::peg::RuleResult::Matched(__pos, __value) => {
+                    ::peg::RuleResult::Matched(__pos, __value)
+                }
+                ::peg::RuleResult::Failed => ::peg::RuleResult::Matched(__pos, (|| false)()),
+            }
+        }
+    }
+    fn __parse_rust_ty_params<'input>(
+        __input: &'input Input,
+        __state: &mut ParseState<'input>,
+        __err_state: &mut ::peg::error::ErrorState,
+        __pos: usize,
+    ) -> ::peg::RuleResult<Vec<TokenStream>> {
+        #![allow(non_snake_case, unused)]
+        match ::peg::ParseLiteral::parse_string_literal(__input, __pos, "<") {
+            ::peg::RuleResult::Matched(__pos, __val) => {
+                let __seq_res = {
+                    let mut __repeat_pos = __pos;
+                    let mut __repeat_value = vec![];
+                    loop {
+                        let __pos = __repeat_pos;
+                        let __pos = if __repeat_value.is_empty() {
+                            __pos
+                        } else {
+                            let __sep_res = match ::peg::ParseLiteral::parse_string_literal(
+                                __input, __pos, ",",
+                            ) {
+                                ::peg::RuleResult::Matched(__pos, __val) => {
+                                    ::peg::RuleResult::Matched(__pos, __val)
+                                }
+                                ::peg::RuleResult::Failed => {
+                                    __err_state.mark_failure(__pos, "\",\"");
+                                    ::peg::RuleResult::Failed
+                                }
+                            };
+                            match __sep_res {
+                                ::peg::RuleResult::Matched(__newpos, _) => __newpos,
+                                ::peg::RuleResult::Failed => break,
+                            }
+                        };
+                        let __step_res = {
+                            let str_start = __pos;
+                            match {
+                                let __choice_res =
+                                    match __parse_IDENT(__input, __state, __err_state, __pos) {
+                                        ::peg::RuleResult::Matched(pos, _) => {
+                                            ::peg::RuleResult::Matched(pos, ())
+                                        }
+                                        ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
+                                    };
+                                match __choice_res {
+                                    ::peg::RuleResult::Matched(__pos, __value) => {
+                                        ::peg::RuleResult::Matched(__pos, __value)
+                                    }
+                                    ::peg::RuleResult::Failed => {
+                                        match __parse_LIFETIME(__input, __state, __err_state, __pos)
+                                        {
+                                            ::peg::RuleResult::Matched(pos, _) => {
+                                                ::peg::RuleResult::Matched(pos, ())
+                                            }
+                                            ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
+                                        }
+                                    }
+                                }
+                            } {
+                                ::peg::RuleResult::Matched(__newpos, _) => {
+                                    ::peg::RuleResult::Matched(
+                                        __newpos,
+                                        ::peg::ParseSlice::parse_slice(
+                                            __input, str_start, __newpos,
+                                        ),
+                                    )
+                                }
+                                ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
+                            }
+                        };
+                        match __step_res {
+                            ::peg::RuleResult::Matched(__newpos, __value) => {
+                                __repeat_pos = __newpos;
+                                __repeat_value.push(__value);
+                            }
+                            ::peg::RuleResult::Failed => {
+                                break;
+                            }
+                        }
+                    }
+                    if __repeat_value.len() >= 1 {
+                        ::peg::RuleResult::Matched(__repeat_pos, __repeat_value)
+                    } else {
+                        ::peg::RuleResult::Failed
+                    }
+                };
+                match __seq_res {
+                    ::peg::RuleResult::Matched(__pos, p) => {
+                        match ::peg::ParseLiteral::parse_string_literal(__input, __pos, ">") {
+                            ::peg::RuleResult::Matched(__pos, __val) => {
+                                ::peg::RuleResult::Matched(__pos, (|| p)())
+                            }
+                            ::peg::RuleResult::Failed => {
+                                __err_state.mark_failure(__pos, "\">\"");
+                                ::peg::RuleResult::Failed
+                            }
+                        }
+                    }
+                    ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
+                }
+            }
+            ::peg::RuleResult::Failed => {
+                __err_state.mark_failure(__pos, "\"<\"");
+                ::peg::RuleResult::Failed
+            }
+        }
+    }
+    fn __parse_rule_param<'input>(
+        __input: &'input Input,
+        __state: &mut ParseState<'input>,
+        __err_state: &mut ::peg::error::ErrorState,
+        __pos: usize,
+    ) -> ::peg::RuleResult<RuleParam> {
+        #![allow(non_snake_case, unused)]
+        {
+            let __seq_res = __parse_IDENT(__input, __state, __err_state, __pos);
+            match __seq_res {
+                ::peg::RuleResult::Matched(__pos, name) => {
+                    match ::peg::ParseLiteral::parse_string_literal(__input, __pos, ":") {
+                        ::peg::RuleResult::Matched(__pos, __val) => {
+                            let __seq_res = {
+                                let __choice_res = match ::peg::ParseLiteral::parse_string_literal(
+                                    __input, __pos, "rule",
+                                ) {
+                                    ::peg::RuleResult::Matched(__pos, __val) => {
+                                        match ::peg::ParseLiteral::parse_string_literal(
+                                            __input, __pos, "<",
+                                        ) {
+                                            ::peg::RuleResult::Matched(__pos, __val) => {
                                                 let __seq_res = {
                                                     let str_start = __pos;
                                                     match match __parse_rust_type(
@@ -227,503 +550,17 @@ pub mod peg {
                                                         }
                                                     }
                                                 };
-                                                match __seq_res {
-                                                    ::peg::RuleResult::Matched(__pos, t) => {
-                                                        ::peg::RuleResult::Matched(
-                                                            __pos,
-                                                            (|| (i, t))(),
-                                                        )
-                                                    }
-                                                    ::peg::RuleResult::Failed => {
-                                                        ::peg::RuleResult::Failed
-                                                    }
-                                                }
+                                                match __seq_res { :: peg :: RuleResult :: Matched (__pos , r) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , ">") { :: peg :: RuleResult :: Matched (__pos , __val) => { :: peg :: RuleResult :: Matched (__pos , (|| { RuleParamTy :: Rule (r) }) ()) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\">\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , }
                                             }
-                                            ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
-                                        }
-                                    }
-                                    ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
-                                }
-                            };
-                            match __step_res {
-                                ::peg::RuleResult::Matched(__newpos, __value) => {
-                                    __repeat_pos = __newpos;
-                                    __repeat_value.push(__value);
-                                }
-                                ::peg::RuleResult::Failed => {
-                                    break;
-                                }
-                            }
-                        }
-                        ::peg::RuleResult::Matched(__repeat_pos, __repeat_value)
-                    };
-                    match __seq_res {
-                        ::peg::RuleResult::Matched(__pos, args) => {
-                            let __seq_res = match match ::peg::ParseLiteral::parse_string_literal(
-                                __input, __pos, ",",
-                            ) {
-                                ::peg::RuleResult::Matched(__pos, __val) => {
-                                    ::peg::RuleResult::Matched(__pos, __val)
-                                }
-                                ::peg::RuleResult::Failed => {
-                                    __err_state.mark_failure(__pos, "\",\"")
-                                }
-                            } {
-                                ::peg::RuleResult::Matched(__newpos, _) => {
-                                    ::peg::RuleResult::Matched(__newpos, ())
-                                }
-                                ::peg::RuleResult::Failed => ::peg::RuleResult::Matched(__pos, ()),
-                            };
-                            match __seq_res {
-                                ::peg::RuleResult::Matched(__pos, _) => {
-                                    let __seq_res = match ::peg::ParseLiteral::parse_string_literal(
-                                        __input, __pos, ")",
-                                    ) {
-                                        ::peg::RuleResult::Matched(__pos, __val) => {
-                                            ::peg::RuleResult::Matched(__pos, __val)
-                                        }
-                                        ::peg::RuleResult::Failed => {
-                                            __err_state.mark_failure(__pos, "\")\"")
-                                        }
-                                    };
-                                    match __seq_res {
-                                        ::peg::RuleResult::Matched(__pos, _) => {
-                                            ::peg::RuleResult::Matched(__pos, (|| args)())
-                                        }
-                                        ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
-                                    }
-                                }
-                                ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
-                            }
-                        }
-                        ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
-                    }
-                }
-                ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
-            }
-        }
-    }
-    fn __parse_peg_rule<'input>(
-        __input: &'input Input,
-        __state: &mut ParseState<'input>,
-        __err_state: &mut ::peg::error::ErrorState,
-        __pos: usize,
-    ) -> ::peg::RuleResult<Rule> {
-        #![allow(non_snake_case, unused)]
-        {
-            let __seq_res = __parse_rust_doc_comment(__input, __state, __err_state, __pos);
-            match __seq_res {
-                ::peg::RuleResult::Matched(__pos, doc) => {
-                    let __seq_res = __parse_cacheflag(__input, __state, __err_state, __pos);
-                    match __seq_res {
-                        ::peg::RuleResult::Matched(__pos, cached) => {
-                            let __seq_res =
-                                __parse_rust_visibility(__input, __state, __err_state, __pos);
-                            match __seq_res {
-                                ::peg::RuleResult::Matched(__pos, visibility) => {
-                                    let __seq_res = match ::peg::ParseLiteral::parse_string_literal(
-                                        __input, __pos, "rule",
-                                    ) {
-                                        ::peg::RuleResult::Matched(__pos, __val) => {
-                                            ::peg::RuleResult::Matched(__pos, __val)
-                                        }
-                                        ::peg::RuleResult::Failed => {
-                                            __err_state.mark_failure(__pos, "\"rule\"")
-                                        }
-                                    };
-                                    match __seq_res {
-                                        ::peg::RuleResult::Matched(__pos, _) => {
-                                            let __seq_res =
-                                                __parse_IDENT(__input, __state, __err_state, __pos);
-                                            match __seq_res {
-                                                ::peg::RuleResult::Matched(__pos, name) => {
-                                                    let __seq_res = match __parse_rust_ty_params(
-                                                        __input,
-                                                        __state,
-                                                        __err_state,
-                                                        __pos,
-                                                    ) {
-                                                        ::peg::RuleResult::Matched(
-                                                            __newpos,
-                                                            __value,
-                                                        ) => ::peg::RuleResult::Matched(
-                                                            __newpos,
-                                                            Some(__value),
-                                                        ),
-                                                        ::peg::RuleResult::Failed => {
-                                                            ::peg::RuleResult::Matched(__pos, None)
-                                                        }
-                                                    };
-                                                    match __seq_res {
-                                                        ::peg::RuleResult::Matched(
-                                                            __pos,
-                                                            ty_params,
-                                                        ) => {
-                                                            let __seq_res = match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "(") { :: peg :: RuleResult :: Matched (__pos , __val) => :: peg :: RuleResult :: Matched (__pos , __val) , :: peg :: RuleResult :: Failed => __err_state . mark_failure (__pos , "\"(\"") } ;
-                                                            match __seq_res {
-                                                                ::peg::RuleResult::Matched(
-                                                                    __pos,
-                                                                    _,
-                                                                ) => {
-                                                                    let __seq_res = {
-                                                                        let mut __repeat_pos =
-                                                                            __pos;
-                                                                        let mut __repeat_value =
-                                                                            vec![];
-                                                                        loop {
-                                                                            let __pos =
-                                                                                __repeat_pos;
-                                                                            let __pos =
-                                                                                if __repeat_value
-                                                                                    .is_empty()
-                                                                                {
-                                                                                    __pos
-                                                                                } else {
-                                                                                    let __sep_res = match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , ",") { :: peg :: RuleResult :: Matched (__pos , __val) => :: peg :: RuleResult :: Matched (__pos , __val) , :: peg :: RuleResult :: Failed => __err_state . mark_failure (__pos , "\",\"") } ;
-                                                                                    match __sep_res { :: peg :: RuleResult :: Matched (__newpos , _) => { __newpos } , :: peg :: RuleResult :: Failed => break , }
-                                                                                };
-                                                                            let __step_res =
-                                                                                __parse_rule_param(
-                                                                                    __input,
-                                                                                    __state,
-                                                                                    __err_state,
-                                                                                    __pos,
-                                                                                );
-                                                                            match __step_res { :: peg :: RuleResult :: Matched (__newpos , __value) => { __repeat_pos = __newpos ; __repeat_value . push (__value) ; } , :: peg :: RuleResult :: Failed => { break ; } }
-                                                                        }
-                                                                        ::peg::RuleResult::Matched(
-                                                                            __repeat_pos,
-                                                                            __repeat_value,
-                                                                        )
-                                                                    };
-                                                                    match __seq_res { :: peg :: RuleResult :: Matched (__pos , params) => { { let __seq_res = match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , ")") { :: peg :: RuleResult :: Matched (__pos , __val) => :: peg :: RuleResult :: Matched (__pos , __val) , :: peg :: RuleResult :: Failed => __err_state . mark_failure (__pos , "\")\"") } ; match __seq_res { :: peg :: RuleResult :: Matched (__pos , _) => { { let __seq_res = match { let __seq_res = match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "->") { :: peg :: RuleResult :: Matched (__pos , __val) => :: peg :: RuleResult :: Matched (__pos , __val) , :: peg :: RuleResult :: Failed => __err_state . mark_failure (__pos , "\"->\"") } ; match __seq_res { :: peg :: RuleResult :: Matched (__pos , _) => { { let __seq_res = { let str_start = __pos ; match match __parse_rust_type (__input , __state , __err_state , __pos) { :: peg :: RuleResult :: Matched (pos , _) => :: peg :: RuleResult :: Matched (pos , ()) , :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } { :: peg :: RuleResult :: Matched (__newpos , _) => { :: peg :: RuleResult :: Matched (__newpos , :: peg :: ParseSlice :: parse_slice (__input , str_start , __newpos)) } , :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } ; match __seq_res { :: peg :: RuleResult :: Matched (__pos , t) => { :: peg :: RuleResult :: Matched (__pos , (|| { t }) ()) } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } { :: peg :: RuleResult :: Matched (__newpos , __value) => { :: peg :: RuleResult :: Matched (__newpos , Some (__value)) } , :: peg :: RuleResult :: Failed => { :: peg :: RuleResult :: Matched (__pos , None) } , } ; match __seq_res { :: peg :: RuleResult :: Matched (__pos , ret_type) => { { let __seq_res = match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "=") { :: peg :: RuleResult :: Matched (__pos , __val) => :: peg :: RuleResult :: Matched (__pos , __val) , :: peg :: RuleResult :: Failed => __err_state . mark_failure (__pos , "\"=\"") } ; match __seq_res { :: peg :: RuleResult :: Matched (__pos , _) => { { let __seq_res = __parse_expression (__input , __state , __err_state , __pos) ; match __seq_res { :: peg :: RuleResult :: Matched (__pos , expr) => { { let __seq_res = match match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , ";") { :: peg :: RuleResult :: Matched (__pos , __val) => :: peg :: RuleResult :: Matched (__pos , __val) , :: peg :: RuleResult :: Failed => __err_state . mark_failure (__pos , "\";\"") } { :: peg :: RuleResult :: Matched (__newpos , _) => { :: peg :: RuleResult :: Matched (__newpos , ()) } , :: peg :: RuleResult :: Failed => { :: peg :: RuleResult :: Matched (__pos , ()) } , } ; match __seq_res { :: peg :: RuleResult :: Matched (__pos , _) => { :: peg :: RuleResult :: Matched (__pos , (|| { Rule { doc , name , ty_params , params , expr , ret_type , visibility , cached } }) ()) } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , }
-                                                                }
-                                                                ::peg::RuleResult::Failed => {
-                                                                    ::peg::RuleResult::Failed
-                                                                }
-                                                            }
-                                                        }
-                                                        ::peg::RuleResult::Failed => {
-                                                            ::peg::RuleResult::Failed
-                                                        }
-                                                    }
-                                                }
-                                                ::peg::RuleResult::Failed => {
-                                                    ::peg::RuleResult::Failed
-                                                }
+                                            ::peg::RuleResult::Failed => {
+                                                __err_state.mark_failure(__pos, "\"<\"");
+                                                ::peg::RuleResult::Failed
                                             }
                                         }
-                                        ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
-                                    }
-                                }
-                                ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
-                            }
-                        }
-                        ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
-                    }
-                }
-                ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
-            }
-        }
-    }
-    fn __parse_cacheflag<'input>(
-        __input: &'input Input,
-        __state: &mut ParseState<'input>,
-        __err_state: &mut ::peg::error::ErrorState,
-        __pos: usize,
-    ) -> ::peg::RuleResult<bool> {
-        #![allow(non_snake_case, unused)]
-        {
-            let __choice_res = {
-                let __seq_res = match ::peg::ParseLiteral::parse_string_literal(__input, __pos, "#")
-                {
-                    ::peg::RuleResult::Matched(__pos, __val) => {
-                        ::peg::RuleResult::Matched(__pos, __val)
-                    }
-                    ::peg::RuleResult::Failed => __err_state.mark_failure(__pos, "\"#\""),
-                };
-                match __seq_res {
-                    ::peg::RuleResult::Matched(__pos, _) => {
-                        let __seq_res =
-                            match ::peg::ParseLiteral::parse_string_literal(__input, __pos, "[") {
-                                ::peg::RuleResult::Matched(__pos, __val) => {
-                                    ::peg::RuleResult::Matched(__pos, __val)
-                                }
-                                ::peg::RuleResult::Failed => {
-                                    __err_state.mark_failure(__pos, "\"[\"")
-                                }
-                            };
-                        match __seq_res {
-                            ::peg::RuleResult::Matched(__pos, _) => {
-                                let __seq_res = match ::peg::ParseLiteral::parse_string_literal(
-                                    __input, __pos, "cache",
-                                ) {
-                                    ::peg::RuleResult::Matched(__pos, __val) => {
-                                        ::peg::RuleResult::Matched(__pos, __val)
                                     }
                                     ::peg::RuleResult::Failed => {
-                                        __err_state.mark_failure(__pos, "\"cache\"")
-                                    }
-                                };
-                                match __seq_res {
-                                    ::peg::RuleResult::Matched(__pos, _) => {
-                                        let __seq_res =
-                                            match ::peg::ParseLiteral::parse_string_literal(
-                                                __input, __pos, "]",
-                                            ) {
-                                                ::peg::RuleResult::Matched(__pos, __val) => {
-                                                    ::peg::RuleResult::Matched(__pos, __val)
-                                                }
-                                                ::peg::RuleResult::Failed => {
-                                                    __err_state.mark_failure(__pos, "\"]\"")
-                                                }
-                                            };
-                                        match __seq_res {
-                                            ::peg::RuleResult::Matched(__pos, _) => {
-                                                ::peg::RuleResult::Matched(__pos, (|| true)())
-                                            }
-                                            ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
-                                        }
-                                    }
-                                    ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
-                                }
-                            }
-                            ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
-                        }
-                    }
-                    ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
-                }
-            };
-            match __choice_res {
-                ::peg::RuleResult::Matched(__pos, __value) => {
-                    ::peg::RuleResult::Matched(__pos, __value)
-                }
-                ::peg::RuleResult::Failed => ::peg::RuleResult::Matched(__pos, (|| false)()),
-            }
-        }
-    }
-    fn __parse_rust_ty_params<'input>(
-        __input: &'input Input,
-        __state: &mut ParseState<'input>,
-        __err_state: &mut ::peg::error::ErrorState,
-        __pos: usize,
-    ) -> ::peg::RuleResult<Vec<TokenStream>> {
-        #![allow(non_snake_case, unused)]
-        {
-            let __seq_res = match ::peg::ParseLiteral::parse_string_literal(__input, __pos, "<") {
-                ::peg::RuleResult::Matched(__pos, __val) => {
-                    ::peg::RuleResult::Matched(__pos, __val)
-                }
-                ::peg::RuleResult::Failed => __err_state.mark_failure(__pos, "\"<\""),
-            };
-            match __seq_res {
-                ::peg::RuleResult::Matched(__pos, _) => {
-                    let __seq_res = {
-                        let mut __repeat_pos = __pos;
-                        let mut __repeat_value = vec![];
-                        loop {
-                            let __pos = __repeat_pos;
-                            let __pos = if __repeat_value.is_empty() {
-                                __pos
-                            } else {
-                                let __sep_res = match ::peg::ParseLiteral::parse_string_literal(
-                                    __input, __pos, ",",
-                                ) {
-                                    ::peg::RuleResult::Matched(__pos, __val) => {
-                                        ::peg::RuleResult::Matched(__pos, __val)
-                                    }
-                                    ::peg::RuleResult::Failed => {
-                                        __err_state.mark_failure(__pos, "\",\"")
-                                    }
-                                };
-                                match __sep_res {
-                                    ::peg::RuleResult::Matched(__newpos, _) => __newpos,
-                                    ::peg::RuleResult::Failed => break,
-                                }
-                            };
-                            let __step_res = {
-                                let str_start = __pos;
-                                match {
-                                    let __choice_res =
-                                        match __parse_IDENT(__input, __state, __err_state, __pos) {
-                                            ::peg::RuleResult::Matched(pos, _) => {
-                                                ::peg::RuleResult::Matched(pos, ())
-                                            }
-                                            ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
-                                        };
-                                    match __choice_res {
-                                        ::peg::RuleResult::Matched(__pos, __value) => {
-                                            ::peg::RuleResult::Matched(__pos, __value)
-                                        }
-                                        ::peg::RuleResult::Failed => match __parse_LIFETIME(
-                                            __input,
-                                            __state,
-                                            __err_state,
-                                            __pos,
-                                        ) {
-                                            ::peg::RuleResult::Matched(pos, _) => {
-                                                ::peg::RuleResult::Matched(pos, ())
-                                            }
-                                            ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
-                                        },
-                                    }
-                                } {
-                                    ::peg::RuleResult::Matched(__newpos, _) => {
-                                        ::peg::RuleResult::Matched(
-                                            __newpos,
-                                            ::peg::ParseSlice::parse_slice(
-                                                __input, str_start, __newpos,
-                                            ),
-                                        )
-                                    }
-                                    ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
-                                }
-                            };
-                            match __step_res {
-                                ::peg::RuleResult::Matched(__newpos, __value) => {
-                                    __repeat_pos = __newpos;
-                                    __repeat_value.push(__value);
-                                }
-                                ::peg::RuleResult::Failed => {
-                                    break;
-                                }
-                            }
-                        }
-                        if __repeat_value.len() >= 1 {
-                            ::peg::RuleResult::Matched(__repeat_pos, __repeat_value)
-                        } else {
-                            ::peg::RuleResult::Failed
-                        }
-                    };
-                    match __seq_res {
-                        ::peg::RuleResult::Matched(__pos, p) => {
-                            let __seq_res = match ::peg::ParseLiteral::parse_string_literal(
-                                __input, __pos, ">",
-                            ) {
-                                ::peg::RuleResult::Matched(__pos, __val) => {
-                                    ::peg::RuleResult::Matched(__pos, __val)
-                                }
-                                ::peg::RuleResult::Failed => {
-                                    __err_state.mark_failure(__pos, "\">\"")
-                                }
-                            };
-                            match __seq_res {
-                                ::peg::RuleResult::Matched(__pos, _) => {
-                                    ::peg::RuleResult::Matched(__pos, (|| p)())
-                                }
-                                ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
-                            }
-                        }
-                        ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
-                    }
-                }
-                ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
-            }
-        }
-    }
-    fn __parse_rule_param<'input>(
-        __input: &'input Input,
-        __state: &mut ParseState<'input>,
-        __err_state: &mut ::peg::error::ErrorState,
-        __pos: usize,
-    ) -> ::peg::RuleResult<RuleParam> {
-        #![allow(non_snake_case, unused)]
-        {
-            let __seq_res = __parse_IDENT(__input, __state, __err_state, __pos);
-            match __seq_res {
-                ::peg::RuleResult::Matched(__pos, name) => {
-                    let __seq_res =
-                        match ::peg::ParseLiteral::parse_string_literal(__input, __pos, ":") {
-                            ::peg::RuleResult::Matched(__pos, __val) => {
-                                ::peg::RuleResult::Matched(__pos, __val)
-                            }
-                            ::peg::RuleResult::Failed => __err_state.mark_failure(__pos, "\":\""),
-                        };
-                    match __seq_res {
-                        ::peg::RuleResult::Matched(__pos, _) => {
-                            let __seq_res = {
-                                let __choice_res = {
-                                    let __seq_res = match ::peg::ParseLiteral::parse_string_literal(
-                                        __input, __pos, "rule",
-                                    ) {
-                                        ::peg::RuleResult::Matched(__pos, __val) => {
-                                            ::peg::RuleResult::Matched(__pos, __val)
-                                        }
-                                        ::peg::RuleResult::Failed => {
-                                            __err_state.mark_failure(__pos, "\"rule\"")
-                                        }
-                                    };
-                                    match __seq_res {
-                                        ::peg::RuleResult::Matched(__pos, _) => {
-                                            let __seq_res =
-                                                match ::peg::ParseLiteral::parse_string_literal(
-                                                    __input, __pos, "<",
-                                                ) {
-                                                    ::peg::RuleResult::Matched(__pos, __val) => {
-                                                        ::peg::RuleResult::Matched(__pos, __val)
-                                                    }
-                                                    ::peg::RuleResult::Failed => {
-                                                        __err_state.mark_failure(__pos, "\"<\"")
-                                                    }
-                                                };
-                                            match __seq_res {
-                                                ::peg::RuleResult::Matched(__pos, _) => {
-                                                    let __seq_res = {
-                                                        let str_start = __pos;
-                                                        match match __parse_rust_type(
-                                                            __input,
-                                                            __state,
-                                                            __err_state,
-                                                            __pos,
-                                                        ) {
-                                                            ::peg::RuleResult::Matched(pos, _) => {
-                                                                ::peg::RuleResult::Matched(pos, ())
-                                                            }
-                                                            ::peg::RuleResult::Failed => {
-                                                                ::peg::RuleResult::Failed
-                                                            }
-                                                        } {
-                                                            ::peg::RuleResult::Matched(
-                                                                __newpos,
-                                                                _,
-                                                            ) => ::peg::RuleResult::Matched(
-                                                                __newpos,
-                                                                ::peg::ParseSlice::parse_slice(
-                                                                    __input, str_start, __newpos,
-                                                                ),
-                                                            ),
-                                                            ::peg::RuleResult::Failed => {
-                                                                ::peg::RuleResult::Failed
-                                                            }
-                                                        }
-                                                    };
-                                                    match __seq_res {
-                                                        ::peg::RuleResult::Matched(__pos, r) => {
-                                                            let __seq_res = match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , ">") { :: peg :: RuleResult :: Matched (__pos , __val) => :: peg :: RuleResult :: Matched (__pos , __val) , :: peg :: RuleResult :: Failed => __err_state . mark_failure (__pos , "\">\"") } ;
-                                                            match __seq_res {
-                                                                ::peg::RuleResult::Matched(
-                                                                    __pos,
-                                                                    _,
-                                                                ) => ::peg::RuleResult::Matched(
-                                                                    __pos,
-                                                                    (|| RuleParamTy::Rule(r))(),
-                                                                ),
-                                                                ::peg::RuleResult::Failed => {
-                                                                    ::peg::RuleResult::Failed
-                                                                }
-                                                            }
-                                                        }
-                                                        ::peg::RuleResult::Failed => {
-                                                            ::peg::RuleResult::Failed
-                                                        }
-                                                    }
-                                                }
-                                                ::peg::RuleResult::Failed => {
-                                                    ::peg::RuleResult::Failed
-                                                }
-                                            }
-                                        }
-                                        ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
+                                        __err_state.mark_failure(__pos, "\"rule\"");
+                                        ::peg::RuleResult::Failed
                                     }
                                 };
                                 match __choice_res {
@@ -778,7 +615,10 @@ pub mod peg {
                                 ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
                             }
                         }
-                        ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
+                        ::peg::RuleResult::Failed => {
+                            __err_state.mark_failure(__pos, "\":\"");
+                            ::peg::RuleResult::Failed
+                        }
                     }
                 }
                 ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
@@ -831,110 +671,56 @@ pub mod peg {
                 let mut __repeat_pos = __pos;
                 loop {
                     let __pos = __repeat_pos;
-                    let __step_res = {
-                        let __seq_res =
-                            match ::peg::ParseLiteral::parse_string_literal(__input, __pos, "#") {
+                    let __step_res = match ::peg::ParseLiteral::parse_string_literal(
+                        __input, __pos, "#",
+                    ) {
+                        ::peg::RuleResult::Matched(__pos, __val) => {
+                            match ::peg::ParseLiteral::parse_string_literal(__input, __pos, "[") {
                                 ::peg::RuleResult::Matched(__pos, __val) => {
-                                    ::peg::RuleResult::Matched(__pos, __val)
-                                }
-                                ::peg::RuleResult::Failed => {
-                                    __err_state.mark_failure(__pos, "\"#\"")
-                                }
-                            };
-                        match __seq_res {
-                            ::peg::RuleResult::Matched(__pos, _) => {
-                                let __seq_res = match ::peg::ParseLiteral::parse_string_literal(
-                                    __input, __pos, "[",
-                                ) {
-                                    ::peg::RuleResult::Matched(__pos, __val) => {
-                                        ::peg::RuleResult::Matched(__pos, __val)
-                                    }
-                                    ::peg::RuleResult::Failed => {
-                                        __err_state.mark_failure(__pos, "\"[\"")
-                                    }
-                                };
-                                match __seq_res {
-                                    ::peg::RuleResult::Matched(__pos, _) => {
-                                        let __seq_res =
+                                    match ::peg::ParseLiteral::parse_string_literal(
+                                        __input, __pos, "doc",
+                                    ) {
+                                        ::peg::RuleResult::Matched(__pos, __val) => {
                                             match ::peg::ParseLiteral::parse_string_literal(
-                                                __input, __pos, "doc",
+                                                __input, __pos, "=",
                                             ) {
                                                 ::peg::RuleResult::Matched(__pos, __val) => {
-                                                    ::peg::RuleResult::Matched(__pos, __val)
-                                                }
-                                                ::peg::RuleResult::Failed => {
-                                                    __err_state.mark_failure(__pos, "\"doc\"")
-                                                }
-                                            };
-                                        match __seq_res {
-                                            ::peg::RuleResult::Matched(__pos, _) => {
-                                                let __seq_res =
-                                                    match ::peg::ParseLiteral::parse_string_literal(
-                                                        __input, __pos, "=",
+                                                    let __seq_res = match __parse_LITERAL(
+                                                        __input,
+                                                        __state,
+                                                        __err_state,
+                                                        __pos,
                                                     ) {
-                                                        ::peg::RuleResult::Matched(
-                                                            __pos,
-                                                            __val,
-                                                        ) => {
-                                                            ::peg::RuleResult::Matched(__pos, __val)
+                                                        ::peg::RuleResult::Matched(pos, _) => {
+                                                            ::peg::RuleResult::Matched(pos, ())
                                                         }
                                                         ::peg::RuleResult::Failed => {
-                                                            __err_state.mark_failure(__pos, "\"=\"")
+                                                            ::peg::RuleResult::Failed
                                                         }
                                                     };
-                                                match __seq_res {
-                                                    ::peg::RuleResult::Matched(__pos, _) => {
-                                                        let __seq_res = match __parse_LITERAL(
-                                                            __input,
-                                                            __state,
-                                                            __err_state,
-                                                            __pos,
-                                                        ) {
-                                                            ::peg::RuleResult::Matched(pos, _) => {
-                                                                ::peg::RuleResult::Matched(pos, ())
-                                                            }
-                                                            ::peg::RuleResult::Failed => {
-                                                                ::peg::RuleResult::Failed
-                                                            }
-                                                        };
-                                                        match __seq_res {
-                                                            ::peg::RuleResult::Matched(
-                                                                __pos,
-                                                                _,
-                                                            ) => {
-                                                                let __seq_res = match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "]") { :: peg :: RuleResult :: Matched (__pos , __val) => :: peg :: RuleResult :: Matched (__pos , __val) , :: peg :: RuleResult :: Failed => __err_state . mark_failure (__pos , "\"]\"") } ;
-                                                                match __seq_res {
-                                                                    ::peg::RuleResult::Matched(
-                                                                        __pos,
-                                                                        _,
-                                                                    ) => {
-                                                                        ::peg::RuleResult::Matched(
-                                                                            __pos,
-                                                                            (),
-                                                                        )
-                                                                    }
-                                                                    ::peg::RuleResult::Failed => {
-                                                                        ::peg::RuleResult::Failed
-                                                                    }
-                                                                }
-                                                            }
-                                                            ::peg::RuleResult::Failed => {
-                                                                ::peg::RuleResult::Failed
-                                                            }
-                                                        }
-                                                    }
-                                                    ::peg::RuleResult::Failed => {
-                                                        ::peg::RuleResult::Failed
-                                                    }
+                                                    match __seq_res { :: peg :: RuleResult :: Matched (__pos , _) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "]") { :: peg :: RuleResult :: Matched (__pos , __val) => { :: peg :: RuleResult :: Matched (__pos , ()) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"]\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , }
+                                                }
+                                                ::peg::RuleResult::Failed => {
+                                                    __err_state.mark_failure(__pos, "\"=\"");
+                                                    ::peg::RuleResult::Failed
                                                 }
                                             }
-                                            ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
+                                        }
+                                        ::peg::RuleResult::Failed => {
+                                            __err_state.mark_failure(__pos, "\"doc\"");
+                                            ::peg::RuleResult::Failed
                                         }
                                     }
-                                    ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
+                                }
+                                ::peg::RuleResult::Failed => {
+                                    __err_state.mark_failure(__pos, "\"[\"");
+                                    ::peg::RuleResult::Failed
                                 }
                             }
-                            ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
+                        }
+                        ::peg::RuleResult::Failed => {
+                            __err_state.mark_failure(__pos, "\"#\"");
+                            ::peg::RuleResult::Failed
                         }
                     };
                     match __step_res {
@@ -971,16 +757,9 @@ pub mod peg {
         match {
             let str_start = __pos;
             match {
-                let __choice_res = {
-                    let __seq_res =
-                        match ::peg::ParseLiteral::parse_string_literal(__input, __pos, "pub") {
-                            ::peg::RuleResult::Matched(__pos, __val) => {
-                                ::peg::RuleResult::Matched(__pos, __val)
-                            }
-                            ::peg::RuleResult::Failed => __err_state.mark_failure(__pos, "\"pub\""),
-                        };
-                    match __seq_res {
-                        ::peg::RuleResult::Matched(__pos, _) => {
+                let __choice_res =
+                    match ::peg::ParseLiteral::parse_string_literal(__input, __pos, "pub") {
+                        ::peg::RuleResult::Matched(__pos, __val) => {
                             let __seq_res = match match __parse_PAREN_GROUP(
                                 __input,
                                 __state,
@@ -1004,9 +783,11 @@ pub mod peg {
                                 ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
                             }
                         }
-                        ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
-                    }
-                };
+                        ::peg::RuleResult::Failed => {
+                            __err_state.mark_failure(__pos, "\"pub\"");
+                            ::peg::RuleResult::Failed
+                        }
+                    };
                 match __choice_res {
                     ::peg::RuleResult::Matched(__pos, __value) => {
                         ::peg::RuleResult::Matched(__pos, __value)
@@ -1017,7 +798,8 @@ pub mod peg {
                                 ::peg::RuleResult::Matched(__pos, __val)
                             }
                             ::peg::RuleResult::Failed => {
-                                __err_state.mark_failure(__pos, "\"crate\"")
+                                __err_state.mark_failure(__pos, "\"crate\"");
+                                ::peg::RuleResult::Failed
                             }
                         }
                     }
@@ -1046,180 +828,73 @@ pub mod peg {
         {
             let __seq_res = {
                 let str_start = __pos;
-                match {
-                    let __seq_res =
-                        match ::peg::ParseLiteral::parse_string_literal(__input, __pos, "use") {
-                            ::peg::RuleResult::Matched(__pos, __val) => {
-                                ::peg::RuleResult::Matched(__pos, __val)
-                            }
-                            ::peg::RuleResult::Failed => __err_state.mark_failure(__pos, "\"use\""),
-                        };
-                    match __seq_res {
-                        ::peg::RuleResult::Matched(__pos, _) => {
-                            let __seq_res =
-                                match __parse_rust_path(__input, __state, __err_state, __pos) {
-                                    ::peg::RuleResult::Matched(pos, _) => {
-                                        ::peg::RuleResult::Matched(pos, ())
-                                    }
-                                    ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
-                                };
-                            match __seq_res {
-                                ::peg::RuleResult::Matched(__pos, _) => {
-                                    let __seq_res = {
-                                        let __choice_res = {
-                                            let __seq_res =
-                                                match ::peg::ParseLiteral::parse_string_literal(
-                                                    __input, __pos, "::",
-                                                ) {
-                                                    ::peg::RuleResult::Matched(__pos, __val) => {
-                                                        ::peg::RuleResult::Matched(__pos, __val)
-                                                    }
-                                                    ::peg::RuleResult::Failed => {
-                                                        __err_state.mark_failure(__pos, "\"::\"")
-                                                    }
-                                                };
-                                            match __seq_res {
-                                                ::peg::RuleResult::Matched(__pos, _) => {
-                                                    let __seq_res = match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "*") { :: peg :: RuleResult :: Matched (__pos , __val) => :: peg :: RuleResult :: Matched (__pos , __val) , :: peg :: RuleResult :: Failed => __err_state . mark_failure (__pos , "\"*\"") } ;
-                                                    match __seq_res {
-                                                        ::peg::RuleResult::Matched(__pos, _) => {
-                                                            ::peg::RuleResult::Matched(__pos, ())
-                                                        }
-                                                        ::peg::RuleResult::Failed => {
-                                                            ::peg::RuleResult::Failed
-                                                        }
-                                                    }
-                                                }
-                                                ::peg::RuleResult::Failed => {
-                                                    ::peg::RuleResult::Failed
-                                                }
-                                            }
-                                        };
-                                        match __choice_res {
-                                            ::peg::RuleResult::Matched(__pos, __value) => {
-                                                ::peg::RuleResult::Matched(__pos, __value)
-                                            }
-                                            ::peg::RuleResult::Failed => {
-                                                let __choice_res = {
-                                                    let __seq_res = match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "::") { :: peg :: RuleResult :: Matched (__pos , __val) => :: peg :: RuleResult :: Matched (__pos , __val) , :: peg :: RuleResult :: Failed => __err_state . mark_failure (__pos , "\"::\"") } ;
-                                                    match __seq_res {
-                                                        ::peg::RuleResult::Matched(__pos, _) => {
-                                                            let __seq_res = match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "{") { :: peg :: RuleResult :: Matched (__pos , __val) => :: peg :: RuleResult :: Matched (__pos , __val) , :: peg :: RuleResult :: Failed => __err_state . mark_failure (__pos , "\"{\"") } ;
-                                                            match __seq_res {
-                                                                ::peg::RuleResult::Matched(
-                                                                    __pos,
-                                                                    _,
-                                                                ) => {
-                                                                    let __seq_res = {
-                                                                        let mut __repeat_pos =
-                                                                            __pos;
-                                                                        let mut __repeat_value =
-                                                                            vec![];
-                                                                        loop {
-                                                                            let __pos =
-                                                                                __repeat_pos;
-                                                                            let __pos =
-                                                                                if __repeat_value
-                                                                                    .is_empty()
-                                                                                {
-                                                                                    __pos
-                                                                                } else {
-                                                                                    let __sep_res = match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , ",") { :: peg :: RuleResult :: Matched (__pos , __val) => :: peg :: RuleResult :: Matched (__pos , __val) , :: peg :: RuleResult :: Failed => __err_state . mark_failure (__pos , "\",\"") } ;
-                                                                                    match __sep_res { :: peg :: RuleResult :: Matched (__newpos , _) => { __newpos } , :: peg :: RuleResult :: Failed => break , }
-                                                                                };
-                                                                            let __step_res = {
-                                                                                let __seq_res = match __parse_IDENT (__input , __state , __err_state , __pos) { :: peg :: RuleResult :: Matched (pos , _) => :: peg :: RuleResult :: Matched (pos , ()) , :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } ;
-                                                                                match __seq_res { :: peg :: RuleResult :: Matched (__pos , _) => { { let __seq_res = match { let __seq_res = match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "as") { :: peg :: RuleResult :: Matched (__pos , __val) => :: peg :: RuleResult :: Matched (__pos , __val) , :: peg :: RuleResult :: Failed => __err_state . mark_failure (__pos , "\"as\"") } ; match __seq_res { :: peg :: RuleResult :: Matched (__pos , _) => { { let __seq_res = match __parse_IDENT (__input , __state , __err_state , __pos) { :: peg :: RuleResult :: Matched (pos , _) => :: peg :: RuleResult :: Matched (pos , ()) , :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } ; match __seq_res { :: peg :: RuleResult :: Matched (__pos , _) => { :: peg :: RuleResult :: Matched (__pos , ()) } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } { :: peg :: RuleResult :: Matched (__newpos , _) => { :: peg :: RuleResult :: Matched (__newpos , ()) } , :: peg :: RuleResult :: Failed => { :: peg :: RuleResult :: Matched (__pos , ()) } , } ; match __seq_res { :: peg :: RuleResult :: Matched (__pos , _) => { :: peg :: RuleResult :: Matched (__pos , ()) } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , }
-                                                                            };
-                                                                            match __step_res { :: peg :: RuleResult :: Matched (__newpos , __value) => { __repeat_pos = __newpos ; __repeat_value . push (__value) ; } , :: peg :: RuleResult :: Failed => { break ; } }
-                                                                        }
-                                                                        if __repeat_value.len() >= 1
-                                                                        {
-                                                                            :: peg :: RuleResult :: Matched (__repeat_pos , ())
-                                                                        } else {
-                                                                            :: peg :: RuleResult :: Failed
-                                                                        }
-                                                                    };
-                                                                    match __seq_res { :: peg :: RuleResult :: Matched (__pos , _) => { { let __seq_res = match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "}") { :: peg :: RuleResult :: Matched (__pos , __val) => :: peg :: RuleResult :: Matched (__pos , __val) , :: peg :: RuleResult :: Failed => __err_state . mark_failure (__pos , "\"}\"") } ; match __seq_res { :: peg :: RuleResult :: Matched (__pos , _) => { :: peg :: RuleResult :: Matched (__pos , ()) } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , }
-                                                                }
-                                                                ::peg::RuleResult::Failed => {
-                                                                    ::peg::RuleResult::Failed
-                                                                }
-                                                            }
-                                                        }
-                                                        ::peg::RuleResult::Failed => {
-                                                            ::peg::RuleResult::Failed
-                                                        }
-                                                    }
-                                                };
-                                                match __choice_res {
-                                                    ::peg::RuleResult::Matched(__pos, __value) => {
-                                                        ::peg::RuleResult::Matched(__pos, __value)
-                                                    }
-                                                    ::peg::RuleResult::Failed => {
-                                                        match {
-                                                            let __seq_res = match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "as") { :: peg :: RuleResult :: Matched (__pos , __val) => :: peg :: RuleResult :: Matched (__pos , __val) , :: peg :: RuleResult :: Failed => __err_state . mark_failure (__pos , "\"as\"") } ;
-                                                            match __seq_res {
-                                                                ::peg::RuleResult::Matched(
-                                                                    __pos,
-                                                                    _,
-                                                                ) => {
-                                                                    let __seq_res = match __parse_IDENT (__input , __state , __err_state , __pos) { :: peg :: RuleResult :: Matched (pos , _) => :: peg :: RuleResult :: Matched (pos , ()) , :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } ;
-                                                                    match __seq_res { :: peg :: RuleResult :: Matched (__pos , _) => { :: peg :: RuleResult :: Matched (__pos , ()) } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , }
-                                                                }
-                                                                ::peg::RuleResult::Failed => {
-                                                                    ::peg::RuleResult::Failed
-                                                                }
-                                                            }
-                                                        } {
-                                                            ::peg::RuleResult::Matched(
-                                                                __newpos,
-                                                                _,
-                                                            ) => ::peg::RuleResult::Matched(
-                                                                __newpos,
-                                                                (),
-                                                            ),
-                                                            ::peg::RuleResult::Failed => {
-                                                                ::peg::RuleResult::Matched(
-                                                                    __pos,
-                                                                    (),
-                                                                )
-                                                            }
-                                                        }
-                                                    }
-                                                }
-                                            }
-                                        }
-                                    };
-                                    match __seq_res {
-                                        ::peg::RuleResult::Matched(__pos, _) => {
-                                            let __seq_res =
-                                                match ::peg::ParseLiteral::parse_string_literal(
-                                                    __input, __pos, ";",
-                                                ) {
-                                                    ::peg::RuleResult::Matched(__pos, __val) => {
-                                                        ::peg::RuleResult::Matched(__pos, __val)
-                                                    }
-                                                    ::peg::RuleResult::Failed => {
-                                                        __err_state.mark_failure(__pos, "\";\"")
-                                                    }
-                                                };
-                                            match __seq_res {
-                                                ::peg::RuleResult::Matched(__pos, _) => {
-                                                    ::peg::RuleResult::Matched(__pos, ())
-                                                }
-                                                ::peg::RuleResult::Failed => {
-                                                    ::peg::RuleResult::Failed
-                                                }
-                                            }
-                                        }
-                                        ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
-                                    }
+                match match ::peg::ParseLiteral::parse_string_literal(__input, __pos, "use") {
+                    ::peg::RuleResult::Matched(__pos, __val) => {
+                        let __seq_res =
+                            match __parse_rust_path(__input, __state, __err_state, __pos) {
+                                ::peg::RuleResult::Matched(pos, _) => {
+                                    ::peg::RuleResult::Matched(pos, ())
                                 }
                                 ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
+                            };
+                        match __seq_res {
+                            ::peg::RuleResult::Matched(__pos, _) => {
+                                let __seq_res = {
+                                    let __choice_res =
+                                        match ::peg::ParseLiteral::parse_string_literal(
+                                            __input, __pos, "::",
+                                        ) {
+                                            ::peg::RuleResult::Matched(__pos, __val) => {
+                                                match ::peg::ParseLiteral::parse_string_literal(
+                                                    __input, __pos, "*",
+                                                ) {
+                                                    ::peg::RuleResult::Matched(__pos, __val) => {
+                                                        ::peg::RuleResult::Matched(__pos, ())
+                                                    }
+                                                    ::peg::RuleResult::Failed => {
+                                                        __err_state.mark_failure(__pos, "\"*\"");
+                                                        ::peg::RuleResult::Failed
+                                                    }
+                                                }
+                                            }
+                                            ::peg::RuleResult::Failed => {
+                                                __err_state.mark_failure(__pos, "\"::\"");
+                                                ::peg::RuleResult::Failed
+                                            }
+                                        };
+                                    match __choice_res {
+                                        ::peg::RuleResult::Matched(__pos, __value) => {
+                                            ::peg::RuleResult::Matched(__pos, __value)
+                                        }
+                                        ::peg::RuleResult::Failed => {
+                                            let __choice_res = match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "::") { :: peg :: RuleResult :: Matched (__pos , __val) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "{") { :: peg :: RuleResult :: Matched (__pos , __val) => { { let __seq_res = { let mut __repeat_pos = __pos ; let mut __repeat_value = vec ! () ; loop { let __pos = __repeat_pos ; let __pos = if __repeat_value . is_empty () { __pos } else { let __sep_res = match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , ",") { :: peg :: RuleResult :: Matched (__pos , __val) => { :: peg :: RuleResult :: Matched (__pos , __val) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\",\"") ; :: peg :: RuleResult :: Failed } } ; match __sep_res { :: peg :: RuleResult :: Matched (__newpos , _) => { __newpos } , :: peg :: RuleResult :: Failed => break , } } ; let __step_res = { let __seq_res = match __parse_IDENT (__input , __state , __err_state , __pos) { :: peg :: RuleResult :: Matched (pos , _) => :: peg :: RuleResult :: Matched (pos , ()) , :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } ; match __seq_res { :: peg :: RuleResult :: Matched (__pos , _) => { { let __seq_res = match match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "as") { :: peg :: RuleResult :: Matched (__pos , __val) => { { let __seq_res = match __parse_IDENT (__input , __state , __err_state , __pos) { :: peg :: RuleResult :: Matched (pos , _) => :: peg :: RuleResult :: Matched (pos , ()) , :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } ; match __seq_res { :: peg :: RuleResult :: Matched (__pos , _) => { :: peg :: RuleResult :: Matched (__pos , ()) } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"as\"") ; :: peg :: RuleResult :: Failed } } { :: peg :: RuleResult :: Matched (__newpos , _) => { :: peg :: RuleResult :: Matched (__newpos , ()) } , :: peg :: RuleResult :: Failed => { :: peg :: RuleResult :: Matched (__pos , ()) } , } ; match __seq_res { :: peg :: RuleResult :: Matched (__pos , _) => { :: peg :: RuleResult :: Matched (__pos , ()) } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } ; match __step_res { :: peg :: RuleResult :: Matched (__newpos , __value) => { __repeat_pos = __newpos ; __repeat_value . push (__value) ; } , :: peg :: RuleResult :: Failed => { break ; } } } if __repeat_value . len () >= 1 { :: peg :: RuleResult :: Matched (__repeat_pos , ()) } else { :: peg :: RuleResult :: Failed } } ; match __seq_res { :: peg :: RuleResult :: Matched (__pos , _) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "}") { :: peg :: RuleResult :: Matched (__pos , __val) => { :: peg :: RuleResult :: Matched (__pos , ()) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"}\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"{\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"::\"") ; :: peg :: RuleResult :: Failed } } ;
+                                            match __choice_res { :: peg :: RuleResult :: Matched (__pos , __value) => :: peg :: RuleResult :: Matched (__pos , __value) , :: peg :: RuleResult :: Failed => match match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "as") { :: peg :: RuleResult :: Matched (__pos , __val) => { { let __seq_res = match __parse_IDENT (__input , __state , __err_state , __pos) { :: peg :: RuleResult :: Matched (pos , _) => :: peg :: RuleResult :: Matched (pos , ()) , :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } ; match __seq_res { :: peg :: RuleResult :: Matched (__pos , _) => { :: peg :: RuleResult :: Matched (__pos , ()) } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"as\"") ; :: peg :: RuleResult :: Failed } } { :: peg :: RuleResult :: Matched (__newpos , _) => { :: peg :: RuleResult :: Matched (__newpos , ()) } , :: peg :: RuleResult :: Failed => { :: peg :: RuleResult :: Matched (__pos , ()) } , } }
+                                        }
+                                    }
+                                };
+                                match __seq_res {
+                                    ::peg::RuleResult::Matched(__pos, _) => {
+                                        match ::peg::ParseLiteral::parse_string_literal(
+                                            __input, __pos, ";",
+                                        ) {
+                                            ::peg::RuleResult::Matched(__pos, __val) => {
+                                                ::peg::RuleResult::Matched(__pos, ())
+                                            }
+                                            ::peg::RuleResult::Failed => {
+                                                __err_state.mark_failure(__pos, "\";\"");
+                                                ::peg::RuleResult::Failed
+                                            }
+                                        }
+                                    }
+                                    ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
+                                }
                             }
+                            ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
                         }
-                        ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
+                    }
+                    ::peg::RuleResult::Failed => {
+                        __err_state.mark_failure(__pos, "\"use\"");
+                        ::peg::RuleResult::Failed
                     }
                 } {
                     ::peg::RuleResult::Matched(__newpos, _) => ::peg::RuleResult::Matched(
@@ -1245,38 +920,29 @@ pub mod peg {
     ) -> ::peg::RuleResult<()> {
         #![allow(non_snake_case, unused)]
         {
-            let __seq_res = match {
-                let __seq_res =
-                    match ::peg::ParseLiteral::parse_string_literal(__input, __pos, "crate") {
-                        ::peg::RuleResult::Matched(__pos, __val) => {
-                            ::peg::RuleResult::Matched(__pos, __val)
-                        }
-                        ::peg::RuleResult::Failed => __err_state.mark_failure(__pos, "\"crate\""),
-                    };
-                match __seq_res {
-                    ::peg::RuleResult::Matched(__pos, _) => {
-                        let __seq_res =
-                            match ::peg::ParseLiteral::parse_string_literal(__input, __pos, "::") {
-                                ::peg::RuleResult::Matched(__pos, __val) => {
-                                    ::peg::RuleResult::Matched(__pos, __val)
-                                }
-                                ::peg::RuleResult::Failed => {
-                                    __err_state.mark_failure(__pos, "\"::\"")
-                                }
-                            };
-                        match __seq_res {
-                            ::peg::RuleResult::Matched(__pos, _) => {
+            let __seq_res =
+                match match ::peg::ParseLiteral::parse_string_literal(__input, __pos, "crate") {
+                    ::peg::RuleResult::Matched(__pos, __val) => {
+                        match ::peg::ParseLiteral::parse_string_literal(__input, __pos, "::") {
+                            ::peg::RuleResult::Matched(__pos, __val) => {
                                 ::peg::RuleResult::Matched(__pos, ())
                             }
-                            ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
+                            ::peg::RuleResult::Failed => {
+                                __err_state.mark_failure(__pos, "\"::\"");
+                                ::peg::RuleResult::Failed
+                            }
                         }
                     }
-                    ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
-                }
-            } {
-                ::peg::RuleResult::Matched(__newpos, _) => ::peg::RuleResult::Matched(__newpos, ()),
-                ::peg::RuleResult::Failed => ::peg::RuleResult::Matched(__pos, ()),
-            };
+                    ::peg::RuleResult::Failed => {
+                        __err_state.mark_failure(__pos, "\"crate\"");
+                        ::peg::RuleResult::Failed
+                    }
+                } {
+                    ::peg::RuleResult::Matched(__newpos, _) => {
+                        ::peg::RuleResult::Matched(__newpos, ())
+                    }
+                    ::peg::RuleResult::Failed => ::peg::RuleResult::Matched(__pos, ()),
+                };
             match __seq_res {
                 ::peg::RuleResult::Matched(__pos, _) => {
                     let __seq_res = {
@@ -1294,7 +960,8 @@ pub mod peg {
                                         ::peg::RuleResult::Matched(__pos, __val)
                                     }
                                     ::peg::RuleResult::Failed => {
-                                        __err_state.mark_failure(__pos, "\"::\"")
+                                        __err_state.mark_failure(__pos, "\"::\"");
+                                        ::peg::RuleResult::Failed
                                     }
                                 };
                                 match __sep_res {
@@ -1353,18 +1020,9 @@ pub mod peg {
                     ::peg::RuleResult::Matched(__pos, __value)
                 }
                 ::peg::RuleResult::Failed => {
-                    let __choice_res = {
-                        let __seq_res =
-                            match ::peg::ParseLiteral::parse_string_literal(__input, __pos, "&") {
-                                ::peg::RuleResult::Matched(__pos, __val) => {
-                                    ::peg::RuleResult::Matched(__pos, __val)
-                                }
-                                ::peg::RuleResult::Failed => {
-                                    __err_state.mark_failure(__pos, "\"&\"")
-                                }
-                            };
-                        match __seq_res {
-                            ::peg::RuleResult::Matched(__pos, _) => {
+                    let __choice_res =
+                        match ::peg::ParseLiteral::parse_string_literal(__input, __pos, "&") {
+                            ::peg::RuleResult::Matched(__pos, __val) => {
                                 let __seq_res =
                                     match match ::peg::ParseLiteral::parse_string_literal(
                                         __input, __pos, "mut",
@@ -1373,7 +1031,8 @@ pub mod peg {
                                             ::peg::RuleResult::Matched(__pos, __val)
                                         }
                                         ::peg::RuleResult::Failed => {
-                                            __err_state.mark_failure(__pos, "\"mut\"")
+                                            __err_state.mark_failure(__pos, "\"mut\"");
+                                            ::peg::RuleResult::Failed
                                         }
                                     } {
                                         ::peg::RuleResult::Matched(__newpos, _) => {
@@ -1433,46 +1092,41 @@ pub mod peg {
                                     ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
                                 }
                             }
-                            ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
-                        }
-                    };
+                            ::peg::RuleResult::Failed => {
+                                __err_state.mark_failure(__pos, "\"&\"");
+                                ::peg::RuleResult::Failed
+                            }
+                        };
                     match __choice_res {
                         ::peg::RuleResult::Matched(__pos, __value) => {
                             ::peg::RuleResult::Matched(__pos, __value)
                         }
                         ::peg::RuleResult::Failed => {
-                            let __choice_res = {
-                                let __seq_res = match ::peg::ParseLiteral::parse_string_literal(
-                                    __input, __pos, "dyn",
-                                ) {
-                                    ::peg::RuleResult::Matched(__pos, __val) => {
-                                        ::peg::RuleResult::Matched(__pos, __val)
-                                    }
-                                    ::peg::RuleResult::Failed => {
-                                        __err_state.mark_failure(__pos, "\"dyn\"")
-                                    }
-                                };
-                                match __seq_res {
-                                    ::peg::RuleResult::Matched(__pos, _) => {
-                                        let __seq_res = match __parse_rust_type(
-                                            __input,
-                                            __state,
-                                            __err_state,
-                                            __pos,
-                                        ) {
-                                            ::peg::RuleResult::Matched(pos, _) => {
-                                                ::peg::RuleResult::Matched(pos, ())
-                                            }
-                                            ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
-                                        };
-                                        match __seq_res {
-                                            ::peg::RuleResult::Matched(__pos, _) => {
-                                                ::peg::RuleResult::Matched(__pos, ())
-                                            }
-                                            ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
+                            let __choice_res = match ::peg::ParseLiteral::parse_string_literal(
+                                __input, __pos, "dyn",
+                            ) {
+                                ::peg::RuleResult::Matched(__pos, __val) => {
+                                    let __seq_res = match __parse_rust_type(
+                                        __input,
+                                        __state,
+                                        __err_state,
+                                        __pos,
+                                    ) {
+                                        ::peg::RuleResult::Matched(pos, _) => {
+                                            ::peg::RuleResult::Matched(pos, ())
                                         }
+                                        ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
+                                    };
+                                    match __seq_res {
+                                        ::peg::RuleResult::Matched(__pos, _) => {
+                                            ::peg::RuleResult::Matched(__pos, ())
+                                        }
+                                        ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
                                     }
-                                    ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
+                                }
+                                ::peg::RuleResult::Failed => {
+                                    __err_state.mark_failure(__pos, "\"dyn\"");
+                                    ::peg::RuleResult::Failed
                                 }
                             };
                             match __choice_res {
@@ -1480,20 +1134,11 @@ pub mod peg {
                                     ::peg::RuleResult::Matched(__pos, __value)
                                 }
                                 ::peg::RuleResult::Failed => {
-                                    let __choice_res = {
-                                        let __seq_res =
-                                            match ::peg::ParseLiteral::parse_string_literal(
-                                                __input, __pos, "impl",
-                                            ) {
-                                                ::peg::RuleResult::Matched(__pos, __val) => {
-                                                    ::peg::RuleResult::Matched(__pos, __val)
-                                                }
-                                                ::peg::RuleResult::Failed => {
-                                                    __err_state.mark_failure(__pos, "\"impl\"")
-                                                }
-                                            };
-                                        match __seq_res {
-                                            ::peg::RuleResult::Matched(__pos, _) => {
+                                    let __choice_res =
+                                        match ::peg::ParseLiteral::parse_string_literal(
+                                            __input, __pos, "impl",
+                                        ) {
+                                            ::peg::RuleResult::Matched(__pos, __val) => {
                                                 let __seq_res = match __parse_rust_type(
                                                     __input,
                                                     __state,
@@ -1516,9 +1161,11 @@ pub mod peg {
                                                     }
                                                 }
                                             }
-                                            ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
-                                        }
-                                    };
+                                            ::peg::RuleResult::Failed => {
+                                                __err_state.mark_failure(__pos, "\"impl\"");
+                                                ::peg::RuleResult::Failed
+                                            }
+                                        };
                                     match __choice_res {
                                         ::peg::RuleResult::Matched(__pos, __value) => {
                                             ::peg::RuleResult::Matched(__pos, __value)
@@ -1538,65 +1185,7 @@ pub mod peg {
                                                         ::peg::RuleResult::Failed
                                                     }
                                                 };
-                                                match __seq_res {
-                                                    ::peg::RuleResult::Matched(__pos, _) => {
-                                                        let __seq_res = match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "<") { :: peg :: RuleResult :: Matched (__pos , __val) => :: peg :: RuleResult :: Matched (__pos , __val) , :: peg :: RuleResult :: Failed => __err_state . mark_failure (__pos , "\"<\"") } ;
-                                                        match __seq_res {
-                                                            ::peg::RuleResult::Matched(
-                                                                __pos,
-                                                                _,
-                                                            ) => {
-                                                                let __seq_res = {
-                                                                    let mut __repeat_pos = __pos;
-                                                                    let mut __repeat_value = vec![];
-                                                                    loop {
-                                                                        let __pos = __repeat_pos;
-                                                                        let __pos =
-                                                                            if __repeat_value
-                                                                                .is_empty()
-                                                                            {
-                                                                                __pos
-                                                                            } else {
-                                                                                let __sep_res = match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , ",") { :: peg :: RuleResult :: Matched (__pos , __val) => :: peg :: RuleResult :: Matched (__pos , __val) , :: peg :: RuleResult :: Failed => __err_state . mark_failure (__pos , "\",\"") } ;
-                                                                                match __sep_res { :: peg :: RuleResult :: Matched (__newpos , _) => { __newpos } , :: peg :: RuleResult :: Failed => break , }
-                                                                            };
-                                                                        let __step_res = {
-                                                                            let __choice_res = match __parse_LIFETIME (__input , __state , __err_state , __pos) { :: peg :: RuleResult :: Matched (pos , _) => :: peg :: RuleResult :: Matched (pos , ()) , :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } ;
-                                                                            match __choice_res { :: peg :: RuleResult :: Matched (__pos , __value) => :: peg :: RuleResult :: Matched (__pos , __value) , :: peg :: RuleResult :: Failed => match __parse_rust_type (__input , __state , __err_state , __pos) { :: peg :: RuleResult :: Matched (pos , _) => :: peg :: RuleResult :: Matched (pos , ()) , :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } }
-                                                                        };
-                                                                        match __step_res { :: peg :: RuleResult :: Matched (__newpos , __value) => { __repeat_pos = __newpos ; __repeat_value . push (__value) ; } , :: peg :: RuleResult :: Failed => { break ; } }
-                                                                    }
-                                                                    if __repeat_value.len() >= 1 {
-                                                                        ::peg::RuleResult::Matched(
-                                                                            __repeat_pos,
-                                                                            (),
-                                                                        )
-                                                                    } else {
-                                                                        ::peg::RuleResult::Failed
-                                                                    }
-                                                                };
-                                                                match __seq_res {
-                                                                    ::peg::RuleResult::Matched(
-                                                                        __pos,
-                                                                        _,
-                                                                    ) => {
-                                                                        let __seq_res = match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , ">") { :: peg :: RuleResult :: Matched (__pos , __val) => :: peg :: RuleResult :: Matched (__pos , __val) , :: peg :: RuleResult :: Failed => __err_state . mark_failure (__pos , "\">\"") } ;
-                                                                        match __seq_res { :: peg :: RuleResult :: Matched (__pos , _) => { :: peg :: RuleResult :: Matched (__pos , ()) } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , }
-                                                                    }
-                                                                    ::peg::RuleResult::Failed => {
-                                                                        ::peg::RuleResult::Failed
-                                                                    }
-                                                                }
-                                                            }
-                                                            ::peg::RuleResult::Failed => {
-                                                                ::peg::RuleResult::Failed
-                                                            }
-                                                        }
-                                                    }
-                                                    ::peg::RuleResult::Failed => {
-                                                        ::peg::RuleResult::Failed
-                                                    }
-                                                }
+                                                match __seq_res { :: peg :: RuleResult :: Matched (__pos , _) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "<") { :: peg :: RuleResult :: Matched (__pos , __val) => { { let __seq_res = { let mut __repeat_pos = __pos ; let mut __repeat_value = vec ! () ; loop { let __pos = __repeat_pos ; let __pos = if __repeat_value . is_empty () { __pos } else { let __sep_res = match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , ",") { :: peg :: RuleResult :: Matched (__pos , __val) => { :: peg :: RuleResult :: Matched (__pos , __val) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\",\"") ; :: peg :: RuleResult :: Failed } } ; match __sep_res { :: peg :: RuleResult :: Matched (__newpos , _) => { __newpos } , :: peg :: RuleResult :: Failed => break , } } ; let __step_res = { let __choice_res = match __parse_LIFETIME (__input , __state , __err_state , __pos) { :: peg :: RuleResult :: Matched (pos , _) => :: peg :: RuleResult :: Matched (pos , ()) , :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } ; match __choice_res { :: peg :: RuleResult :: Matched (__pos , __value) => :: peg :: RuleResult :: Matched (__pos , __value) , :: peg :: RuleResult :: Failed => match __parse_rust_type (__input , __state , __err_state , __pos) { :: peg :: RuleResult :: Matched (pos , _) => :: peg :: RuleResult :: Matched (pos , ()) , :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } } ; match __step_res { :: peg :: RuleResult :: Matched (__newpos , __value) => { __repeat_pos = __newpos ; __repeat_value . push (__value) ; } , :: peg :: RuleResult :: Failed => { break ; } } } if __repeat_value . len () >= 1 { :: peg :: RuleResult :: Matched (__repeat_pos , ()) } else { :: peg :: RuleResult :: Failed } } ; match __seq_res { :: peg :: RuleResult :: Matched (__pos , _) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , ">") { :: peg :: RuleResult :: Matched (__pos , __val) => { :: peg :: RuleResult :: Matched (__pos , ()) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\">\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"<\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , }
                                             };
                                             match __choice_res {
                                                 ::peg::RuleResult::Matched(__pos, __value) => {
@@ -1617,29 +1206,7 @@ pub mod peg {
                                                                 ::peg::RuleResult::Failed
                                                             }
                                                         };
-                                                        match __seq_res {
-                                                            ::peg::RuleResult::Matched(
-                                                                __pos,
-                                                                _,
-                                                            ) => {
-                                                                let __seq_res = match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "::") { :: peg :: RuleResult :: Matched (__pos , __val) => :: peg :: RuleResult :: Matched (__pos , __val) , :: peg :: RuleResult :: Failed => __err_state . mark_failure (__pos , "\"::\"") } ;
-                                                                match __seq_res {
-                                                                    ::peg::RuleResult::Matched(
-                                                                        __pos,
-                                                                        _,
-                                                                    ) => {
-                                                                        let __seq_res = match __parse_rust_type (__input , __state , __err_state , __pos) { :: peg :: RuleResult :: Matched (pos , _) => :: peg :: RuleResult :: Matched (pos , ()) , :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } ;
-                                                                        match __seq_res { :: peg :: RuleResult :: Matched (__pos , _) => { :: peg :: RuleResult :: Matched (__pos , ()) } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , }
-                                                                    }
-                                                                    ::peg::RuleResult::Failed => {
-                                                                        ::peg::RuleResult::Failed
-                                                                    }
-                                                                }
-                                                            }
-                                                            ::peg::RuleResult::Failed => {
-                                                                ::peg::RuleResult::Failed
-                                                            }
-                                                        }
+                                                        match __seq_res { :: peg :: RuleResult :: Matched (__pos , _) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "::") { :: peg :: RuleResult :: Matched (__pos , __val) => { { let __seq_res = match __parse_rust_type (__input , __state , __err_state , __pos) { :: peg :: RuleResult :: Matched (pos , _) => :: peg :: RuleResult :: Matched (pos , ()) , :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } ; match __seq_res { :: peg :: RuleResult :: Matched (__pos , _) => { :: peg :: RuleResult :: Matched (__pos , ()) } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"::\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , }
                                                     };
                                                     match __choice_res {
                                                         ::peg::RuleResult::Matched(
@@ -1649,34 +1216,7 @@ pub mod peg {
                                                             __pos, __value,
                                                         ),
                                                         ::peg::RuleResult::Failed => {
-                                                            let __choice_res = {
-                                                                let __seq_res = match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "(") { :: peg :: RuleResult :: Matched (__pos , __val) => :: peg :: RuleResult :: Matched (__pos , __val) , :: peg :: RuleResult :: Failed => __err_state . mark_failure (__pos , "\"(\"") } ;
-                                                                match __seq_res {
-                                                                    ::peg::RuleResult::Matched(
-                                                                        __pos,
-                                                                        _,
-                                                                    ) => {
-                                                                        let __seq_res = {
-                                                                            let mut __repeat_pos =
-                                                                                __pos;
-                                                                            let mut __repeat_value =
-                                                                                vec![];
-                                                                            loop {
-                                                                                let __pos =
-                                                                                    __repeat_pos;
-                                                                                let __pos = if __repeat_value . is_empty () { __pos } else { let __sep_res = match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , ",") { :: peg :: RuleResult :: Matched (__pos , __val) => :: peg :: RuleResult :: Matched (__pos , __val) , :: peg :: RuleResult :: Failed => __err_state . mark_failure (__pos , "\",\"") } ; match __sep_res { :: peg :: RuleResult :: Matched (__newpos , _) => { __newpos } , :: peg :: RuleResult :: Failed => break , } } ;
-                                                                                let __step_res = match __parse_rust_type (__input , __state , __err_state , __pos) { :: peg :: RuleResult :: Matched (pos , _) => :: peg :: RuleResult :: Matched (pos , ()) , :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } ;
-                                                                                match __step_res { :: peg :: RuleResult :: Matched (__newpos , __value) => { __repeat_pos = __newpos ; __repeat_value . push (__value) ; } , :: peg :: RuleResult :: Failed => { break ; } }
-                                                                            }
-                                                                            :: peg :: RuleResult :: Matched (__repeat_pos , ())
-                                                                        };
-                                                                        match __seq_res { :: peg :: RuleResult :: Matched (__pos , _) => { { let __seq_res = match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , ")") { :: peg :: RuleResult :: Matched (__pos , __val) => :: peg :: RuleResult :: Matched (__pos , __val) , :: peg :: RuleResult :: Failed => __err_state . mark_failure (__pos , "\")\"") } ; match __seq_res { :: peg :: RuleResult :: Matched (__pos , _) => { :: peg :: RuleResult :: Matched (__pos , ()) } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , }
-                                                                    }
-                                                                    ::peg::RuleResult::Failed => {
-                                                                        ::peg::RuleResult::Failed
-                                                                    }
-                                                                }
-                                                            };
+                                                            let __choice_res = match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "(") { :: peg :: RuleResult :: Matched (__pos , __val) => { { let __seq_res = { let mut __repeat_pos = __pos ; let mut __repeat_value = vec ! () ; loop { let __pos = __repeat_pos ; let __pos = if __repeat_value . is_empty () { __pos } else { let __sep_res = match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , ",") { :: peg :: RuleResult :: Matched (__pos , __val) => { :: peg :: RuleResult :: Matched (__pos , __val) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\",\"") ; :: peg :: RuleResult :: Failed } } ; match __sep_res { :: peg :: RuleResult :: Matched (__newpos , _) => { __newpos } , :: peg :: RuleResult :: Failed => break , } } ; let __step_res = match __parse_rust_type (__input , __state , __err_state , __pos) { :: peg :: RuleResult :: Matched (pos , _) => :: peg :: RuleResult :: Matched (pos , ()) , :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } ; match __step_res { :: peg :: RuleResult :: Matched (__newpos , __value) => { __repeat_pos = __newpos ; __repeat_value . push (__value) ; } , :: peg :: RuleResult :: Failed => { break ; } } } :: peg :: RuleResult :: Matched (__repeat_pos , ()) } ; match __seq_res { :: peg :: RuleResult :: Matched (__pos , _) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , ")") { :: peg :: RuleResult :: Matched (__pos , __val) => { :: peg :: RuleResult :: Matched (__pos , ()) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\")\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"(\"") ; :: peg :: RuleResult :: Failed } } ;
                                                             match __choice_res { :: peg :: RuleResult :: Matched (__pos , __value) => :: peg :: RuleResult :: Matched (__pos , __value) , :: peg :: RuleResult :: Failed => match __parse_IDENT (__input , __state , __err_state , __pos) { :: peg :: RuleResult :: Matched (pos , _) => :: peg :: RuleResult :: Matched (pos , ()) , :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } }
                                                         }
                                                     }
@@ -1723,7 +1263,8 @@ pub mod peg {
                                     ::peg::RuleResult::Matched(__pos, __val)
                                 }
                                 ::peg::RuleResult::Failed => {
-                                    __err_state.mark_failure(__pos, "\"/\"")
+                                    __err_state.mark_failure(__pos, "\"/\"");
+                                    ::peg::RuleResult::Failed
                                 }
                             };
                         match __sep_res {
@@ -1830,20 +1371,14 @@ pub mod peg {
                 let __seq_res = __parse_IDENT(__input, __state, __err_state, __pos);
                 match __seq_res {
                     ::peg::RuleResult::Matched(__pos, l) => {
-                        let __seq_res =
-                            match ::peg::ParseLiteral::parse_string_literal(__input, __pos, ":") {
-                                ::peg::RuleResult::Matched(__pos, __val) => {
-                                    ::peg::RuleResult::Matched(__pos, __val)
-                                }
-                                ::peg::RuleResult::Failed => {
-                                    __err_state.mark_failure(__pos, "\":\"")
-                                }
-                            };
-                        match __seq_res {
-                            ::peg::RuleResult::Matched(__pos, _) => {
+                        match ::peg::ParseLiteral::parse_string_literal(__input, __pos, ":") {
+                            ::peg::RuleResult::Matched(__pos, __val) => {
                                 ::peg::RuleResult::Matched(__pos, (|| l)())
                             }
-                            ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
+                            ::peg::RuleResult::Failed => {
+                                __err_state.mark_failure(__pos, "\":\"");
+                                ::peg::RuleResult::Failed
+                            }
                         }
                     }
                     ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
@@ -1886,20 +1421,14 @@ pub mod peg {
                 let __seq_res = __parse_prefixed(__input, __state, __err_state, __pos);
                 match __seq_res {
                     ::peg::RuleResult::Matched(__pos, e) => {
-                        let __seq_res =
-                            match ::peg::ParseLiteral::parse_string_literal(__input, __pos, "?") {
-                                ::peg::RuleResult::Matched(__pos, __val) => {
-                                    ::peg::RuleResult::Matched(__pos, __val)
-                                }
-                                ::peg::RuleResult::Failed => {
-                                    __err_state.mark_failure(__pos, "\"?\"")
-                                }
-                            };
-                        match __seq_res {
-                            ::peg::RuleResult::Matched(__pos, _) => {
+                        match ::peg::ParseLiteral::parse_string_literal(__input, __pos, "?") {
+                            ::peg::RuleResult::Matched(__pos, __val) => {
                                 ::peg::RuleResult::Matched(__pos, (|| OptionalExpr(Box::new(e)))())
                             }
-                            ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
+                            ::peg::RuleResult::Failed => {
+                                __err_state.mark_failure(__pos, "\"?\"");
+                                ::peg::RuleResult::Failed
+                            }
                         }
                     }
                     ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
@@ -1914,18 +1443,10 @@ pub mod peg {
                         let __seq_res = __parse_prefixed(__input, __state, __err_state, __pos);
                         match __seq_res {
                             ::peg::RuleResult::Matched(__pos, e) => {
-                                let __seq_res = match ::peg::ParseLiteral::parse_string_literal(
+                                match ::peg::ParseLiteral::parse_string_literal(
                                     __input, __pos, "**",
                                 ) {
                                     ::peg::RuleResult::Matched(__pos, __val) => {
-                                        ::peg::RuleResult::Matched(__pos, __val)
-                                    }
-                                    ::peg::RuleResult::Failed => {
-                                        __err_state.mark_failure(__pos, "\"**\"")
-                                    }
-                                };
-                                match __seq_res {
-                                    ::peg::RuleResult::Matched(__pos, _) => {
                                         let __seq_res = __parse_repeatcount(
                                             __input,
                                             __state,
@@ -1962,7 +1483,10 @@ pub mod peg {
                                             ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
                                         }
                                     }
-                                    ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
+                                    ::peg::RuleResult::Failed => {
+                                        __err_state.mark_failure(__pos, "\"**\"");
+                                        ::peg::RuleResult::Failed
+                                    }
                                 }
                             }
                             ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
@@ -1978,19 +1502,10 @@ pub mod peg {
                                     __parse_prefixed(__input, __state, __err_state, __pos);
                                 match __seq_res {
                                     ::peg::RuleResult::Matched(__pos, e) => {
-                                        let __seq_res =
-                                            match ::peg::ParseLiteral::parse_string_literal(
-                                                __input, __pos, "++",
-                                            ) {
-                                                ::peg::RuleResult::Matched(__pos, __val) => {
-                                                    ::peg::RuleResult::Matched(__pos, __val)
-                                                }
-                                                ::peg::RuleResult::Failed => {
-                                                    __err_state.mark_failure(__pos, "\"++\"")
-                                                }
-                                            };
-                                        match __seq_res {
-                                            ::peg::RuleResult::Matched(__pos, _) => {
+                                        match ::peg::ParseLiteral::parse_string_literal(
+                                            __input, __pos, "++",
+                                        ) {
+                                            ::peg::RuleResult::Matched(__pos, __val) => {
                                                 let __seq_res = __parse_primary(
                                                     __input,
                                                     __state,
@@ -2016,7 +1531,10 @@ pub mod peg {
                                                     }
                                                 }
                                             }
-                                            ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
+                                            ::peg::RuleResult::Failed => {
+                                                __err_state.mark_failure(__pos, "\"++\"");
+                                                ::peg::RuleResult::Failed
+                                            }
                                         }
                                     }
                                     ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
@@ -2032,22 +1550,10 @@ pub mod peg {
                                             __parse_prefixed(__input, __state, __err_state, __pos);
                                         match __seq_res {
                                             ::peg::RuleResult::Matched(__pos, e) => {
-                                                let __seq_res =
-                                                    match ::peg::ParseLiteral::parse_string_literal(
-                                                        __input, __pos, "*",
-                                                    ) {
-                                                        ::peg::RuleResult::Matched(
-                                                            __pos,
-                                                            __val,
-                                                        ) => {
-                                                            ::peg::RuleResult::Matched(__pos, __val)
-                                                        }
-                                                        ::peg::RuleResult::Failed => {
-                                                            __err_state.mark_failure(__pos, "\"*\"")
-                                                        }
-                                                    };
-                                                match __seq_res {
-                                                    ::peg::RuleResult::Matched(__pos, _) => {
+                                                match ::peg::ParseLiteral::parse_string_literal(
+                                                    __input, __pos, "*",
+                                                ) {
+                                                    ::peg::RuleResult::Matched(__pos, __val) => {
                                                         let __seq_res = __parse_repeatcount(
                                                             __input,
                                                             __state,
@@ -2071,6 +1577,7 @@ pub mod peg {
                                                         }
                                                     }
                                                     ::peg::RuleResult::Failed => {
+                                                        __err_state.mark_failure(__pos, "\"*\"");
                                                         ::peg::RuleResult::Failed
                                                     }
                                                 }
@@ -2090,33 +1597,7 @@ pub mod peg {
                                                     __err_state,
                                                     __pos,
                                                 );
-                                                match __seq_res {
-                                                    ::peg::RuleResult::Matched(__pos, e) => {
-                                                        let __seq_res = match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "+") { :: peg :: RuleResult :: Matched (__pos , __val) => :: peg :: RuleResult :: Matched (__pos , __val) , :: peg :: RuleResult :: Failed => __err_state . mark_failure (__pos , "\"+\"") } ;
-                                                        match __seq_res {
-                                                            ::peg::RuleResult::Matched(
-                                                                __pos,
-                                                                _,
-                                                            ) => ::peg::RuleResult::Matched(
-                                                                __pos,
-                                                                (|| {
-                                                                    Repeat(
-                                                                        Box::new(e),
-                                                                        BoundedRepeat::Plus,
-                                                                        None,
-                                                                    )
-                                                                })(
-                                                                ),
-                                                            ),
-                                                            ::peg::RuleResult::Failed => {
-                                                                ::peg::RuleResult::Failed
-                                                            }
-                                                        }
-                                                    }
-                                                    ::peg::RuleResult::Failed => {
-                                                        ::peg::RuleResult::Failed
-                                                    }
-                                                }
+                                                match __seq_res { :: peg :: RuleResult :: Matched (__pos , e) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "+") { :: peg :: RuleResult :: Matched (__pos , __val) => { :: peg :: RuleResult :: Matched (__pos , (|| { Repeat (Box :: new (e) , BoundedRepeat :: Plus , None) }) ()) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"+\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , }
                                             };
                                             match __choice_res {
                                                 ::peg::RuleResult::Matched(__pos, __value) => {
@@ -2147,43 +1628,31 @@ pub mod peg {
     ) -> ::peg::RuleResult<BoundedRepeat> {
         #![allow(non_snake_case, unused)]
         {
-            let __choice_res = {
-                let __seq_res = match ::peg::ParseLiteral::parse_string_literal(__input, __pos, "<")
-                {
-                    ::peg::RuleResult::Matched(__pos, __val) => {
-                        ::peg::RuleResult::Matched(__pos, __val)
-                    }
-                    ::peg::RuleResult::Failed => __err_state.mark_failure(__pos, "\"<\""),
-                };
-                match __seq_res {
-                    ::peg::RuleResult::Matched(__pos, _) => {
-                        let __seq_res = __parse_repeatnum(__input, __state, __err_state, __pos);
-                        match __seq_res {
-                            ::peg::RuleResult::Matched(__pos, n) => {
-                                let __seq_res = match ::peg::ParseLiteral::parse_string_literal(
-                                    __input, __pos, ">",
-                                ) {
-                                    ::peg::RuleResult::Matched(__pos, __val) => {
-                                        ::peg::RuleResult::Matched(__pos, __val)
-                                    }
-                                    ::peg::RuleResult::Failed => {
-                                        __err_state.mark_failure(__pos, "\">\"")
-                                    }
-                                };
-                                match __seq_res {
-                                    ::peg::RuleResult::Matched(__pos, _) => {
-                                        ::peg::RuleResult::Matched(
-                                            __pos,
-                                            (|| BoundedRepeat::Exact(n))(),
-                                        )
-                                    }
-                                    ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
+            let __choice_res = match ::peg::ParseLiteral::parse_string_literal(__input, __pos, "<")
+            {
+                ::peg::RuleResult::Matched(__pos, __val) => {
+                    let __seq_res = __parse_repeatnum(__input, __state, __err_state, __pos);
+                    match __seq_res {
+                        ::peg::RuleResult::Matched(__pos, n) => {
+                            match ::peg::ParseLiteral::parse_string_literal(__input, __pos, ">") {
+                                ::peg::RuleResult::Matched(__pos, __val) => {
+                                    ::peg::RuleResult::Matched(
+                                        __pos,
+                                        (|| BoundedRepeat::Exact(n))(),
+                                    )
+                                }
+                                ::peg::RuleResult::Failed => {
+                                    __err_state.mark_failure(__pos, "\">\"");
+                                    ::peg::RuleResult::Failed
                                 }
                             }
-                            ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
                         }
+                        ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
                     }
-                    ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
+                }
+                ::peg::RuleResult::Failed => {
+                    __err_state.mark_failure(__pos, "\"<\"");
+                    ::peg::RuleResult::Failed
                 }
             };
             match __choice_res {
@@ -2191,88 +1660,77 @@ pub mod peg {
                     ::peg::RuleResult::Matched(__pos, __value)
                 }
                 ::peg::RuleResult::Failed => {
-                    let __choice_res = {
-                        let __seq_res =
-                            match ::peg::ParseLiteral::parse_string_literal(__input, __pos, "<") {
-                                ::peg::RuleResult::Matched(__pos, __val) => {
-                                    ::peg::RuleResult::Matched(__pos, __val)
-                                }
-                                ::peg::RuleResult::Failed => {
-                                    __err_state.mark_failure(__pos, "\"<\"")
-                                }
-                            };
-                        match __seq_res {
-                            ::peg::RuleResult::Matched(__pos, _) => {
-                                let __seq_res =
-                                    match __parse_repeatnum(__input, __state, __err_state, __pos) {
-                                        ::peg::RuleResult::Matched(__newpos, __value) => {
-                                            ::peg::RuleResult::Matched(__newpos, Some(__value))
-                                        }
-                                        ::peg::RuleResult::Failed => {
-                                            ::peg::RuleResult::Matched(__pos, None)
-                                        }
-                                    };
-                                match __seq_res {
-                                    ::peg::RuleResult::Matched(__pos, min) => {
-                                        let __seq_res =
-                                            match ::peg::ParseLiteral::parse_string_literal(
-                                                __input, __pos, ",",
+                    let __choice_res = match ::peg::ParseLiteral::parse_string_literal(
+                        __input, __pos, "<",
+                    ) {
+                        ::peg::RuleResult::Matched(__pos, __val) => {
+                            let __seq_res =
+                                match __parse_repeatnum(__input, __state, __err_state, __pos) {
+                                    ::peg::RuleResult::Matched(__newpos, __value) => {
+                                        ::peg::RuleResult::Matched(__newpos, Some(__value))
+                                    }
+                                    ::peg::RuleResult::Failed => {
+                                        ::peg::RuleResult::Matched(__pos, None)
+                                    }
+                                };
+                            match __seq_res {
+                                ::peg::RuleResult::Matched(__pos, min) => {
+                                    match ::peg::ParseLiteral::parse_string_literal(
+                                        __input, __pos, ",",
+                                    ) {
+                                        ::peg::RuleResult::Matched(__pos, __val) => {
+                                            let __seq_res = match __parse_repeatnum(
+                                                __input,
+                                                __state,
+                                                __err_state,
+                                                __pos,
                                             ) {
-                                                ::peg::RuleResult::Matched(__pos, __val) => {
-                                                    ::peg::RuleResult::Matched(__pos, __val)
-                                                }
-                                                ::peg::RuleResult::Failed => {
-                                                    __err_state.mark_failure(__pos, "\",\"")
-                                                }
-                                            };
-                                        match __seq_res {
-                                            ::peg::RuleResult::Matched(__pos, _) => {
-                                                let __seq_res = match __parse_repeatnum(
-                                                    __input,
-                                                    __state,
-                                                    __err_state,
-                                                    __pos,
-                                                ) {
+                                                ::peg::RuleResult::Matched(__newpos, __value) => {
                                                     ::peg::RuleResult::Matched(
                                                         __newpos,
-                                                        __value,
-                                                    ) => ::peg::RuleResult::Matched(
-                                                        __newpos,
                                                         Some(__value),
-                                                    ),
-                                                    ::peg::RuleResult::Failed => {
-                                                        ::peg::RuleResult::Matched(__pos, None)
-                                                    }
-                                                };
-                                                match __seq_res {
-                                                    ::peg::RuleResult::Matched(__pos, max) => {
-                                                        let __seq_res = match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , ">") { :: peg :: RuleResult :: Matched (__pos , __val) => :: peg :: RuleResult :: Matched (__pos , __val) , :: peg :: RuleResult :: Failed => __err_state . mark_failure (__pos , "\">\"") } ;
-                                                        match __seq_res {
-                                                            ::peg::RuleResult::Matched(
-                                                                __pos,
-                                                                _,
-                                                            ) => ::peg::RuleResult::Matched(
-                                                                __pos,
-                                                                (|| BoundedRepeat::Both(min, max))(
-                                                                ),
-                                                            ),
-                                                            ::peg::RuleResult::Failed => {
-                                                                ::peg::RuleResult::Failed
-                                                            }
+                                                    )
+                                                }
+                                                ::peg::RuleResult::Failed => {
+                                                    ::peg::RuleResult::Matched(__pos, None)
+                                                }
+                                            };
+                                            match __seq_res {
+                                                ::peg::RuleResult::Matched(__pos, max) => {
+                                                    match ::peg::ParseLiteral::parse_string_literal(
+                                                        __input, __pos, ">",
+                                                    ) {
+                                                        ::peg::RuleResult::Matched(
+                                                            __pos,
+                                                            __val,
+                                                        ) => ::peg::RuleResult::Matched(
+                                                            __pos,
+                                                            (|| BoundedRepeat::Both(min, max))(),
+                                                        ),
+                                                        ::peg::RuleResult::Failed => {
+                                                            __err_state
+                                                                .mark_failure(__pos, "\">\"");
+                                                            ::peg::RuleResult::Failed
                                                         }
                                                     }
-                                                    ::peg::RuleResult::Failed => {
-                                                        ::peg::RuleResult::Failed
-                                                    }
+                                                }
+                                                ::peg::RuleResult::Failed => {
+                                                    ::peg::RuleResult::Failed
                                                 }
                                             }
-                                            ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
+                                        }
+                                        ::peg::RuleResult::Failed => {
+                                            __err_state.mark_failure(__pos, "\",\"");
+                                            ::peg::RuleResult::Failed
                                         }
                                     }
-                                    ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
                                 }
+                                ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
                             }
-                            ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
+                        }
+                        ::peg::RuleResult::Failed => {
+                            __err_state.mark_failure(__pos, "\"<\"");
+                            ::peg::RuleResult::Failed
                         }
                     };
                     match __choice_res {
@@ -2331,28 +1789,23 @@ pub mod peg {
     ) -> ::peg::RuleResult<Expr> {
         #![allow(non_snake_case, unused)]
         {
-            let __choice_res = {
-                let __seq_res = match ::peg::ParseLiteral::parse_string_literal(__input, __pos, "$")
-                {
-                    ::peg::RuleResult::Matched(__pos, __val) => {
-                        ::peg::RuleResult::Matched(__pos, __val)
-                    }
-                    ::peg::RuleResult::Failed => __err_state.mark_failure(__pos, "\"$\""),
-                };
-                match __seq_res {
-                    ::peg::RuleResult::Matched(__pos, _) => {
-                        let __seq_res = __parse_primary(__input, __state, __err_state, __pos);
-                        match __seq_res {
-                            ::peg::RuleResult::Matched(__pos, expression) => {
-                                ::peg::RuleResult::Matched(
-                                    __pos,
-                                    (|| MatchStrExpr(Box::new(expression)))(),
-                                )
-                            }
-                            ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
+            let __choice_res = match ::peg::ParseLiteral::parse_string_literal(__input, __pos, "$")
+            {
+                ::peg::RuleResult::Matched(__pos, __val) => {
+                    let __seq_res = __parse_primary(__input, __state, __err_state, __pos);
+                    match __seq_res {
+                        ::peg::RuleResult::Matched(__pos, expression) => {
+                            ::peg::RuleResult::Matched(
+                                __pos,
+                                (|| MatchStrExpr(Box::new(expression)))(),
+                            )
                         }
+                        ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
                     }
-                    ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
+                }
+                ::peg::RuleResult::Failed => {
+                    __err_state.mark_failure(__pos, "\"$\"");
+                    ::peg::RuleResult::Failed
                 }
             };
             match __choice_res {
@@ -2360,18 +1813,9 @@ pub mod peg {
                     ::peg::RuleResult::Matched(__pos, __value)
                 }
                 ::peg::RuleResult::Failed => {
-                    let __choice_res = {
-                        let __seq_res =
-                            match ::peg::ParseLiteral::parse_string_literal(__input, __pos, "&") {
-                                ::peg::RuleResult::Matched(__pos, __val) => {
-                                    ::peg::RuleResult::Matched(__pos, __val)
-                                }
-                                ::peg::RuleResult::Failed => {
-                                    __err_state.mark_failure(__pos, "\"&\"")
-                                }
-                            };
-                        match __seq_res {
-                            ::peg::RuleResult::Matched(__pos, _) => {
+                    let __choice_res =
+                        match ::peg::ParseLiteral::parse_string_literal(__input, __pos, "&") {
+                            ::peg::RuleResult::Matched(__pos, __val) => {
                                 let __seq_res =
                                     __parse_primary(__input, __state, __err_state, __pos);
                                 match __seq_res {
@@ -2384,40 +1828,35 @@ pub mod peg {
                                     ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
                                 }
                             }
-                            ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
-                        }
-                    };
+                            ::peg::RuleResult::Failed => {
+                                __err_state.mark_failure(__pos, "\"&\"");
+                                ::peg::RuleResult::Failed
+                            }
+                        };
                     match __choice_res {
                         ::peg::RuleResult::Matched(__pos, __value) => {
                             ::peg::RuleResult::Matched(__pos, __value)
                         }
                         ::peg::RuleResult::Failed => {
-                            let __choice_res = {
-                                let __seq_res = match ::peg::ParseLiteral::parse_string_literal(
-                                    __input, __pos, "!",
-                                ) {
-                                    ::peg::RuleResult::Matched(__pos, __val) => {
-                                        ::peg::RuleResult::Matched(__pos, __val)
-                                    }
-                                    ::peg::RuleResult::Failed => {
-                                        __err_state.mark_failure(__pos, "\"!\"")
-                                    }
-                                };
-                                match __seq_res {
-                                    ::peg::RuleResult::Matched(__pos, _) => {
-                                        let __seq_res =
-                                            __parse_primary(__input, __state, __err_state, __pos);
-                                        match __seq_res {
-                                            ::peg::RuleResult::Matched(__pos, expression) => {
-                                                ::peg::RuleResult::Matched(
-                                                    __pos,
-                                                    (|| NegAssertExpr(Box::new(expression)))(),
-                                                )
-                                            }
-                                            ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
+                            let __choice_res = match ::peg::ParseLiteral::parse_string_literal(
+                                __input, __pos, "!",
+                            ) {
+                                ::peg::RuleResult::Matched(__pos, __val) => {
+                                    let __seq_res =
+                                        __parse_primary(__input, __state, __err_state, __pos);
+                                    match __seq_res {
+                                        ::peg::RuleResult::Matched(__pos, expression) => {
+                                            ::peg::RuleResult::Matched(
+                                                __pos,
+                                                (|| NegAssertExpr(Box::new(expression)))(),
+                                            )
                                         }
+                                        ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
                                     }
-                                    ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
+                                }
+                                ::peg::RuleResult::Failed => {
+                                    __err_state.mark_failure(__pos, "\"!\"");
+                                    ::peg::RuleResult::Failed
                                 }
                             };
                             match __choice_res {
@@ -2445,83 +1884,27 @@ pub mod peg {
             return entry.clone();
         }
         let __rule_result = {
-            let __choice_res = {
-                let __seq_res =
-                    match ::peg::ParseLiteral::parse_string_literal(__input, __pos, "precedence") {
+            let __choice_res = match ::peg::ParseLiteral::parse_string_literal(
+                __input,
+                __pos,
+                "precedence",
+            ) {
+                ::peg::RuleResult::Matched(__pos, __val) => {
+                    match ::peg::ParseLiteral::parse_string_literal(__input, __pos, "!") {
                         ::peg::RuleResult::Matched(__pos, __val) => {
-                            ::peg::RuleResult::Matched(__pos, __val)
-                        }
-                        ::peg::RuleResult::Failed => {
-                            __err_state.mark_failure(__pos, "\"precedence\"")
-                        }
-                    };
-                match __seq_res {
-                    ::peg::RuleResult::Matched(__pos, _) => {
-                        let __seq_res =
-                            match ::peg::ParseLiteral::parse_string_literal(__input, __pos, "!") {
+                            match ::peg::ParseLiteral::parse_string_literal(__input, __pos, "{") {
                                 ::peg::RuleResult::Matched(__pos, __val) => {
-                                    ::peg::RuleResult::Matched(__pos, __val)
-                                }
-                                ::peg::RuleResult::Failed => {
-                                    __err_state.mark_failure(__pos, "\"!\"")
-                                }
-                            };
-                        match __seq_res {
-                            ::peg::RuleResult::Matched(__pos, _) => {
-                                let __seq_res = match ::peg::ParseLiteral::parse_string_literal(
-                                    __input, __pos, "{",
-                                ) {
-                                    ::peg::RuleResult::Matched(__pos, __val) => {
-                                        ::peg::RuleResult::Matched(__pos, __val)
-                                    }
-                                    ::peg::RuleResult::Failed => {
-                                        __err_state.mark_failure(__pos, "\"{\"")
-                                    }
-                                };
-                                match __seq_res {
-                                    ::peg::RuleResult::Matched(__pos, _) => {
-                                        let __seq_res = {
-                                            let mut __repeat_pos = __pos;
-                                            let mut __repeat_value = vec![];
-                                            loop {
-                                                let __pos = __repeat_pos;
-                                                let __pos = if __repeat_value.is_empty() {
-                                                    __pos
-                                                } else {
-                                                    let __sep_res = match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "--") { :: peg :: RuleResult :: Matched (__pos , __val) => :: peg :: RuleResult :: Matched (__pos , __val) , :: peg :: RuleResult :: Failed => __err_state . mark_failure (__pos , "\"--\"") } ;
-                                                    match __sep_res {
-                                                        ::peg::RuleResult::Matched(__newpos, _) => {
-                                                            __newpos
-                                                        }
-                                                        ::peg::RuleResult::Failed => break,
-                                                    }
-                                                };
-                                                let __step_res = __parse_precedence_level(
-                                                    __input,
-                                                    __state,
-                                                    __err_state,
-                                                    __pos,
-                                                );
-                                                match __step_res {
-                                                    ::peg::RuleResult::Matched(
-                                                        __newpos,
-                                                        __value,
-                                                    ) => {
-                                                        __repeat_pos = __newpos;
-                                                        __repeat_value.push(__value);
-                                                    }
-                                                    ::peg::RuleResult::Failed => {
-                                                        break;
-                                                    }
-                                                }
-                                            }
-                                            ::peg::RuleResult::Matched(__repeat_pos, __repeat_value)
-                                        };
-                                        match __seq_res {
-                                            ::peg::RuleResult::Matched(__pos, levels) => {
-                                                let __seq_res =
+                                    let __seq_res = {
+                                        let mut __repeat_pos = __pos;
+                                        let mut __repeat_value = vec![];
+                                        loop {
+                                            let __pos = __repeat_pos;
+                                            let __pos = if __repeat_value.is_empty() {
+                                                __pos
+                                            } else {
+                                                let __sep_res =
                                                     match ::peg::ParseLiteral::parse_string_literal(
-                                                        __input, __pos, "}",
+                                                        __input, __pos, "--",
                                                     ) {
                                                         ::peg::RuleResult::Matched(
                                                             __pos,
@@ -2530,32 +1913,71 @@ pub mod peg {
                                                             ::peg::RuleResult::Matched(__pos, __val)
                                                         }
                                                         ::peg::RuleResult::Failed => {
-                                                            __err_state.mark_failure(__pos, "\"}\"")
+                                                            __err_state
+                                                                .mark_failure(__pos, "\"--\"");
+                                                            ::peg::RuleResult::Failed
                                                         }
                                                     };
-                                                match __seq_res {
-                                                    ::peg::RuleResult::Matched(__pos, _) => {
-                                                        ::peg::RuleResult::Matched(
-                                                            __pos,
-                                                            (|| PrecedenceExpr { levels: levels })(
-                                                            ),
-                                                        )
+                                                match __sep_res {
+                                                    ::peg::RuleResult::Matched(__newpos, _) => {
+                                                        __newpos
                                                     }
-                                                    ::peg::RuleResult::Failed => {
-                                                        ::peg::RuleResult::Failed
-                                                    }
+                                                    ::peg::RuleResult::Failed => break,
+                                                }
+                                            };
+                                            let __step_res = __parse_precedence_level(
+                                                __input,
+                                                __state,
+                                                __err_state,
+                                                __pos,
+                                            );
+                                            match __step_res {
+                                                ::peg::RuleResult::Matched(__newpos, __value) => {
+                                                    __repeat_pos = __newpos;
+                                                    __repeat_value.push(__value);
+                                                }
+                                                ::peg::RuleResult::Failed => {
+                                                    break;
                                                 }
                                             }
-                                            ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
                                         }
+                                        ::peg::RuleResult::Matched(__repeat_pos, __repeat_value)
+                                    };
+                                    match __seq_res {
+                                        ::peg::RuleResult::Matched(__pos, levels) => {
+                                            match ::peg::ParseLiteral::parse_string_literal(
+                                                __input, __pos, "}",
+                                            ) {
+                                                ::peg::RuleResult::Matched(__pos, __val) => {
+                                                    ::peg::RuleResult::Matched(
+                                                        __pos,
+                                                        (|| PrecedenceExpr { levels: levels })(),
+                                                    )
+                                                }
+                                                ::peg::RuleResult::Failed => {
+                                                    __err_state.mark_failure(__pos, "\"}\"");
+                                                    ::peg::RuleResult::Failed
+                                                }
+                                            }
+                                        }
+                                        ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
                                     }
-                                    ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
+                                }
+                                ::peg::RuleResult::Failed => {
+                                    __err_state.mark_failure(__pos, "\"{\"");
+                                    ::peg::RuleResult::Failed
                                 }
                             }
-                            ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
+                        }
+                        ::peg::RuleResult::Failed => {
+                            __err_state.mark_failure(__pos, "\"!\"");
+                            ::peg::RuleResult::Failed
                         }
                     }
-                    ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
+                }
+                ::peg::RuleResult::Failed => {
+                    __err_state.mark_failure(__pos, "\"precedence\"");
+                    ::peg::RuleResult::Failed
                 }
             };
             match __choice_res {
@@ -2563,172 +1985,89 @@ pub mod peg {
                     ::peg::RuleResult::Matched(__pos, __value)
                 }
                 ::peg::RuleResult::Failed => {
-                    let __choice_res = {
-                        let __seq_res = match ::peg::ParseLiteral::parse_string_literal(
-                            __input, __pos, "position",
-                        ) {
+                    let __choice_res =
+                        match ::peg::ParseLiteral::parse_string_literal(__input, __pos, "position")
+                        {
                             ::peg::RuleResult::Matched(__pos, __val) => {
-                                ::peg::RuleResult::Matched(__pos, __val)
-                            }
-                            ::peg::RuleResult::Failed => {
-                                __err_state.mark_failure(__pos, "\"position\"")
-                            }
-                        };
-                        match __seq_res {
-                            ::peg::RuleResult::Matched(__pos, _) => {
-                                let __seq_res = match ::peg::ParseLiteral::parse_string_literal(
-                                    __input, __pos, "!",
-                                ) {
+                                match ::peg::ParseLiteral::parse_string_literal(__input, __pos, "!")
+                                {
                                     ::peg::RuleResult::Matched(__pos, __val) => {
-                                        ::peg::RuleResult::Matched(__pos, __val)
-                                    }
-                                    ::peg::RuleResult::Failed => {
-                                        __err_state.mark_failure(__pos, "\"!\"")
-                                    }
-                                };
-                                match __seq_res {
-                                    ::peg::RuleResult::Matched(__pos, _) => {
-                                        let __seq_res =
-                                            match ::peg::ParseLiteral::parse_string_literal(
-                                                __input, __pos, "(",
-                                            ) {
-                                                ::peg::RuleResult::Matched(__pos, __val) => {
-                                                    ::peg::RuleResult::Matched(__pos, __val)
-                                                }
-                                                ::peg::RuleResult::Failed => {
-                                                    __err_state.mark_failure(__pos, "\"(\"")
-                                                }
-                                            };
-                                        match __seq_res {
-                                            ::peg::RuleResult::Matched(__pos, _) => {
-                                                let __seq_res =
-                                                    match ::peg::ParseLiteral::parse_string_literal(
-                                                        __input, __pos, ")",
-                                                    ) {
-                                                        ::peg::RuleResult::Matched(
-                                                            __pos,
-                                                            __val,
-                                                        ) => {
-                                                            ::peg::RuleResult::Matched(__pos, __val)
-                                                        }
-                                                        ::peg::RuleResult::Failed => {
-                                                            __err_state.mark_failure(__pos, "\")\"")
-                                                        }
-                                                    };
-                                                match __seq_res {
-                                                    ::peg::RuleResult::Matched(__pos, _) => {
+                                        match ::peg::ParseLiteral::parse_string_literal(
+                                            __input, __pos, "(",
+                                        ) {
+                                            ::peg::RuleResult::Matched(__pos, __val) => {
+                                                match ::peg::ParseLiteral::parse_string_literal(
+                                                    __input, __pos, ")",
+                                                ) {
+                                                    ::peg::RuleResult::Matched(__pos, __val) => {
                                                         ::peg::RuleResult::Matched(
                                                             __pos,
                                                             (|| PositionExpr)(),
                                                         )
                                                     }
                                                     ::peg::RuleResult::Failed => {
+                                                        __err_state.mark_failure(__pos, "\")\"");
                                                         ::peg::RuleResult::Failed
                                                     }
                                                 }
                                             }
-                                            ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
+                                            ::peg::RuleResult::Failed => {
+                                                __err_state.mark_failure(__pos, "\"(\"");
+                                                ::peg::RuleResult::Failed
+                                            }
                                         }
                                     }
-                                    ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
+                                    ::peg::RuleResult::Failed => {
+                                        __err_state.mark_failure(__pos, "\"!\"");
+                                        ::peg::RuleResult::Failed
+                                    }
                                 }
                             }
-                            ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
-                        }
-                    };
+                            ::peg::RuleResult::Failed => {
+                                __err_state.mark_failure(__pos, "\"position\"");
+                                ::peg::RuleResult::Failed
+                            }
+                        };
                     match __choice_res {
                         ::peg::RuleResult::Matched(__pos, __value) => {
                             ::peg::RuleResult::Matched(__pos, __value)
                         }
                         ::peg::RuleResult::Failed => {
-                            let __choice_res = {
-                                let __seq_res = match ::peg::ParseLiteral::parse_string_literal(
-                                    __input, __pos, "quiet",
-                                ) {
-                                    ::peg::RuleResult::Matched(__pos, __val) => {
-                                        ::peg::RuleResult::Matched(__pos, __val)
-                                    }
-                                    ::peg::RuleResult::Failed => {
-                                        __err_state.mark_failure(__pos, "\"quiet\"")
-                                    }
-                                };
-                                match __seq_res {
-                                    ::peg::RuleResult::Matched(__pos, _) => {
-                                        let __seq_res =
+                            let __choice_res = match ::peg::ParseLiteral::parse_string_literal(
+                                __input, __pos, "quiet",
+                            ) {
+                                ::peg::RuleResult::Matched(__pos, __val) => {
+                                    match ::peg::ParseLiteral::parse_string_literal(
+                                        __input, __pos, "!",
+                                    ) {
+                                        ::peg::RuleResult::Matched(__pos, __val) => {
                                             match ::peg::ParseLiteral::parse_string_literal(
-                                                __input, __pos, "!",
+                                                __input, __pos, "{",
                                             ) {
                                                 ::peg::RuleResult::Matched(__pos, __val) => {
-                                                    ::peg::RuleResult::Matched(__pos, __val)
+                                                    let __seq_res = __parse_expression(
+                                                        __input,
+                                                        __state,
+                                                        __err_state,
+                                                        __pos,
+                                                    );
+                                                    match __seq_res { :: peg :: RuleResult :: Matched (__pos , e) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "}") { :: peg :: RuleResult :: Matched (__pos , __val) => { :: peg :: RuleResult :: Matched (__pos , (|| { QuietExpr (Box :: new (e)) }) ()) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"}\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , }
                                                 }
                                                 ::peg::RuleResult::Failed => {
-                                                    __err_state.mark_failure(__pos, "\"!\"")
-                                                }
-                                            };
-                                        match __seq_res {
-                                            ::peg::RuleResult::Matched(__pos, _) => {
-                                                let __seq_res =
-                                                    match ::peg::ParseLiteral::parse_string_literal(
-                                                        __input, __pos, "{",
-                                                    ) {
-                                                        ::peg::RuleResult::Matched(
-                                                            __pos,
-                                                            __val,
-                                                        ) => {
-                                                            ::peg::RuleResult::Matched(__pos, __val)
-                                                        }
-                                                        ::peg::RuleResult::Failed => {
-                                                            __err_state.mark_failure(__pos, "\"{\"")
-                                                        }
-                                                    };
-                                                match __seq_res {
-                                                    ::peg::RuleResult::Matched(__pos, _) => {
-                                                        let __seq_res = __parse_expression(
-                                                            __input,
-                                                            __state,
-                                                            __err_state,
-                                                            __pos,
-                                                        );
-                                                        match __seq_res {
-                                                            ::peg::RuleResult::Matched(
-                                                                __pos,
-                                                                e,
-                                                            ) => {
-                                                                let __seq_res = match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "}") { :: peg :: RuleResult :: Matched (__pos , __val) => :: peg :: RuleResult :: Matched (__pos , __val) , :: peg :: RuleResult :: Failed => __err_state . mark_failure (__pos , "\"}\"") } ;
-                                                                match __seq_res {
-                                                                    ::peg::RuleResult::Matched(
-                                                                        __pos,
-                                                                        _,
-                                                                    ) => {
-                                                                        ::peg::RuleResult::Matched(
-                                                                            __pos,
-                                                                            (|| {
-                                                                                QuietExpr(Box::new(
-                                                                                    e,
-                                                                                ))
-                                                                            })(
-                                                                            ),
-                                                                        )
-                                                                    }
-                                                                    ::peg::RuleResult::Failed => {
-                                                                        ::peg::RuleResult::Failed
-                                                                    }
-                                                                }
-                                                            }
-                                                            ::peg::RuleResult::Failed => {
-                                                                ::peg::RuleResult::Failed
-                                                            }
-                                                        }
-                                                    }
-                                                    ::peg::RuleResult::Failed => {
-                                                        ::peg::RuleResult::Failed
-                                                    }
+                                                    __err_state.mark_failure(__pos, "\"{\"");
+                                                    ::peg::RuleResult::Failed
                                                 }
                                             }
-                                            ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
+                                        }
+                                        ::peg::RuleResult::Failed => {
+                                            __err_state.mark_failure(__pos, "\"!\"");
+                                            ::peg::RuleResult::Failed
                                         }
                                     }
-                                    ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
+                                }
+                                ::peg::RuleResult::Failed => {
+                                    __err_state.mark_failure(__pos, "\"quiet\"");
+                                    ::peg::RuleResult::Failed
                                 }
                             };
                             match __choice_res {
@@ -2736,74 +2075,7 @@ pub mod peg {
                                     ::peg::RuleResult::Matched(__pos, __value)
                                 }
                                 ::peg::RuleResult::Failed => {
-                                    let __choice_res = {
-                                        let __seq_res =
-                                            match ::peg::ParseLiteral::parse_string_literal(
-                                                __input, __pos, "expected",
-                                            ) {
-                                                ::peg::RuleResult::Matched(__pos, __val) => {
-                                                    ::peg::RuleResult::Matched(__pos, __val)
-                                                }
-                                                ::peg::RuleResult::Failed => {
-                                                    __err_state.mark_failure(__pos, "\"expected\"")
-                                                }
-                                            };
-                                        match __seq_res {
-                                            ::peg::RuleResult::Matched(__pos, _) => {
-                                                let __seq_res =
-                                                    match ::peg::ParseLiteral::parse_string_literal(
-                                                        __input, __pos, "!",
-                                                    ) {
-                                                        ::peg::RuleResult::Matched(
-                                                            __pos,
-                                                            __val,
-                                                        ) => {
-                                                            ::peg::RuleResult::Matched(__pos, __val)
-                                                        }
-                                                        ::peg::RuleResult::Failed => {
-                                                            __err_state.mark_failure(__pos, "\"!\"")
-                                                        }
-                                                    };
-                                                match __seq_res {
-                                                    ::peg::RuleResult::Matched(__pos, _) => {
-                                                        let __seq_res = match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "(") { :: peg :: RuleResult :: Matched (__pos , __val) => :: peg :: RuleResult :: Matched (__pos , __val) , :: peg :: RuleResult :: Failed => __err_state . mark_failure (__pos , "\"(\"") } ;
-                                                        match __seq_res {
-                                                            ::peg::RuleResult::Matched(
-                                                                __pos,
-                                                                _,
-                                                            ) => {
-                                                                let __seq_res = __parse_LITERAL(
-                                                                    __input,
-                                                                    __state,
-                                                                    __err_state,
-                                                                    __pos,
-                                                                );
-                                                                match __seq_res {
-                                                                    ::peg::RuleResult::Matched(
-                                                                        __pos,
-                                                                        s,
-                                                                    ) => {
-                                                                        let __seq_res = match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , ")") { :: peg :: RuleResult :: Matched (__pos , __val) => :: peg :: RuleResult :: Matched (__pos , __val) , :: peg :: RuleResult :: Failed => __err_state . mark_failure (__pos , "\")\"") } ;
-                                                                        match __seq_res { :: peg :: RuleResult :: Matched (__pos , _) => { :: peg :: RuleResult :: Matched (__pos , (|| { FailExpr (s) }) ()) } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , }
-                                                                    }
-                                                                    ::peg::RuleResult::Failed => {
-                                                                        ::peg::RuleResult::Failed
-                                                                    }
-                                                                }
-                                                            }
-                                                            ::peg::RuleResult::Failed => {
-                                                                ::peg::RuleResult::Failed
-                                                            }
-                                                        }
-                                                    }
-                                                    ::peg::RuleResult::Failed => {
-                                                        ::peg::RuleResult::Failed
-                                                    }
-                                                }
-                                            }
-                                            ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
-                                        }
-                                    };
+                                    let __choice_res = match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "expected") { :: peg :: RuleResult :: Matched (__pos , __val) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "!") { :: peg :: RuleResult :: Matched (__pos , __val) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "(") { :: peg :: RuleResult :: Matched (__pos , __val) => { { let __seq_res = __parse_LITERAL (__input , __state , __err_state , __pos) ; match __seq_res { :: peg :: RuleResult :: Matched (__pos , s) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , ")") { :: peg :: RuleResult :: Matched (__pos , __val) => { :: peg :: RuleResult :: Matched (__pos , (|| { FailExpr (s) }) ()) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\")\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"(\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"!\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"expected\"") ; :: peg :: RuleResult :: Failed } } ;
                                     match __choice_res {
                                         ::peg::RuleResult::Matched(__pos, __value) => {
                                             ::peg::RuleResult::Matched(__pos, __value)
@@ -2813,7 +2085,7 @@ pub mod peg {
                                                 let __seq_res = {
                                                     __err_state.suppress_fail += 1;
                                                     let __assert_res = {
-                                                        let __choice_res = match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "_") { :: peg :: RuleResult :: Matched (__pos , __val) => :: peg :: RuleResult :: Matched (__pos , __val) , :: peg :: RuleResult :: Failed => __err_state . mark_failure (__pos , "\"_\"") } ;
+                                                        let __choice_res = match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "_") { :: peg :: RuleResult :: Matched (__pos , __val) => { :: peg :: RuleResult :: Matched (__pos , __val) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"_\"") ; :: peg :: RuleResult :: Failed } } ;
                                                         match __choice_res {
                                                             ::peg::RuleResult::Matched(
                                                                 __pos,
@@ -2822,8 +2094,8 @@ pub mod peg {
                                                                 __pos, __value,
                                                             ),
                                                             ::peg::RuleResult::Failed => {
-                                                                let __choice_res = match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "__") { :: peg :: RuleResult :: Matched (__pos , __val) => :: peg :: RuleResult :: Matched (__pos , __val) , :: peg :: RuleResult :: Failed => __err_state . mark_failure (__pos , "\"__\"") } ;
-                                                                match __choice_res { :: peg :: RuleResult :: Matched (__pos , __value) => :: peg :: RuleResult :: Matched (__pos , __value) , :: peg :: RuleResult :: Failed => match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "___") { :: peg :: RuleResult :: Matched (__pos , __val) => :: peg :: RuleResult :: Matched (__pos , __val) , :: peg :: RuleResult :: Failed => __err_state . mark_failure (__pos , "\"___\"") } }
+                                                                let __choice_res = match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "__") { :: peg :: RuleResult :: Matched (__pos , __val) => { :: peg :: RuleResult :: Matched (__pos , __val) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"__\"") ; :: peg :: RuleResult :: Failed } } ;
+                                                                match __choice_res { :: peg :: RuleResult :: Matched (__pos , __value) => :: peg :: RuleResult :: Matched (__pos , __value) , :: peg :: RuleResult :: Failed => match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "___") { :: peg :: RuleResult :: Matched (__pos , __val) => { :: peg :: RuleResult :: Matched (__pos , __val) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"___\"") ; :: peg :: RuleResult :: Failed } } }
                                                             }
                                                         }
                                                     };
@@ -2877,42 +2149,7 @@ pub mod peg {
                                                             __err_state,
                                                             __pos,
                                                         );
-                                                        match __seq_res {
-                                                            ::peg::RuleResult::Matched(
-                                                                __pos,
-                                                                name,
-                                                            ) => {
-                                                                let __seq_res = match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "(") { :: peg :: RuleResult :: Matched (__pos , __val) => :: peg :: RuleResult :: Matched (__pos , __val) , :: peg :: RuleResult :: Failed => __err_state . mark_failure (__pos , "\"(\"") } ;
-                                                                match __seq_res {
-                                                                    ::peg::RuleResult::Matched(
-                                                                        __pos,
-                                                                        _,
-                                                                    ) => {
-                                                                        let __seq_res = {
-                                                                            let mut __repeat_pos =
-                                                                                __pos;
-                                                                            let mut __repeat_value =
-                                                                                vec![];
-                                                                            loop {
-                                                                                let __pos =
-                                                                                    __repeat_pos;
-                                                                                let __pos = if __repeat_value . is_empty () { __pos } else { let __sep_res = match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , ",") { :: peg :: RuleResult :: Matched (__pos , __val) => :: peg :: RuleResult :: Matched (__pos , __val) , :: peg :: RuleResult :: Failed => __err_state . mark_failure (__pos , "\",\"") } ; match __sep_res { :: peg :: RuleResult :: Matched (__newpos , _) => { __newpos } , :: peg :: RuleResult :: Failed => break , } } ;
-                                                                                let __step_res = __parse_rule_arg (__input , __state , __err_state , __pos) ;
-                                                                                match __step_res { :: peg :: RuleResult :: Matched (__newpos , __value) => { __repeat_pos = __newpos ; __repeat_value . push (__value) ; } , :: peg :: RuleResult :: Failed => { break ; } }
-                                                                            }
-                                                                            :: peg :: RuleResult :: Matched (__repeat_pos , __repeat_value)
-                                                                        };
-                                                                        match __seq_res { :: peg :: RuleResult :: Matched (__pos , args) => { { let __seq_res = match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , ")") { :: peg :: RuleResult :: Matched (__pos , __val) => :: peg :: RuleResult :: Matched (__pos , __val) , :: peg :: RuleResult :: Failed => __err_state . mark_failure (__pos , "\")\"") } ; match __seq_res { :: peg :: RuleResult :: Matched (__pos , _) => { :: peg :: RuleResult :: Matched (__pos , (|| { RuleExpr (name , args) }) ()) } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , }
-                                                                    }
-                                                                    ::peg::RuleResult::Failed => {
-                                                                        ::peg::RuleResult::Failed
-                                                                    }
-                                                                }
-                                                            }
-                                                            ::peg::RuleResult::Failed => {
-                                                                ::peg::RuleResult::Failed
-                                                            }
-                                                        }
+                                                        match __seq_res { :: peg :: RuleResult :: Matched (__pos , name) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "(") { :: peg :: RuleResult :: Matched (__pos , __val) => { { let __seq_res = { let mut __repeat_pos = __pos ; let mut __repeat_value = vec ! () ; loop { let __pos = __repeat_pos ; let __pos = if __repeat_value . is_empty () { __pos } else { let __sep_res = match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , ",") { :: peg :: RuleResult :: Matched (__pos , __val) => { :: peg :: RuleResult :: Matched (__pos , __val) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\",\"") ; :: peg :: RuleResult :: Failed } } ; match __sep_res { :: peg :: RuleResult :: Matched (__newpos , _) => { __newpos } , :: peg :: RuleResult :: Failed => break , } } ; let __step_res = __parse_rule_arg (__input , __state , __err_state , __pos) ; match __step_res { :: peg :: RuleResult :: Matched (__newpos , __value) => { __repeat_pos = __newpos ; __repeat_value . push (__value) ; } , :: peg :: RuleResult :: Failed => { break ; } } } :: peg :: RuleResult :: Matched (__repeat_pos , __repeat_value) } ; match __seq_res { :: peg :: RuleResult :: Matched (__pos , args) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , ")") { :: peg :: RuleResult :: Matched (__pos , __val) => { :: peg :: RuleResult :: Matched (__pos , (|| { RuleExpr (name , args) }) ()) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\")\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"(\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , }
                                                     };
                                                     match __choice_res {
                                                         ::peg::RuleResult::Matched(
@@ -2962,7 +2199,7 @@ pub mod peg {
                                                                             );
                                                                         match __seq_res { :: peg :: RuleResult :: Matched (__pos , p) => { :: peg :: RuleResult :: Matched (__pos , (|| { PatternExpr (p) }) ()) } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , }
                                                                     };
-                                                                    match __choice_res { :: peg :: RuleResult :: Matched (__pos , __value) => :: peg :: RuleResult :: Matched (__pos , __value) , :: peg :: RuleResult :: Failed => { let __choice_res = { let __seq_res = match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "(") { :: peg :: RuleResult :: Matched (__pos , __val) => :: peg :: RuleResult :: Matched (__pos , __val) , :: peg :: RuleResult :: Failed => __err_state . mark_failure (__pos , "\"(\"") } ; match __seq_res { :: peg :: RuleResult :: Matched (__pos , _) => { { let __seq_res = match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "@") { :: peg :: RuleResult :: Matched (__pos , __val) => :: peg :: RuleResult :: Matched (__pos , __val) , :: peg :: RuleResult :: Failed => __err_state . mark_failure (__pos , "\"@\"") } ; match __seq_res { :: peg :: RuleResult :: Matched (__pos , _) => { { let __seq_res = match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , ")") { :: peg :: RuleResult :: Matched (__pos , __val) => :: peg :: RuleResult :: Matched (__pos , __val) , :: peg :: RuleResult :: Failed => __err_state . mark_failure (__pos , "\")\"") } ; match __seq_res { :: peg :: RuleResult :: Matched (__pos , _) => { :: peg :: RuleResult :: Matched (__pos , (|| { MarkerExpr (true) }) ()) } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } ; match __choice_res { :: peg :: RuleResult :: Matched (__pos , __value) => :: peg :: RuleResult :: Matched (__pos , __value) , :: peg :: RuleResult :: Failed => { let __choice_res = { let __seq_res = match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "@") { :: peg :: RuleResult :: Matched (__pos , __val) => :: peg :: RuleResult :: Matched (__pos , __val) , :: peg :: RuleResult :: Failed => __err_state . mark_failure (__pos , "\"@\"") } ; match __seq_res { :: peg :: RuleResult :: Matched (__pos , _) => { :: peg :: RuleResult :: Matched (__pos , (|| { MarkerExpr (false) }) ()) } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } ; match __choice_res { :: peg :: RuleResult :: Matched (__pos , __value) => :: peg :: RuleResult :: Matched (__pos , __value) , :: peg :: RuleResult :: Failed => { let __choice_res = { let __seq_res = match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "##") { :: peg :: RuleResult :: Matched (__pos , __val) => :: peg :: RuleResult :: Matched (__pos , __val) , :: peg :: RuleResult :: Failed => __err_state . mark_failure (__pos , "\"##\"") } ; match __seq_res { :: peg :: RuleResult :: Matched (__pos , _) => { { let __seq_res = __parse_IDENT (__input , __state , __err_state , __pos) ; match __seq_res { :: peg :: RuleResult :: Matched (__pos , method) => { { let __seq_res = __parse_PAREN_GROUP (__input , __state , __err_state , __pos) ; match __seq_res { :: peg :: RuleResult :: Matched (__pos , args) => { :: peg :: RuleResult :: Matched (__pos , (|| { MethodExpr (method , args . stream ()) }) ()) } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } ; match __choice_res { :: peg :: RuleResult :: Matched (__pos , __value) => :: peg :: RuleResult :: Matched (__pos , __value) , :: peg :: RuleResult :: Failed => { let __seq_res = match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "(") { :: peg :: RuleResult :: Matched (__pos , __val) => :: peg :: RuleResult :: Matched (__pos , __val) , :: peg :: RuleResult :: Failed => __err_state . mark_failure (__pos , "\"(\"") } ; match __seq_res { :: peg :: RuleResult :: Matched (__pos , _) => { { let __seq_res = __parse_expression (__input , __state , __err_state , __pos) ; match __seq_res { :: peg :: RuleResult :: Matched (__pos , expression) => { { let __seq_res = match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , ")") { :: peg :: RuleResult :: Matched (__pos , __val) => :: peg :: RuleResult :: Matched (__pos , __val) , :: peg :: RuleResult :: Failed => __err_state . mark_failure (__pos , "\")\"") } ; match __seq_res { :: peg :: RuleResult :: Matched (__pos , _) => { :: peg :: RuleResult :: Matched (__pos , (|| { expression }) ()) } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } } } } } } } }
+                                                                    match __choice_res { :: peg :: RuleResult :: Matched (__pos , __value) => :: peg :: RuleResult :: Matched (__pos , __value) , :: peg :: RuleResult :: Failed => { let __choice_res = match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "(") { :: peg :: RuleResult :: Matched (__pos , __val) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "@") { :: peg :: RuleResult :: Matched (__pos , __val) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , ")") { :: peg :: RuleResult :: Matched (__pos , __val) => { :: peg :: RuleResult :: Matched (__pos , (|| { MarkerExpr (true) }) ()) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\")\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"@\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"(\"") ; :: peg :: RuleResult :: Failed } } ; match __choice_res { :: peg :: RuleResult :: Matched (__pos , __value) => :: peg :: RuleResult :: Matched (__pos , __value) , :: peg :: RuleResult :: Failed => { let __choice_res = match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "@") { :: peg :: RuleResult :: Matched (__pos , __val) => { :: peg :: RuleResult :: Matched (__pos , (|| { MarkerExpr (false) }) ()) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"@\"") ; :: peg :: RuleResult :: Failed } } ; match __choice_res { :: peg :: RuleResult :: Matched (__pos , __value) => :: peg :: RuleResult :: Matched (__pos , __value) , :: peg :: RuleResult :: Failed => { let __choice_res = match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "##") { :: peg :: RuleResult :: Matched (__pos , __val) => { { let __seq_res = __parse_IDENT (__input , __state , __err_state , __pos) ; match __seq_res { :: peg :: RuleResult :: Matched (__pos , method) => { { let __seq_res = __parse_PAREN_GROUP (__input , __state , __err_state , __pos) ; match __seq_res { :: peg :: RuleResult :: Matched (__pos , args) => { :: peg :: RuleResult :: Matched (__pos , (|| { MethodExpr (method , args . stream ()) }) ()) } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"##\"") ; :: peg :: RuleResult :: Failed } } ; match __choice_res { :: peg :: RuleResult :: Matched (__pos , __value) => :: peg :: RuleResult :: Matched (__pos , __value) , :: peg :: RuleResult :: Failed => match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "(") { :: peg :: RuleResult :: Matched (__pos , __val) => { { let __seq_res = __parse_expression (__input , __state , __err_state , __pos) ; match __seq_res { :: peg :: RuleResult :: Matched (__pos , expression) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , ")") { :: peg :: RuleResult :: Matched (__pos , __val) => { :: peg :: RuleResult :: Matched (__pos , (|| { expression }) ()) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\")\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"(\"") ; :: peg :: RuleResult :: Failed } } } } } } } } }
                                                                 }
                                                             }
                                                         }
@@ -2989,40 +2226,28 @@ pub mod peg {
     ) -> ::peg::RuleResult<RuleArg> {
         #![allow(non_snake_case, unused)]
         {
-            let __choice_res = {
-                let __seq_res = match ::peg::ParseLiteral::parse_string_literal(__input, __pos, "<")
-                {
-                    ::peg::RuleResult::Matched(__pos, __val) => {
-                        ::peg::RuleResult::Matched(__pos, __val)
-                    }
-                    ::peg::RuleResult::Failed => __err_state.mark_failure(__pos, "\"<\""),
-                };
-                match __seq_res {
-                    ::peg::RuleResult::Matched(__pos, _) => {
-                        let __seq_res = __parse_expression(__input, __state, __err_state, __pos);
-                        match __seq_res {
-                            ::peg::RuleResult::Matched(__pos, e) => {
-                                let __seq_res = match ::peg::ParseLiteral::parse_string_literal(
-                                    __input, __pos, ">",
-                                ) {
-                                    ::peg::RuleResult::Matched(__pos, __val) => {
-                                        ::peg::RuleResult::Matched(__pos, __val)
-                                    }
-                                    ::peg::RuleResult::Failed => {
-                                        __err_state.mark_failure(__pos, "\">\"")
-                                    }
-                                };
-                                match __seq_res {
-                                    ::peg::RuleResult::Matched(__pos, _) => {
-                                        ::peg::RuleResult::Matched(__pos, (|| RuleArg::Peg(e))())
-                                    }
-                                    ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
+            let __choice_res = match ::peg::ParseLiteral::parse_string_literal(__input, __pos, "<")
+            {
+                ::peg::RuleResult::Matched(__pos, __val) => {
+                    let __seq_res = __parse_expression(__input, __state, __err_state, __pos);
+                    match __seq_res {
+                        ::peg::RuleResult::Matched(__pos, e) => {
+                            match ::peg::ParseLiteral::parse_string_literal(__input, __pos, ">") {
+                                ::peg::RuleResult::Matched(__pos, __val) => {
+                                    ::peg::RuleResult::Matched(__pos, (|| RuleArg::Peg(e))())
+                                }
+                                ::peg::RuleResult::Failed => {
+                                    __err_state.mark_failure(__pos, "\">\"");
+                                    ::peg::RuleResult::Failed
                                 }
                             }
-                            ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
                         }
+                        ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
                     }
-                    ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
+                }
+                ::peg::RuleResult::Failed => {
+                    __err_state.mark_failure(__pos, "\"<\"");
+                    ::peg::RuleResult::Failed
                 }
             };
             match __choice_res {
@@ -3187,7 +2412,10 @@ pub mod peg {
                     ::peg::RuleResult::Matched(__pos, __val) => {
                         ::peg::RuleResult::Matched(__pos, __val)
                     }
-                    ::peg::RuleResult::Failed => __err_state.mark_failure(__pos, "\"pub\""),
+                    ::peg::RuleResult::Failed => {
+                        __err_state.mark_failure(__pos, "\"pub\"");
+                        ::peg::RuleResult::Failed
+                    }
                 };
             match __choice_res {
                 ::peg::RuleResult::Matched(__pos, __value) => {
@@ -3200,7 +2428,8 @@ pub mod peg {
                                 ::peg::RuleResult::Matched(__pos, __val)
                             }
                             ::peg::RuleResult::Failed => {
-                                __err_state.mark_failure(__pos, "\"crate\"")
+                                __err_state.mark_failure(__pos, "\"crate\"");
+                                ::peg::RuleResult::Failed
                             }
                         };
                     match __choice_res {
@@ -3215,7 +2444,8 @@ pub mod peg {
                                     ::peg::RuleResult::Matched(__pos, __val)
                                 }
                                 ::peg::RuleResult::Failed => {
-                                    __err_state.mark_failure(__pos, "\"rule\"")
+                                    __err_state.mark_failure(__pos, "\"rule\"");
+                                    ::peg::RuleResult::Failed
                                 }
                             };
                             match __choice_res {
@@ -3231,7 +2461,8 @@ pub mod peg {
                                                 ::peg::RuleResult::Matched(__pos, __val)
                                             }
                                             ::peg::RuleResult::Failed => {
-                                                __err_state.mark_failure(__pos, "\"use\"")
+                                                __err_state.mark_failure(__pos, "\"use\"");
+                                                ::peg::RuleResult::Failed
                                             }
                                         };
                                     match __choice_res {
@@ -3246,7 +2477,8 @@ pub mod peg {
                                                     ::peg::RuleResult::Matched(__pos, __val)
                                                 }
                                                 ::peg::RuleResult::Failed => {
-                                                    __err_state.mark_failure(__pos, "\"type\"")
+                                                    __err_state.mark_failure(__pos, "\"type\"");
+                                                    ::peg::RuleResult::Failed
                                                 }
                                             }
                                         }
@@ -3336,27 +2568,20 @@ pub mod peg {
         __pos: usize,
     ) -> ::peg::RuleResult<()> {
         #![allow(non_snake_case, unused)]
-        {
-            let __seq_res = match ::peg::ParseLiteral::parse_string_literal(__input, __pos, "'") {
-                ::peg::RuleResult::Matched(__pos, __val) => {
-                    ::peg::RuleResult::Matched(__pos, __val)
+        match ::peg::ParseLiteral::parse_string_literal(__input, __pos, "'") {
+            ::peg::RuleResult::Matched(__pos, __val) => {
+                let __seq_res = match __parse_IDENT(__input, __state, __err_state, __pos) {
+                    ::peg::RuleResult::Matched(pos, _) => ::peg::RuleResult::Matched(pos, ()),
+                    ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
+                };
+                match __seq_res {
+                    ::peg::RuleResult::Matched(__pos, _) => ::peg::RuleResult::Matched(__pos, ()),
+                    ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
                 }
-                ::peg::RuleResult::Failed => __err_state.mark_failure(__pos, "\"'\""),
-            };
-            match __seq_res {
-                ::peg::RuleResult::Matched(__pos, _) => {
-                    let __seq_res = match __parse_IDENT(__input, __state, __err_state, __pos) {
-                        ::peg::RuleResult::Matched(pos, _) => ::peg::RuleResult::Matched(pos, ()),
-                        ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
-                    };
-                    match __seq_res {
-                        ::peg::RuleResult::Matched(__pos, _) => {
-                            ::peg::RuleResult::Matched(__pos, ())
-                        }
-                        ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
-                    }
-                }
-                ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
+            }
+            ::peg::RuleResult::Failed => {
+                __err_state.mark_failure(__pos, "\"'\"");
+                ::peg::RuleResult::Failed
             }
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,7 +63,9 @@
 //!
 //!   * `"keyword"` - _Literal:_ match a literal string.
 //!   * `['0'..='9']`  - _Pattern:_ match a single element that matches a Rust `match`-style
-//!     pattern. [(details)](#match-expressions)
+//!     pattern. [(details)](#pattern-expressions)
+//!   * `[^ '0'..='9']`  - _Inverted pattern:_ match a single element that does not match a Rust `match`-style
+//!     pattern. [(details)](#pattern-expressions)
 //!   * `some_rule()` - _Rule:_ match a rule defined elsewhere in the grammar and return its
 //!     result. Arguments in the parentheses are Rust expressions.
 //!   * `_` or `__` or `___` - _Rule (underscore):_ As a special case, rule names
@@ -130,7 +132,8 @@
 //!
 //! The `[pat]` syntax expands into a [Rust `match`
 //! pattern](https://doc.rust-lang.org/book/ch18-03-pattern-syntax.html) against the next character
-//! (or element) of the input.
+//! (or element) of the input. When the pattern begins with `^`, the matching behavior is inverted:
+//! the expression succeeds only if the pattern does *not* match.
 //!
 //! To match sets of characters, use Rust's `..=` inclusive range pattern
 //! syntax and `|` to match multiple patterns. For example `['a'..='z' | 'A'..='Z']` matches an

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -141,6 +141,9 @@
 //!
 //! If your input type is a slice of an enum type, a pattern could match an enum variant like
 //! `[Token::Operator('+')]`.
+//! 
+//! Variables captured by the pattern are accessible in a subsequent action
+//! block: `[Token::Integer(i)] { i }`
 //!
 //! `[_]` matches any single element. As this always matches except at end-of-file, combining it
 //! with negative lookahead as `![_]` is the idiom for matching EOF in PEG.

--- a/tests/run-pass/pattern.rs
+++ b/tests/run-pass/pattern.rs
@@ -1,0 +1,12 @@
+peg::parser!( grammar test() for str {
+    pub rule alphanumeric() = ['a'..='z' | 'A'..='Z' | '0'..='9']*
+    pub rule inverted_pat() -> &'input str = "(" s:$([^')']*) ")" {s}
+});
+
+fn main() {
+    assert!(test::alphanumeric("azAZ09").is_ok());
+    assert!(test::alphanumeric("@").is_err());
+
+    assert_eq!(test::inverted_pat("(asdf)"), Ok("asdf"));
+}
+

--- a/tests/run-pass/tokens.rs
+++ b/tests/run-pass/tokens.rs
@@ -1,0 +1,17 @@
+#[derive(Clone)]
+pub enum Token {
+    Open,
+    Number(i32),
+    Comma,
+    Close,
+}
+
+peg::parser!{
+    grammar tokenparser() for [Token] {
+        pub rule list() -> (i32, i32) = [Token::Open] [Token::Number(a)] [Token::Comma] [Token::Number(b)] [Token::Close] { (a, b) }
+    }
+}
+
+fn main() {
+    assert_eq!(tokenparser::list(&[Token::Open, Token::Number(5), Token::Comma, Token::Number(7), Token::Close]), Ok((5, 7)));
+}


### PR DESCRIPTION
This changes the expansion of pattern expressions when used in a labeled
sequence such that the remainder of the sequence is lexically within the
match arm so that the variable is in scope.

Literal expressions are also included for the sake of generating nicer
code by not generating RuleResult in a `match` that is itself
immediately matched upon.

Fixes #227

