### PR TITLE
Add is_eof() function to Parse trait

### DIFF
--- a/peg-macros/grammar.rs
+++ b/peg-macros/grammar.rs
@@ -33,7 +33,7 @@ pub mod peg {
             ::peg::Parse::start(__input),
         ) {
             ::peg::RuleResult::Matched(__pos, __value) => {
-                if __pos == __input.len() {
+                if ::peg::Parse::is_eof(__input, __pos) {
                     return Ok(__value);
                 } else {
                     __err_state.mark_failure(__pos, "EOF");
@@ -50,7 +50,7 @@ pub mod peg {
             ::peg::Parse::start(__input),
         ) {
             ::peg::RuleResult::Matched(__pos, __value) => {
-                if __pos == __input.len() {
+                if ::peg::Parse::is_eof(__input, __pos) {
                     panic!(
                         "Parser is nondeterministic: succeeded when reparsing for error position"
                     );

--- a/peg-macros/tokens.rs
+++ b/peg-macros/tokens.rs
@@ -89,6 +89,10 @@ impl Parse for FlatTokenStream {
         0
     }
 
+    fn is_eof(&self, pos: usize) -> bool {
+        pos >= self.len()
+    }
+
     fn position_repr(&self, pos: usize) -> Sp {
         Sp(
             match &self.tokens[pos] {

--- a/peg-macros/translate.rs
+++ b/peg-macros/translate.rs
@@ -279,7 +279,7 @@ fn compile_rule_export(context: &Context, rule: &Rule) -> TokenStream {
             let mut __state = ParseState::new();
             match #parse_fn(__input, &mut __state, &mut __err_state, ::peg::Parse::start(__input) #extra_args_call #(, #rule_params_call)*) {
                 ::peg::RuleResult::Matched(__pos, __value) => {
-                    if __pos == __input.len() {
+                    if ::peg::Parse::is_eof(__input, __pos) {
                         return Ok(__value)
                     } else {
                         __err_state.mark_failure(__pos, "EOF");
@@ -293,7 +293,7 @@ fn compile_rule_export(context: &Context, rule: &Rule) -> TokenStream {
 
             match #parse_fn(__input, &mut __state, &mut __err_state, ::peg::Parse::start(__input) #extra_args_call #(, #rule_params_call)*) {
                 ::peg::RuleResult::Matched(__pos, __value) => {
-                    if __pos == __input.len() {
+                    if ::peg::Parse::is_eof(__input, __pos) {
                         panic!("Parser is nondeterministic: succeeded when reparsing for error position");
                     } else {
                         __err_state.mark_failure(__pos, "EOF");

--- a/peg-runtime/lib.rs
+++ b/peg-runtime/lib.rs
@@ -18,6 +18,7 @@ pub enum RuleResult<T> {
 pub trait Parse {
     type PositionRepr: Display;
     fn start<'input>(&'input self) -> usize;
+    fn is_eof<'input>(&'input self, p: usize) -> bool;
     fn position_repr<'input>(&'input self, p: usize) -> Self::PositionRepr;
 }
 

--- a/peg-runtime/slice.rs
+++ b/peg-runtime/slice.rs
@@ -6,6 +6,10 @@ impl<T> Parse for [T] {
         0
     }
 
+    fn is_eof(&self, pos: usize) -> bool {
+        pos >= self.len()
+    }
+
     fn position_repr(&self, pos: usize) -> usize {
         pos
     }

--- a/peg-runtime/str.rs
+++ b/peg-runtime/str.rs
@@ -28,6 +28,10 @@ impl Parse for str {
         0
     }
 
+    fn is_eof(&self, pos: usize) -> bool {
+        pos >= self.len()
+    }
+
     fn position_repr(&self, pos: usize) -> LineCol {
         let before = &self[..pos];
         let line = before.as_bytes().iter().filter(|&&c| c == b'\n').count() + 1;


### PR DESCRIPTION
Use Parse::is_eof() to replace the previous check for end-of-input.

Fixes #251