### PR TITLE
Indent trace statements for readability

### DIFF
--- a/peg-macros/translate.rs
+++ b/peg-macros/translate.rs
@@ -132,8 +132,39 @@ fn make_parse_state(grammar: &Grammar) -> TokenStream {
         }
     }
 
+    let (trace_def, trace_set, trace_push_pop) = if cfg!(feature = "trace") {
+        (
+            quote! { __trace_depth: usize, },
+            quote! { __trace_depth: 1, },
+            quote! {
+                fn __indent_depth(&self) -> usize {
+                    self.__trace_depth
+                }
+                fn __trace_print(&self) {
+                    print!("[PEG_TRACE]");
+                    for _ in 0..self.__trace_depth {
+                        print!(" ");
+                    }
+                }
+                fn __trace_push(&mut self) {
+                    self.__trace_depth += 1;
+                }
+                fn __trace_pop(&mut self) {
+                    self.__trace_depth -= 1;
+                }
+            },
+        )
+    } else {
+        (
+            quote! { },
+            quote! { },
+            quote! { },
+        )
+    };
+
     quote! {
         struct ParseState<'input> {
+            #trace_def
             _phantom: ::std::marker::PhantomData<&'input ()>,
             #(#cache_fields_def),*
         }
@@ -141,10 +172,12 @@ fn make_parse_state(grammar: &Grammar) -> TokenStream {
         impl<'input> ParseState<'input> {
             fn new() -> ParseState<'input> {
                 ParseState {
+                    #trace_set
                     _phantom: ::std::marker::PhantomData,
                     #(#cache_fields: ::std::collections::HashMap::new()),*
                 }
             }
+            #trace_push_pop
         }
     }
 }
@@ -179,16 +212,20 @@ fn compile_rule(context: &Context, rule: &Rule) -> TokenStream {
         let str_rule_name = rule_name.to_string();
         quote! {{
             let loc = ::peg::Parse::position_repr(__input, __pos);
-            println!("[PEG_TRACE] Attempting to match rule `{}` at {}", #str_rule_name, loc);
+            let indent = __state.__indent_depth();
+            __state.__trace_print();
+            println!("Attempting to match rule `{}` at {} {{", #str_rule_name, loc);
             let __peg_result: ::peg::RuleResult<#ret_ty> = {#body};
             match __peg_result {
                 ::peg::RuleResult::Matched(epos, v) => {
                     let eloc = ::peg::Parse::position_repr(__input, epos);
-                    println!("[PEG_TRACE] Matched rule `{}` at {} to {}", #str_rule_name, loc, eloc);
+                    __state.__trace_print();
+                    println!("}} Matched rule `{}` at {} to {}", #str_rule_name, loc, eloc);
                     ::peg::RuleResult::Matched(epos, v)
                 }
                 ::peg::RuleResult::Failed => {
-                    println!("[PEG_TRACE] Failed to match rule `{}` at {}", #str_rule_name, loc);
+                    __state.__trace_print();
+                    println!("}} Failed to match rule `{}` at {}", #str_rule_name, loc);
                     ::peg::RuleResult::Failed
                 }
             }
@@ -209,8 +246,14 @@ fn compile_rule(context: &Context, rule: &Rule) -> TokenStream {
             quote! {
                 let loc = ::peg::Parse::position_repr(__input, __pos);
                 match &entry {
-                    &::peg::RuleResult::Matched(..) => println!("[PEG_TRACE] Cached match of rule {} at {}", #str_rule_name, loc),
-                    &Failed => println!("[PEG_TRACE] Cached fail of rule {} at {}", #str_rule_name, loc),
+                    &::peg::RuleResult::Matched(..) => {
+                        __state.__trace_print();
+                        println!("Cached match of rule {} at {}", #str_rule_name, loc)
+                    },
+                    &Failed => {
+                        __state.__trace_print();
+                        println!("Cached fail of rule {} at {}", #str_rule_name, loc)
+                    },
                 };
             }
         } else {
@@ -386,7 +429,14 @@ fn compile_expr(context: &Context, e: &Expr, result_used: bool) -> TokenStream {
                 );
             }
 
-            quote! { #rule_name(__input, __state, __err_state, __pos) }
+            let rule_name_call = quote! { #rule_name(__input, __state, __err_state, __pos) };
+            if cfg!(feature = "trace") {
+                quote! { 
+                    (__state.__trace_push(), #rule_name_call, __state.__trace_pop()).1
+                }
+            } else {
+                rule_name_call
+            }
         }
 
         RuleExpr(ref rule_name, ref rule_args) => {
@@ -459,11 +509,19 @@ fn compile_expr(context: &Context, e: &Expr, result_used: bool) -> TokenStream {
                 })
                 .collect();
 
+            let call_func = quote! { 
+                #func(__input, __state, __err_state, __pos #extra_args_call #(, #rule_args_call)*)
+            };
+            let call_func = if cfg!(feature = "trace") {
+                quote! { (__state.__trace_push(), #call_func, __state.__trace_pop()).1 }
+            } else {
+                call_func
+            };
             if result_used {
-                quote! { #func(__input, __state, __err_state, __pos #extra_args_call #(, #rule_args_call)*) }
+                call_func
             } else {
                 quote! {
-                    match #func(__input, __state, __err_state, __pos #extra_args_call #(, #rule_args_call)*){
+                    match #call_func {
                         ::peg::RuleResult::Matched(pos, _) => ::peg::RuleResult::Matched(pos, ()),
                         ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
                     }
@@ -774,8 +832,8 @@ fn compile_expr(context: &Context, e: &Expr, result_used: bool) -> TokenStream {
 
             let (enter, leave) = if cfg!(feature = "trace") {
                 (
-                    quote! {println!("[PEG_TRACE] Entering level {}", min_prec);},
-                    quote! {println!("[PEG_TRACE] Leaving level {}", min_prec);},
+                    quote! {{ __state.__trace_print(); println!("Entering level {}", min_prec); }},
+                    quote! {{ __state.__trace_print(); println!("Leaving level {}", min_prec); }},
                 )
             } else {
                 (quote!(), quote!())


### PR DESCRIPTION
I found this made it easier for me to read the scopes of each rule. I think it could be improved more, but I'm finding it useful so I thought I'd share it back.

Essentially it changes trace statements so they better reflect their hierarchy.
```
[PEG_TRACE] Attempting rule `atom_type` at 3:21 {
[PEG_TRACE]   Attempting rule `identifier` at 3:21, matched `identifier` from 3:21 to 3:32
[PEG_TRACE]   Attempting rule `ws` at 3:32, matched `ws` from 3:32 to 3:32
[PEG_TRACE]   Attempting rule `parse_char` at 3:21, failed `parse_char` at 3:21
[PEG_TRACE]   Attempting rule `parse_char` at 3:21, failed `parse_char` at 3:21
[PEG_TRACE]   Attempting rule `parse_string` at 3:21, failed `parse_string` at 3:21
[PEG_TRACE] } failed `atom_type` at 3:21
```