### PR TITLE
Accept type parameters on grammar (e.g. lifetimes) (Fixes #220)

### DIFF
--- a/peg-macros/ast.rs
+++ b/peg-macros/ast.rs
@@ -5,6 +5,7 @@ pub struct Grammar {
     pub doc: Option<TokenStream>,
     pub visibility: Option<TokenStream>,
     pub name: Ident,
+    pub ty_params: Option<Vec<TokenStream>>,
     pub args: Vec<(Ident, TokenStream)>,
     pub items: Vec<Item>,
     pub input_type: TokenStream,

--- a/peg-macros/grammar.rs
+++ b/peg-macros/grammar.rs
@@ -84,33 +84,31 @@ pub mod peg {
                                         __parse_IDENT(__input, __state, __err_state, __pos);
                                     match __seq_res {
                                         ::peg::RuleResult::Matched(__pos, name) => {
-                                            let __seq_res = __parse_grammar_args(
+                                            let __seq_res = match __parse_rust_ty_params(
                                                 __input,
                                                 __state,
                                                 __err_state,
                                                 __pos,
-                                            );
+                                            ) {
+                                                ::peg::RuleResult::Matched(__newpos, __value) => {
+                                                    ::peg::RuleResult::Matched(
+                                                        __newpos,
+                                                        Some(__value),
+                                                    )
+                                                }
+                                                ::peg::RuleResult::Failed => {
+                                                    ::peg::RuleResult::Matched(__pos, None)
+                                                }
+                                            };
                                             match __seq_res {
-                                                ::peg::RuleResult::Matched(__pos, args) => {
-                                                    match ::peg::ParseLiteral::parse_string_literal(
-                                                        __input, __pos, "for",
-                                                    ) {
-                                                        ::peg::RuleResult::Matched(
-                                                            __pos,
-                                                            __val,
-                                                        ) => {
-                                                            let __seq_res = {
-                                                                let str_start = __pos;
-                                                                match match __parse_rust_type (__input , __state , __err_state , __pos) { :: peg :: RuleResult :: Matched (pos , _) => :: peg :: RuleResult :: Matched (pos , ()) , :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } { :: peg :: RuleResult :: Matched (__newpos , _) => { :: peg :: RuleResult :: Matched (__newpos , :: peg :: ParseSlice :: parse_slice (__input , str_start , __newpos)) } , :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , }
-                                                            };
-                                                            match __seq_res { :: peg :: RuleResult :: Matched (__pos , input_type) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "{") { :: peg :: RuleResult :: Matched (__pos , __val) => { { let __seq_res = { let mut __repeat_pos = __pos ; let mut __repeat_value = vec ! () ; loop { let __pos = __repeat_pos ; let __step_res = __parse_item (__input , __state , __err_state , __pos) ; match __step_res { :: peg :: RuleResult :: Matched (__newpos , __value) => { __repeat_pos = __newpos ; __repeat_value . push (__value) ; } , :: peg :: RuleResult :: Failed => { break ; } } } :: peg :: RuleResult :: Matched (__repeat_pos , __repeat_value) } ; match __seq_res { :: peg :: RuleResult :: Matched (__pos , items) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "}") { :: peg :: RuleResult :: Matched (__pos , __val) => { :: peg :: RuleResult :: Matched (__pos , (|| { Grammar { doc , visibility , name , args , input_type , items } }) ()) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"}\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"{\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , }
-                                                        }
-                                                        ::peg::RuleResult::Failed => {
-                                                            __err_state
-                                                                .mark_failure(__pos, "\"for\"");
-                                                            ::peg::RuleResult::Failed
-                                                        }
-                                                    }
+                                                ::peg::RuleResult::Matched(__pos, ty_params) => {
+                                                    let __seq_res = __parse_grammar_args(
+                                                        __input,
+                                                        __state,
+                                                        __err_state,
+                                                        __pos,
+                                                    );
+                                                    match __seq_res { :: peg :: RuleResult :: Matched (__pos , args) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "for") { :: peg :: RuleResult :: Matched (__pos , __val) => { { let __seq_res = { let str_start = __pos ; match match __parse_rust_type (__input , __state , __err_state , __pos) { :: peg :: RuleResult :: Matched (pos , _) => :: peg :: RuleResult :: Matched (pos , ()) , :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } { :: peg :: RuleResult :: Matched (__newpos , _) => { :: peg :: RuleResult :: Matched (__newpos , :: peg :: ParseSlice :: parse_slice (__input , str_start , __newpos)) } , :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } ; match __seq_res { :: peg :: RuleResult :: Matched (__pos , input_type) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "{") { :: peg :: RuleResult :: Matched (__pos , __val) => { { let __seq_res = { let mut __repeat_pos = __pos ; let mut __repeat_value = vec ! () ; loop { let __pos = __repeat_pos ; let __step_res = __parse_item (__input , __state , __err_state , __pos) ; match __step_res { :: peg :: RuleResult :: Matched (__newpos , __value) => { __repeat_pos = __newpos ; __repeat_value . push (__value) ; } , :: peg :: RuleResult :: Failed => { break ; } } } :: peg :: RuleResult :: Matched (__repeat_pos , __repeat_value) } ; match __seq_res { :: peg :: RuleResult :: Matched (__pos , items) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "}") { :: peg :: RuleResult :: Matched (__pos , __val) => { :: peg :: RuleResult :: Matched (__pos , (|| { Grammar { doc , visibility , name , ty_params , args , input_type , items } }) ()) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"}\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"{\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"for\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , }
                                                 }
                                                 ::peg::RuleResult::Failed => {
                                                     ::peg::RuleResult::Failed

--- a/peg-macros/grammar.rustpeg
+++ b/peg-macros/grammar.rustpeg
@@ -6,8 +6,8 @@ use crate::tokens::FlatTokenStream;
 use proc_macro2::{ TokenStream, Ident, Group, Literal, Delimiter, Span };
 
 pub rule peg_grammar() -> Grammar
-    = doc:rust_doc_comment() visibility:rust_visibility() "grammar" name:IDENT() args:grammar_args() "for" input_type:$(rust_type()) "{" items:item()* "}"
-        { Grammar { doc, visibility, name, args, input_type, items } }
+    = doc:rust_doc_comment() visibility:rust_visibility() "grammar" name:IDENT() ty_params:rust_ty_params()? args:grammar_args() "for" input_type:$(rust_type()) "{" items:item()* "}"
+        { Grammar { doc, visibility, name, ty_params, args, input_type, items } }
 
 rule grammar_args() -> Vec<(Ident, TokenStream)>
     = "(" args:((i:IDENT() ":" t:$(rust_type()) { (i, t) })**",") ","? ")" { args }

--- a/tests/run-pass/lifetimes.rs
+++ b/tests/run-pass/lifetimes.rs
@@ -1,0 +1,24 @@
+#[derive(Clone)]
+pub struct Token<'text>(&'text str);
+
+peg::parser!{
+    grammar tokenparser<'t>() for [Token<'t>] {
+        pub rule program() -> Vec<&'t str> = list()
+
+        // add this indirection to ensure that rule args work with a global lifetime
+        rule commasep<T>(x: rule<T>) -> Vec<T> = v:(x() ** [Token(",")]) [Token(",")]? { v }
+
+        rule list() -> Vec<&'t str> = [Token("(")] l:commasep(<string()>) [Token(")")] { l }
+        rule string() -> &'t str = [Token(inner)] { inner }
+    }
+}
+
+fn main() {
+    let input = "(one,two)";
+    assert_eq!(
+        tokenparser::program(
+            &[Token(&input[0..1]), Token(&input[1..4]), Token(&input[4..5]), Token(&input[5..8]), Token(&input[8..9])],
+        ),
+        Ok(vec!["one", "two"])
+    );
+}


### PR DESCRIPTION
This allows the parser to operate over types like `Token<'code>` by supplying the lifetime as a type parameter on the grammar (#220):

```rust
peg::parser! {
    grammar feeny<'a>() for Tokens<'a> {
        // snip
    }
}
```

This should work with all type parameters, not just lifetimes, but lifetimes are the motivating example here.

Like @kevinmehall's comment on #220 suggests, this simply adds `rust_ty_params()` to `peg_grammar` in the meta-grammar, and then threads that through.

If a rule defines it's own type parameters, those come after the grammar's type parameters on the parser's exported functions/entrypoints.