### PR TITLE
Add lifetime param to ParseElem

### DIFF
--- a/peg-macros/tokens.rs
+++ b/peg-macros/tokens.rs
@@ -126,10 +126,10 @@ impl Parse for FlatTokenStream {
     }
 }
 
-impl ParseElem for FlatTokenStream {
+impl<'input> ParseElem<'input> for FlatTokenStream {
     type Element = Token;
 
-    fn parse_elem(&self, pos: usize) -> RuleResult<Token> {
+    fn parse_elem(&'input self, pos: usize) -> RuleResult<Token> {
         match self.tokens.get(pos) {
             Some(c) => RuleResult::Matched(pos + 1, c.clone()),
             None => RuleResult::Failed,

--- a/peg-runtime/lib.rs
+++ b/peg-runtime/lib.rs
@@ -15,6 +15,7 @@ pub enum RuleResult<T> {
 }
 
 /// A type that can be used as input to a parser.
+#[allow(clippy::needless_lifetimes)]
 pub trait Parse {
     type PositionRepr: Display;
     fn start<'input>(&'input self) -> usize;
@@ -23,12 +24,12 @@ pub trait Parse {
 }
 
 /// A parser input type supporting the `[...]` syntax.
-pub trait ParseElem: Parse {
+pub trait ParseElem<'input>: Parse {
     /// Type of a single atomic element of the input, for example a character or token
     type Element;
 
     /// Get the element at `pos`, or `Failed` if past end of input.
-    fn parse_elem(&self, pos: usize) -> RuleResult<Self::Element>;
+    fn parse_elem(&'input self, pos: usize) -> RuleResult<Self::Element>;
 }
 
 /// A parser input type supporting the `"literal"` syntax.

--- a/peg-runtime/slice.rs
+++ b/peg-runtime/slice.rs
@@ -15,10 +15,10 @@ impl<T> Parse for [T] {
     }
 }
 
-impl<T: Clone> ParseElem for [T] {
+impl<'input, T: 'input + Clone> ParseElem<'input> for [T] {
     type Element = T;
 
-    fn parse_elem(&self, pos: usize) -> RuleResult<T> {
+    fn parse_elem(&'input self, pos: usize) -> RuleResult<T> {
         match self[pos..].first() {
             Some(c) => RuleResult::Matched(pos + 1, c.clone()),
             None => RuleResult::Failed,

--- a/peg-runtime/slice.rs
+++ b/peg-runtime/slice.rs
@@ -16,11 +16,11 @@ impl<T> Parse for [T] {
 }
 
 impl<'input, T: 'input + Clone> ParseElem<'input> for [T] {
-    type Element = T;
+    type Element = &'input T;
 
-    fn parse_elem(&'input self, pos: usize) -> RuleResult<T> {
+    fn parse_elem(&'input self, pos: usize) -> RuleResult<&'input T> {
         match self[pos..].first() {
-            Some(c) => RuleResult::Matched(pos + 1, c.clone()),
+            Some(c) => RuleResult::Matched(pos + 1, c),
             None => RuleResult::Failed,
         }
     }

--- a/peg-runtime/str.rs
+++ b/peg-runtime/str.rs
@@ -44,10 +44,10 @@ impl Parse for str {
     }
 }
 
-impl ParseElem for str {
+impl<'input> ParseElem<'input> for str {
     type Element = char;
 
-    fn parse_elem(&self, pos: usize) -> RuleResult<char> {
+    fn parse_elem(&'input self, pos: usize) -> RuleResult<char> {
         match self[pos..].chars().next() {
             Some(c) => RuleResult::Matched(pos + c.len_utf8(), c),
             None => RuleResult::Failed,

--- a/tests/run-pass/lifetimes.rs
+++ b/tests/run-pass/lifetimes.rs
@@ -12,7 +12,7 @@ peg::parser!{
         rule string() -> &'t str = [Token(inner)] { inner }
 
         #[cache]
-        rule cached() -> Token<'t> = [a] { a }
+        rule cached() -> Token<'t> = [a] { a.clone() }
     }
 }
 

--- a/tests/run-pass/tokens.rs
+++ b/tests/run-pass/tokens.rs
@@ -8,7 +8,7 @@ pub enum Token {
 
 peg::parser!{
     grammar tokenparser() for [Token] {
-        pub rule list() -> (i32, i32) = [Token::Open] [Token::Number(a)] [Token::Comma] [Token::Number(b)] [Token::Close] { (a, b) }
+        pub rule list() -> (i32, i32) = [Token::Open] [Token::Number(a)] [Token::Comma] [Token::Number(b)] [Token::Close] { (a.clone(), b.clone()) }
     }
 }
 


### PR DESCRIPTION
This PR adds an `'input` lifetime parameter to `ParseElem` and changes changes the signature of `parse_elem` to take `self` by `&'input`. 

This change allows `ParseElem` implementations that return `Element`s by reference, avoiding a potentially expensive `clone()`. Case in point, the implementation of `parse_elem` in `ParseElem for [T]` now returns `&'input T`.

Both of these are breaking changes.

Closes #268.