### PR TITLE
Add error recovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
 * Helpful `rustc` error messages for errors in the grammar definition or the Rust
   code embedded within it
 * Rule-level tracing to debug grammars
+* Error recovery
 
 ## Example
 
@@ -39,12 +40,12 @@ pub fn main() {
 
 ## Comparison with similar parser generators
 
-| crate     	| parser type 	| action code 	| integration        	| input type             	| precedence climbing 	| parameterized rules 	| streaming input 	|
-|-----------	|-------------	|-------------	|--------------------	|------------------------	|---------------------	|--------------------	|-----------------	|
-| peg       	| PEG         	| in grammar  	| proc macro (block) 	| `&str`, `&[T]`, custom 	| Yes                 	| Yes                	| No              	|
-| [pest]    	| PEG         	| external    	| proc macro (file)  	| `&str`                 	| Yes                 	| No                 	| No              	|
-| [nom]     	| combinators 	| in source   	| library            	| `&[u8]`, custom        	| No                  	| Yes                	| Yes             	|
-| [lalrpop] 	| LR(1)       	| in grammar  	| build script       	| `&str`                 	| No                  	| Yes                	| No              	|
+| crate     	| parser type 	| action code 	| integration        	| input type             	| precedence climbing 	| parameterized rules | streaming input 	| recovery |
+|-----------	|-------------	|-------------	|--------------------	|------------------------	|---------------------	|--------------------	|-----------------	|--------- |
+| peg       	| PEG         	| in grammar  	| proc macro (block) 	| `&str`, `&[T]`, custom 	| Yes                 	| Yes                	| No              	| Yes      |
+| [pest]    	| PEG         	| external    	| proc macro (file)  	| `&str`                 	| Yes                 	| No                 	| No              	| No       |
+| [nom]     	| combinators 	| in source   	| library            	| `&[u8]`, custom        	| No                  	| Yes                	| Yes             	| No       |
+| [lalrpop] 	| LR(1)       	| in grammar  	| build script       	| `&str`                 	| No                  	| Yes                	| No              	| Yes      |
 
 [pest]: https://github.com/pest-parser/pest
 [nom]: https://github.com/geal/nom
@@ -63,7 +64,8 @@ pub fn main() {
 
 ## Upgrade guide
 
-The rule return type has changed between 0.8 to 0.9.
+The rule return type has changed between 0.8 to 0.9,
+and now supports recovery and reporting multiple errors.
 To upgrade, add a call to `.into_result()` to convert the new rule return type
 to a simple `Result`.
 ## Development

--- a/README.md
+++ b/README.md
@@ -30,11 +30,11 @@ peg::parser!{
 }
 
 pub fn main() {
-    assert_eq!(list_parser::list("[1,1,2,3,5,8]"), Ok(vec![1, 1, 2, 3, 5, 8]));
+    assert_eq!(list_parser::list("[1,1,2,3,5,8]").into_result(), Ok(vec![1, 1, 2, 3, 5, 8]));
 }
 ```
 
-[See the tests for more examples](./tests/run-pass/)  
+[See the tests for more examples](./tests/run-pass/)
 [Grammar rule syntax reference in rustdoc](https://docs.rs/peg)
 
 ## Comparison with similar parser generators
@@ -60,6 +60,12 @@ pub fn main() {
 [annotate-snippets]: https://crates.io/crates/annotate-snippets
 [codespan-reporting]: https://crates.io/crates/codespan-reporting
 [codemap-diagnostic]: https://crates.io/crates/codemap-diagnostic
+
+## Upgrade guide
+
+The rule return type has changed between 0.8 to 0.9.
+To upgrade, add a call to `.into_result()` to convert the new rule return type
+to a simple `Result`.
 ## Development
 
 The `rust-peg` grammar is written in `rust-peg`: `peg-macros/grammar.rustpeg`. To avoid the circular dependency, a precompiled grammar is checked in as `peg-macros/grammar.rs`. To regenerate this, run the `./bootstrap.sh` script.

--- a/peg-macros/analysis.rs
+++ b/peg-macros/analysis.rs
@@ -164,7 +164,7 @@ impl<'a> LeftRecursionVisitor<'a> {
                nullable
             }
 
-            LiteralExpr(_) | PatternExpr(_) | MethodExpr(_, _) | FailExpr(_) | MarkerExpr(_) => false,
+            LiteralExpr(_) | PatternExpr(_) | MethodExpr(_, _) | FailExpr(_) | ErrorIfExpr(..) | ErrorUnlessExpr(..) |MarkerExpr(_) => false,
 
             PositionExpr => true,
         }
@@ -220,7 +220,7 @@ impl<'a> LoopNullabilityVisitor<'a> {
                 let name = rule_ident.to_string();
                 *self.rule_nullability.get(&name).unwrap_or(&false)
             }
-            
+
             ActionExpr(ref elems, ..) => {
                 let mut nullable = true;
                 for elem in elems {
@@ -250,7 +250,7 @@ impl<'a> LoopNullabilityVisitor<'a> {
                 if inner_nullable && sep_nullable && !bound.has_upper_bound() {
                     self.errors.push(LoopNullabilityError { span: this_expr.span });
                 }
-                
+
                 inner_nullable | !bound.has_lower_bound()
             }
 
@@ -269,10 +269,10 @@ impl<'a> LoopNullabilityVisitor<'a> {
                     }
                 }
 
-                nullable 
+                nullable
             }
 
-            LiteralExpr(_) | PatternExpr(_) | MethodExpr(_, _) | FailExpr(_) | MarkerExpr(_) => false,
+            LiteralExpr(_) | PatternExpr(_) | MethodExpr(_, _) | FailExpr(_) | ErrorIfExpr(..) | ErrorUnlessExpr(..) | MarkerExpr(_) => false,
             PositionExpr => true,
         }
     }

--- a/peg-macros/ast.rs
+++ b/peg-macros/ast.rs
@@ -85,6 +85,8 @@ pub enum Expr {
     PositionExpr,
     QuietExpr(Box<SpannedExpr>),
     FailExpr(Literal),
+    ErrorIfExpr(Box<SpannedExpr>, Literal, Box<SpannedExpr>),
+    ErrorUnlessExpr(Box<SpannedExpr>, Literal, Box<SpannedExpr>),
     PrecedenceExpr {
         levels: Vec<PrecedenceLevel>,
     },

--- a/peg-macros/bin.rs
+++ b/peg-macros/bin.rs
@@ -42,7 +42,7 @@ fn main() {
 
     let source_tokens = source.parse().expect("Error tokenizing input");
     let input_tokens = tokens::FlatTokenStream::new(source_tokens);
-    let grammar = match grammar::peg::peg_grammar(&input_tokens) {
+    let grammar = match grammar::peg::peg_grammar(&input_tokens).into_result() {
         Ok(g) => g,
         Err(err) => {
             eprintln!("Failed to parse grammar: expected {}", err.expected);

--- a/peg-macros/grammar.rs
+++ b/peg-macros/grammar.rs
@@ -23,7 +23,7 @@ pub mod peg {
     use proc_macro2::{Delimiter, Group, Ident, Literal, Span, TokenStream};
     pub fn peg_grammar<'input>(
         __input: &'input Input,
-    ) -> ::std::result::Result<Grammar, ::peg::error::ParseError<PositionRepr>> {
+    ) -> ::peg::ParseResults<Grammar, PositionRepr> {
         #![allow(non_snake_case, unused)]
         let mut __err_state = ::peg::error::ErrorState::new(::peg::Parse::start(__input));
         let mut __state = ParseState::new();
@@ -35,7 +35,7 @@ pub mod peg {
         ) {
             ::peg::RuleResult::Matched(__pos, __value) => {
                 if ::peg::Parse::is_eof(__input, __pos) {
-                    return Ok(__value);
+                    return __err_state.into_matched(__value, __input);
                 } else {
                     __err_state.mark_failure(__pos, "EOF");
                 }
@@ -61,7 +61,7 @@ pub mod peg {
             }
             _ => (),
         }
-        Err(__err_state.into_parse_error(__input))
+        __err_state.into_failure(__input)
     }
     fn __parse_peg_grammar<'input>(
         __input: &'input Input,
@@ -3256,7 +3256,7 @@ pub mod peg {
                 __err_state.suppress_fail -= 1;
                 match __assert_res {
                     ::peg::RuleResult::Failed => ::peg::RuleResult::Matched(__pos, ()),
-                    ::peg::RuleResult::Matched(..) => ::peg::RuleResult::Failed,
+                    ::peg::RuleResult::Matched(..) => __err_state.mark_failure(__pos, "mismatch"),
                 }
             };
             match __seq_res {

--- a/peg-macros/grammar.rs
+++ b/peg-macros/grammar.rs
@@ -100,6 +100,7 @@ pub mod peg {
                                                 ::peg::RuleResult::Failed => {
                                                     ::peg::RuleResult::Matched(__pos, None)
                                                 }
+                                                ::peg::RuleResult::Error(..) => panic!()
                                             };
                                             match __seq_res {
                                                 ::peg::RuleResult::Matched(
@@ -112,26 +113,31 @@ pub mod peg {
                                                         __err_state,
                                                         __pos,
                                                     );
-                                                    match __seq_res { :: peg :: RuleResult :: Matched (__pos , args) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "for") { :: peg :: RuleResult :: Matched (__pos , __val) => { { let __seq_res = { let str_start = __pos ; match match __parse_rust_type (__input , __state , __err_state , __pos) { :: peg :: RuleResult :: Matched (pos , _) => :: peg :: RuleResult :: Matched (pos , ()) , :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } { :: peg :: RuleResult :: Matched (__newpos , _) => { :: peg :: RuleResult :: Matched (__newpos , :: peg :: ParseSlice :: parse_slice (__input , str_start , __newpos)) } , :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } ; match __seq_res { :: peg :: RuleResult :: Matched (__pos , input_type) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "{") { :: peg :: RuleResult :: Matched (__pos , __val) => { { let __seq_res = { let mut __repeat_pos = __pos ; let mut __repeat_value = vec ! () ; loop { let __pos = __repeat_pos ; let __step_res = __parse_item (__input , __state , __err_state , __pos) ; match __step_res { :: peg :: RuleResult :: Matched (__newpos , __value) => { __repeat_pos = __newpos ; __repeat_value . push (__value) ; } , :: peg :: RuleResult :: Failed => { break ; } } } :: peg :: RuleResult :: Matched (__repeat_pos , __repeat_value) } ; match __seq_res { :: peg :: RuleResult :: Matched (__pos , items) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "}") { :: peg :: RuleResult :: Matched (__pos , __val) => { :: peg :: RuleResult :: Matched (__pos , (|| { Grammar { doc , visibility , name , lifetime_params , args , input_type , items } }) ()) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"}\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"{\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"for\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , }
+                                                    match __seq_res { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , args) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "for") { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , __val) => { { let __seq_res = { let str_start = __pos ; match match __parse_rust_type (__input , __state , __err_state , __pos) { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (pos , _) => :: peg :: RuleResult :: Matched (pos , ()) , :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , ::peg::RuleResult::Error(..) => panic!() } { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__newpos , _) => { :: peg :: RuleResult :: Matched (__newpos , :: peg :: ParseSlice :: parse_slice (__input , str_start , __newpos)) } , :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , ::peg::RuleResult::Error(..) => panic!() } } ; match __seq_res { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , input_type) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "{") { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , __val) => { { let __seq_res = { let mut __repeat_pos = __pos ; let mut __repeat_value = vec ! () ; loop { let __pos = __repeat_pos ; let __step_res = __parse_item (__input , __state , __err_state , __pos) ; match __step_res { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__newpos , __value) => { __repeat_pos = __newpos ; __repeat_value . push (__value) ; } , :: peg :: RuleResult :: Failed => { break ; }, ::peg::RuleResult::Error(..) => panic!() } } :: peg :: RuleResult :: Matched (__repeat_pos , __repeat_value) } ; match __seq_res { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , items) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "}") { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , __val) => { :: peg :: RuleResult :: Matched (__pos , (|| { Grammar { doc , visibility , name , lifetime_params , args , input_type , items } }) ()) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"}\"") ; :: peg :: RuleResult :: Failed }, ::peg::RuleResult::Error(..) => panic!() } } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , ::peg::RuleResult::Error(..) => panic!() } } } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"{\"") ; :: peg :: RuleResult :: Failed } , ::peg::RuleResult::Error(..) => panic!() } } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , ::peg::RuleResult::Error(..) => panic!() } } } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"for\"") ; :: peg :: RuleResult :: Failed } , ::peg::RuleResult::Error(..) => panic!() } } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , ::peg::RuleResult::Error(..) => panic!() }
                                                 }
                                                 ::peg::RuleResult::Failed => {
                                                     ::peg::RuleResult::Failed
                                                 }
+                                                ::peg::RuleResult::Error(..) => panic!()
                                             }
                                         }
                                         ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
+                                        ::peg::RuleResult::Error(..) => panic!()
                                     }
                                 }
                                 ::peg::RuleResult::Failed => {
                                     __err_state.mark_failure(__pos, "\"grammar\"");
                                     ::peg::RuleResult::Failed
                                 }
+                                ::peg::RuleResult::Error(..) => panic!()
                             }
                         }
                         ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
+                        ::peg::RuleResult::Error(..) => panic!()
                     }
                 }
                 ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
+                ::peg::RuleResult::Error(..) => panic!()
             }
         }
     }
@@ -162,10 +168,12 @@ pub mod peg {
                                     __err_state.mark_failure(__pos, "\",\"");
                                     ::peg::RuleResult::Failed
                                 }
+                                ::peg::RuleResult::Error(..) => panic!()
                             };
                             match __sep_res {
                                 ::peg::RuleResult::Matched(__newpos, _) => __newpos,
                                 ::peg::RuleResult::Failed => break,
+                                ::peg::RuleResult::Error(..) => panic!()
                             }
                         };
                         let __step_res = {
@@ -175,6 +183,7 @@ pub mod peg {
                                     ::peg::RuleResult::Matched(pos, ())
                                 }
                                 ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
+                                ::peg::RuleResult::Error(..) => panic!()
                             } {
                                 ::peg::RuleResult::Matched(__newpos, _) => {
                                     ::peg::RuleResult::Matched(
@@ -185,6 +194,7 @@ pub mod peg {
                                     )
                                 }
                                 ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
+                                ::peg::RuleResult::Error(..) => panic!()
                             }
                         };
                         match __step_res {
@@ -195,6 +205,7 @@ pub mod peg {
                             ::peg::RuleResult::Failed => {
                                 break;
                             }
+                            ::peg::RuleResult::Error(..) => panic!()
                         }
                     }
                     if __repeat_value.len() >= 1 {
@@ -213,15 +224,18 @@ pub mod peg {
                                 __err_state.mark_failure(__pos, "\">\"");
                                 ::peg::RuleResult::Failed
                             }
+                            ::peg::RuleResult::Error(..) => panic!()
                         }
                     }
                     ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
+                    ::peg::RuleResult::Error(..) => panic!()
                 }
             }
             ::peg::RuleResult::Failed => {
                 __err_state.mark_failure(__pos, "\"<\"");
                 ::peg::RuleResult::Failed
             }
+            ::peg::RuleResult::Error(..) => panic!()
         }
     }
     fn __parse_grammar_args<'input>(
@@ -251,10 +265,12 @@ pub mod peg {
                                     __err_state.mark_failure(__pos, "\",\"");
                                     ::peg::RuleResult::Failed
                                 }
+                                ::peg::RuleResult::Error(..) => panic!()
                             };
                             match __sep_res {
                                 ::peg::RuleResult::Matched(__newpos, _) => __newpos,
                                 ::peg::RuleResult::Failed => break,
+                                ::peg::RuleResult::Error(..) => panic!()
                             }
                         };
                         let __step_res = {
@@ -279,6 +295,7 @@ pub mod peg {
                                                     ::peg::RuleResult::Failed => {
                                                         ::peg::RuleResult::Failed
                                                     }
+                                                    ::peg::RuleResult::Error(..) => panic!()
                                                 } {
                                                     ::peg::RuleResult::Matched(__newpos, _) => {
                                                         ::peg::RuleResult::Matched(
@@ -291,6 +308,7 @@ pub mod peg {
                                                     ::peg::RuleResult::Failed => {
                                                         ::peg::RuleResult::Failed
                                                     }
+                                                    ::peg::RuleResult::Error(..) => panic!()
                                                 }
                                             };
                                             match __seq_res {
@@ -300,15 +318,18 @@ pub mod peg {
                                                 ::peg::RuleResult::Failed => {
                                                     ::peg::RuleResult::Failed
                                                 }
+                                                ::peg::RuleResult::Error(..) => panic!()
                                             }
                                         }
                                         ::peg::RuleResult::Failed => {
                                             __err_state.mark_failure(__pos, "\":\"");
                                             ::peg::RuleResult::Failed
                                         }
+                                        ::peg::RuleResult::Error(..) => panic!()
                                     }
                                 }
                                 ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
+                                ::peg::RuleResult::Error(..) => panic!()
                             }
                         };
                         match __step_res {
@@ -319,6 +340,7 @@ pub mod peg {
                             ::peg::RuleResult::Failed => {
                                 break;
                             }
+                            ::peg::RuleResult::Error(..) => panic!()
                         }
                     }
                     ::peg::RuleResult::Matched(__repeat_pos, __repeat_value)
@@ -335,11 +357,13 @@ pub mod peg {
                                 __err_state.mark_failure(__pos, "\",\"");
                                 ::peg::RuleResult::Failed
                             }
+                            ::peg::RuleResult::Error(..) => panic!()
                         } {
                             ::peg::RuleResult::Matched(__newpos, _) => {
                                 ::peg::RuleResult::Matched(__newpos, ())
                             }
                             ::peg::RuleResult::Failed => ::peg::RuleResult::Matched(__pos, ()),
+                            ::peg::RuleResult::Error(..) => panic!()
                         };
                         match __seq_res {
                             ::peg::RuleResult::Matched(__pos, _) => {
@@ -352,18 +376,22 @@ pub mod peg {
                                         __err_state.mark_failure(__pos, "\")\"");
                                         ::peg::RuleResult::Failed
                                     }
+                                    ::peg::RuleResult::Error(..) => panic!()
                                 }
                             }
                             ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
+                            ::peg::RuleResult::Error(..) => panic!()
                         }
                     }
                     ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
+                    ::peg::RuleResult::Error(..) => panic!()
                 }
             }
             ::peg::RuleResult::Failed => {
                 __err_state.mark_failure(__pos, "\"(\"");
                 ::peg::RuleResult::Failed
             }
+            ::peg::RuleResult::Error(..) => panic!()
         }
     }
     fn __parse_peg_rule<'input>(
@@ -409,14 +437,14 @@ pub mod peg {
                                                                         __err_state
                                                                             .suppress_fail += 1;
                                                                         let __assert_res = {
-                                                                            let __choice_res = match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "_") { :: peg :: RuleResult :: Matched (__pos , __val) => { :: peg :: RuleResult :: Matched (__pos , __val) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"_\"") ; :: peg :: RuleResult :: Failed } } ;
-                                                                            match __choice_res { :: peg :: RuleResult :: Matched (__pos , __value) => :: peg :: RuleResult :: Matched (__pos , __value) , :: peg :: RuleResult :: Failed => { let __choice_res = match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "__") { :: peg :: RuleResult :: Matched (__pos , __val) => { :: peg :: RuleResult :: Matched (__pos , __val) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"__\"") ; :: peg :: RuleResult :: Failed } } ; match __choice_res { :: peg :: RuleResult :: Matched (__pos , __value) => :: peg :: RuleResult :: Matched (__pos , __value) , :: peg :: RuleResult :: Failed => match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "___") { :: peg :: RuleResult :: Matched (__pos , __val) => { :: peg :: RuleResult :: Matched (__pos , __val) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"___\"") ; :: peg :: RuleResult :: Failed } } } } }
+                                                                            let __choice_res = match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "_") { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , __val) => { :: peg :: RuleResult :: Matched (__pos , __val) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"_\"") ; :: peg :: RuleResult :: Failed }, ::peg::RuleResult::Error(..) => panic!() } ;
+                                                                            match __choice_res { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , __value) => :: peg :: RuleResult :: Matched (__pos , __value) , :: peg :: RuleResult :: Failed => { let __choice_res = match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "__") { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , __val) => { :: peg :: RuleResult :: Matched (__pos , __val) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"__\"") ; :: peg :: RuleResult :: Failed }, ::peg::RuleResult::Error(..) => panic!()  } ; match __choice_res { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , __value) => :: peg :: RuleResult :: Matched (__pos , __value) , :: peg :: RuleResult :: Failed => match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "___") { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , __val) => { :: peg :: RuleResult :: Matched (__pos , __val) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"___\"") ; :: peg :: RuleResult :: Failed }, ::peg::RuleResult::Error(..) => panic!()  } } }, ::peg::RuleResult::Error(..) => panic!()  }
                                                                         };
                                                                         __err_state
                                                                             .suppress_fail -= 1;
-                                                                        match __assert_res { :: peg :: RuleResult :: Matched (_ , __value) => :: peg :: RuleResult :: Matched (__pos , __value) , :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , }
+                                                                        match __assert_res { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (_ , __value) => :: peg :: RuleResult :: Matched (__pos , __value) , :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , }
                                                                     };
-                                                                    match __seq_res { :: peg :: RuleResult :: Matched (__pos , _) => { { let __seq_res = __parse_IDENT (__input , __state , __err_state , __pos) ; match __seq_res { :: peg :: RuleResult :: Matched (__pos , name) => { { let __seq_res = match match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "(") { :: peg :: RuleResult :: Matched (__pos , __val) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , ")") { :: peg :: RuleResult :: Matched (__pos , __val) => { :: peg :: RuleResult :: Matched (__pos , ()) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\")\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"(\"") ; :: peg :: RuleResult :: Failed } } { :: peg :: RuleResult :: Matched (__newpos , _) => { :: peg :: RuleResult :: Matched (__newpos , ()) } , :: peg :: RuleResult :: Failed => { :: peg :: RuleResult :: Matched (__pos , ()) } , } ; match __seq_res { :: peg :: RuleResult :: Matched (__pos , _) => { :: peg :: RuleResult :: Matched (__pos , (|| { (name , None , Vec :: new ()) }) ()) } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , }
+                                                                    match __seq_res { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , _) => { { let __seq_res = __parse_IDENT (__input , __state , __err_state , __pos) ; match __seq_res { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , name) => { { let __seq_res = match match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "(") { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , __val) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , ")") { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , __val) => { :: peg :: RuleResult :: Matched (__pos , ()) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\")\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"(\"") ; :: peg :: RuleResult :: Failed } } { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__newpos , _) => { :: peg :: RuleResult :: Matched (__newpos , ()) } , :: peg :: RuleResult :: Failed => { :: peg :: RuleResult :: Matched (__pos , ()) } , } ; match __seq_res { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , _) => { :: peg :: RuleResult :: Matched (__pos , (|| { (name , None , Vec :: new ()) }) ()) } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , }
                                                                 };
                                                                 match __choice_res {
                                                                     ::peg::RuleResult::Matched(
@@ -435,8 +463,9 @@ pub mod peg {
                                                                                 __err_state,
                                                                                 __pos,
                                                                             );
-                                                                        match __seq_res { :: peg :: RuleResult :: Matched (__pos , name) => { { let __seq_res = match __parse_rust_ty_params (__input , __state , __err_state , __pos) { :: peg :: RuleResult :: Matched (__newpos , __value) => { :: peg :: RuleResult :: Matched (__newpos , Some (__value)) } , :: peg :: RuleResult :: Failed => { :: peg :: RuleResult :: Matched (__pos , None) } , } ; match __seq_res { :: peg :: RuleResult :: Matched (__pos , ty_params) => { { let __seq_res = __parse_rule_params (__input , __state , __err_state , __pos) ; match __seq_res { :: peg :: RuleResult :: Matched (__pos , params) => { :: peg :: RuleResult :: Matched (__pos , (|| { (name , ty_params , params) }) ()) } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , }
+                                                                        match __seq_res { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , name) => { { let __seq_res = match __parse_rust_ty_params (__input , __state , __err_state , __pos) { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__newpos , __value) => { :: peg :: RuleResult :: Matched (__newpos , Some (__value)) } , :: peg :: RuleResult :: Failed => { :: peg :: RuleResult :: Matched (__pos , None) } , } ; match __seq_res { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , ty_params) => { { let __seq_res = __parse_rule_params (__input , __state , __err_state , __pos) ; match __seq_res { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , params) => { :: peg :: RuleResult :: Matched (__pos , (|| { (name , ty_params , params) }) ()) } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , }
                                                                     }
+                                                                    ::peg::RuleResult::Error(..) => panic!()
                                                                 }
                                                             };
                                                             match __seq_res {
@@ -444,12 +473,13 @@ pub mod peg {
                                                                     __pos,
                                                                     header,
                                                                 ) => {
-                                                                    let __seq_res = match match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "->") { :: peg :: RuleResult :: Matched (__pos , __val) => { { let __seq_res = { let str_start = __pos ; match match __parse_rust_type (__input , __state , __err_state , __pos) { :: peg :: RuleResult :: Matched (pos , _) => :: peg :: RuleResult :: Matched (pos , ()) , :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } { :: peg :: RuleResult :: Matched (__newpos , _) => { :: peg :: RuleResult :: Matched (__newpos , :: peg :: ParseSlice :: parse_slice (__input , str_start , __newpos)) } , :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } ; match __seq_res { :: peg :: RuleResult :: Matched (__pos , t) => { :: peg :: RuleResult :: Matched (__pos , (|| { t }) ()) } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"->\"") ; :: peg :: RuleResult :: Failed } } { :: peg :: RuleResult :: Matched (__newpos , __value) => { :: peg :: RuleResult :: Matched (__newpos , Some (__value)) } , :: peg :: RuleResult :: Failed => { :: peg :: RuleResult :: Matched (__pos , None) } , } ;
-                                                                    match __seq_res { :: peg :: RuleResult :: Matched (__pos , ret_type) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "=") { :: peg :: RuleResult :: Matched (__pos , __val) => { { let __seq_res = __parse_expression (__input , __state , __err_state , __pos) ; match __seq_res { :: peg :: RuleResult :: Matched (__pos , expr) => { { let __seq_res = match match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , ";") { :: peg :: RuleResult :: Matched (__pos , __val) => { :: peg :: RuleResult :: Matched (__pos , __val) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\";\"") ; :: peg :: RuleResult :: Failed } } { :: peg :: RuleResult :: Matched (__newpos , _) => { :: peg :: RuleResult :: Matched (__newpos , ()) } , :: peg :: RuleResult :: Failed => { :: peg :: RuleResult :: Matched (__pos , ()) } , } ; match __seq_res { :: peg :: RuleResult :: Matched (__pos , _) => { :: peg :: RuleResult :: Matched (__pos , (|| { Rule { span , doc , name : header . 0 , ty_params : header . 1 , params : header . 2 , expr , ret_type , visibility , no_eof , cache } }) ()) } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"=\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , }
+                                                                    let __seq_res = match match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "->") { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , __val) => { { let __seq_res = { let str_start = __pos ; match match __parse_rust_type (__input , __state , __err_state , __pos) { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (pos , _) => :: peg :: RuleResult :: Matched (pos , ()) , :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__newpos , _) => { :: peg :: RuleResult :: Matched (__newpos , :: peg :: ParseSlice :: parse_slice (__input , str_start , __newpos)) } , :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } ; match __seq_res { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , t) => { :: peg :: RuleResult :: Matched (__pos , (|| { t }) ()) } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"->\"") ; :: peg :: RuleResult :: Failed } } { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__newpos , __value) => { :: peg :: RuleResult :: Matched (__newpos , Some (__value)) } , :: peg :: RuleResult :: Failed => { :: peg :: RuleResult :: Matched (__pos , None) } , } ;
+                                                                    match __seq_res { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , ret_type) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "=") { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , __val) => { { let __seq_res = __parse_expression (__input , __state , __err_state , __pos) ; match __seq_res { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , expr) => { { let __seq_res = match match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , ";") { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , __val) => { :: peg :: RuleResult :: Matched (__pos , __val) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\";\"") ; :: peg :: RuleResult :: Failed } } { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__newpos , _) => { :: peg :: RuleResult :: Matched (__newpos , ()) } , :: peg :: RuleResult :: Failed => { :: peg :: RuleResult :: Matched (__pos , ()) } , } ; match __seq_res { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , _) => { :: peg :: RuleResult :: Matched (__pos , (|| { Rule { span , doc , name : header . 0 , ty_params : header . 1 , params : header . 2 , expr , ret_type , visibility , no_eof , cache } }) ()) } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"=\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , }
                                                                 }
                                                                 ::peg::RuleResult::Failed => {
                                                                     ::peg::RuleResult::Failed
                                                                 }
+                                                                ::peg::RuleResult::Error(..) => panic!()
                                                             }
                                                         }
                                                         ::peg::RuleResult::Failed => {
@@ -457,23 +487,29 @@ pub mod peg {
                                                                 .mark_failure(__pos, "\"rule\"");
                                                             ::peg::RuleResult::Failed
                                                         }
+                                                        ::peg::RuleResult::Error(..) => panic!()
                                                     }
                                                 }
                                                 ::peg::RuleResult::Failed => {
                                                     ::peg::RuleResult::Failed
                                                 }
+                                                ::peg::RuleResult::Error(..) => panic!()
                                             }
                                         }
                                         ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
+                                        ::peg::RuleResult::Error(..) => panic!()
                                     }
                                 }
                                 ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
+                                ::peg::RuleResult::Error(..) => panic!()
                             }
                         }
                         ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
+                        ::peg::RuleResult::Error(..) => panic!()
                     }
                 }
                 ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
+                ::peg::RuleResult::Error(..) => panic!()
             }
         }
     }
@@ -506,24 +542,28 @@ pub mod peg {
                                             __err_state.mark_failure(__pos, "\"]\"");
                                             ::peg::RuleResult::Failed
                                         }
+                                        ::peg::RuleResult::Error(..) => panic!()
                                     }
                                 }
                                 ::peg::RuleResult::Failed => {
                                     __err_state.mark_failure(__pos, "\"cache\"");
                                     ::peg::RuleResult::Failed
                                 }
+                                ::peg::RuleResult::Error(..) => panic!()
                             }
                         }
                         ::peg::RuleResult::Failed => {
                             __err_state.mark_failure(__pos, "\"[\"");
                             ::peg::RuleResult::Failed
                         }
+                        ::peg::RuleResult::Error(..) => panic!()
                     }
                 }
                 ::peg::RuleResult::Failed => {
                     __err_state.mark_failure(__pos, "\"#\"");
                     ::peg::RuleResult::Failed
                 }
+                ::peg::RuleResult::Error(..) => panic!()
             };
             match __choice_res {
                 ::peg::RuleResult::Matched(__pos, __value) => {
@@ -555,6 +595,7 @@ pub mod peg {
                                                         __err_state.mark_failure(__pos, "\"]\"");
                                                         ::peg::RuleResult::Failed
                                                     }
+                                                    ::peg::RuleResult::Error(..) => panic!()
                                                 }
                                             }
                                             ::peg::RuleResult::Failed => {
@@ -562,26 +603,31 @@ pub mod peg {
                                                     .mark_failure(__pos, "\"cache_left_rec\"");
                                                 ::peg::RuleResult::Failed
                                             }
+                                            ::peg::RuleResult::Error(..) => panic!()
                                         }
                                     }
                                     ::peg::RuleResult::Failed => {
                                         __err_state.mark_failure(__pos, "\"[\"");
                                         ::peg::RuleResult::Failed
                                     }
+                                    ::peg::RuleResult::Error(..) => panic!()
                                 }
                             }
                             ::peg::RuleResult::Failed => {
                                 __err_state.mark_failure(__pos, "\"#\"");
                                 ::peg::RuleResult::Failed
                             }
+                            ::peg::RuleResult::Error(..) => panic!()
                         };
                     match __choice_res {
                         ::peg::RuleResult::Matched(__pos, __value) => {
                             ::peg::RuleResult::Matched(__pos, __value)
                         }
                         ::peg::RuleResult::Failed => ::peg::RuleResult::Matched(__pos, (|| None)()),
+                        ::peg::RuleResult::Error(..) => panic!()
                     }
                 }
+                ::peg::RuleResult::Error(..) => panic!()
             }
         }
     }
@@ -612,30 +658,35 @@ pub mod peg {
                                             __err_state.mark_failure(__pos, "\"]\"");
                                             ::peg::RuleResult::Failed
                                         }
+                                        ::peg::RuleResult::Error(..) => panic!()
                                     }
                                 }
                                 ::peg::RuleResult::Failed => {
                                     __err_state.mark_failure(__pos, "\"no_eof\"");
                                     ::peg::RuleResult::Failed
                                 }
+                                ::peg::RuleResult::Error(..) => panic!()
                             }
                         }
                         ::peg::RuleResult::Failed => {
                             __err_state.mark_failure(__pos, "\"[\"");
                             ::peg::RuleResult::Failed
                         }
+                        ::peg::RuleResult::Error(..) => panic!()
                     }
                 }
                 ::peg::RuleResult::Failed => {
                     __err_state.mark_failure(__pos, "\"#\"");
                     ::peg::RuleResult::Failed
                 }
+                ::peg::RuleResult::Error(..) => panic!()
             };
             match __choice_res {
                 ::peg::RuleResult::Matched(__pos, __value) => {
                     ::peg::RuleResult::Matched(__pos, __value)
                 }
                 ::peg::RuleResult::Failed => ::peg::RuleResult::Matched(__pos, (|| false)()),
+                ::peg::RuleResult::Error(..) => panic!()
             }
         }
     }
@@ -664,6 +715,7 @@ pub mod peg {
                                             ::peg::RuleResult::Matched(pos, ())
                                         }
                                         ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
+                                        ::peg::RuleResult::Error(..) => panic!()
                                     } {
                                         ::peg::RuleResult::Matched(__newpos, _) => {
                                             ::peg::RuleResult::Matched(
@@ -674,6 +726,7 @@ pub mod peg {
                                             )
                                         }
                                         ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
+                                        ::peg::RuleResult::Error(..) => panic!()
                                     }
                                 };
                                 match __seq_res {
@@ -691,21 +744,25 @@ pub mod peg {
                                                 __err_state.mark_failure(__pos, "\">\"");
                                                 ::peg::RuleResult::Failed
                                             }
+                                            ::peg::RuleResult::Error(..) => panic!()
                                         }
                                     }
                                     ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
+                                    ::peg::RuleResult::Error(..) => panic!()
                                 }
                             }
                             ::peg::RuleResult::Failed => {
                                 __err_state.mark_failure(__pos, "\"<\"");
                                 ::peg::RuleResult::Failed
                             }
+                            ::peg::RuleResult::Error(..) => panic!()
                         }
                     }
                     ::peg::RuleResult::Failed => {
                         __err_state.mark_failure(__pos, "\"rule\"");
                         ::peg::RuleResult::Failed
                     }
+                    ::peg::RuleResult::Error(..) => panic!()
                 };
             match __choice_res {
                 ::peg::RuleResult::Matched(__pos, __value) => {
@@ -719,12 +776,14 @@ pub mod peg {
                                 ::peg::RuleResult::Matched(pos, ())
                             }
                             ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
+                            ::peg::RuleResult::Error(..) => panic!()
                         } {
                             ::peg::RuleResult::Matched(__newpos, _) => ::peg::RuleResult::Matched(
                                 __newpos,
                                 ::peg::ParseSlice::parse_slice(__input, str_start, __newpos),
                             ),
                             ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
+                            ::peg::RuleResult::Error(..) => panic!()
                         }
                     };
                     match __seq_res {
@@ -732,8 +791,10 @@ pub mod peg {
                             ::peg::RuleResult::Matched(__pos, (|| RuleParamTy::Rust(t))())
                         }
                         ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
+                        ::peg::RuleResult::Error(..) => panic!()
                     }
                 }
+                ::peg::RuleResult::Error(..) => panic!()
             }
         }
     }
@@ -764,10 +825,12 @@ pub mod peg {
                                     __err_state.mark_failure(__pos, "\",\"");
                                     ::peg::RuleResult::Failed
                                 }
+                                ::peg::RuleResult::Error(..) => panic!()
                             };
                             match __sep_res {
                                 ::peg::RuleResult::Matched(__newpos, _) => __newpos,
                                 ::peg::RuleResult::Failed => break,
+                                ::peg::RuleResult::Error(..) => panic!()
                             }
                         };
                         let __step_res = {
@@ -794,15 +857,18 @@ pub mod peg {
                                                 ::peg::RuleResult::Failed => {
                                                     ::peg::RuleResult::Failed
                                                 }
+                                                ::peg::RuleResult::Error(..) => panic!()
                                             }
                                         }
                                         ::peg::RuleResult::Failed => {
                                             __err_state.mark_failure(__pos, "\":\"");
                                             ::peg::RuleResult::Failed
                                         }
+                                        ::peg::RuleResult::Error(..) => panic!()
                                     }
                                 }
                                 ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
+                                ::peg::RuleResult::Error(..) => panic!()
                             }
                         };
                         match __step_res {
@@ -813,6 +879,7 @@ pub mod peg {
                             ::peg::RuleResult::Failed => {
                                 break;
                             }
+                            ::peg::RuleResult::Error(..) => panic!()
                         }
                     }
                     ::peg::RuleResult::Matched(__repeat_pos, __repeat_value)
@@ -827,15 +894,18 @@ pub mod peg {
                                 __err_state.mark_failure(__pos, "\")\"");
                                 ::peg::RuleResult::Failed
                             }
+                            ::peg::RuleResult::Error(..) => panic!()
                         }
                     }
                     ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
+                    ::peg::RuleResult::Error(..) => panic!()
                 }
             }
             ::peg::RuleResult::Failed => {
                 __err_state.mark_failure(__pos, "\"(\"");
                 ::peg::RuleResult::Failed
             }
+            ::peg::RuleResult::Error(..) => panic!()
         }
     }
     fn __parse_item<'input>(
@@ -853,6 +923,7 @@ pub mod peg {
                         ::peg::RuleResult::Matched(__pos, (|| Item::Use(u))())
                     }
                     ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
+                    ::peg::RuleResult::Error(..) => panic!()
                 }
             };
             match __choice_res {
@@ -866,8 +937,10 @@ pub mod peg {
                             ::peg::RuleResult::Matched(__pos, (|| Item::Rule(r))())
                         }
                         ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
+                        ::peg::RuleResult::Error(..) => panic!()
                     }
                 }
+                ::peg::RuleResult::Error(..) => panic!()
             }
         }
     }
@@ -910,31 +983,36 @@ pub mod peg {
                                                         ::peg::RuleResult::Failed => {
                                                             ::peg::RuleResult::Failed
                                                         }
+                                                        ::peg::RuleResult::Error(..) => panic!()
                                                     };
-                                                    match __seq_res { :: peg :: RuleResult :: Matched (__pos , _) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "]") { :: peg :: RuleResult :: Matched (__pos , __val) => { :: peg :: RuleResult :: Matched (__pos , ()) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"]\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , }
+                                                    match __seq_res { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , _) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "]") { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , __val) => { :: peg :: RuleResult :: Matched (__pos , ()) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"]\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , }
                                                 }
                                                 ::peg::RuleResult::Failed => {
                                                     __err_state.mark_failure(__pos, "\"=\"");
                                                     ::peg::RuleResult::Failed
                                                 }
+                                                ::peg::RuleResult::Error(..) => panic!()
                                             }
                                         }
                                         ::peg::RuleResult::Failed => {
                                             __err_state.mark_failure(__pos, "\"doc\"");
                                             ::peg::RuleResult::Failed
                                         }
+                                        ::peg::RuleResult::Error(..) => panic!()
                                     }
                                 }
                                 ::peg::RuleResult::Failed => {
                                     __err_state.mark_failure(__pos, "\"[\"");
                                     ::peg::RuleResult::Failed
                                 }
+                                ::peg::RuleResult::Error(..) => panic!()
                             }
                         }
                         ::peg::RuleResult::Failed => {
                             __err_state.mark_failure(__pos, "\"#\"");
                             ::peg::RuleResult::Failed
                         }
+                        ::peg::RuleResult::Error(..) => panic!()
                     };
                     match __step_res {
                         ::peg::RuleResult::Matched(__newpos, __value) => {
@@ -943,6 +1021,7 @@ pub mod peg {
                         ::peg::RuleResult::Failed => {
                             break;
                         }
+                        ::peg::RuleResult::Error(..) => panic!()
                     }
                 }
                 ::peg::RuleResult::Matched(__repeat_pos, ())
@@ -952,12 +1031,14 @@ pub mod peg {
                     ::peg::ParseSlice::parse_slice(__input, str_start, __newpos),
                 ),
                 ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
+                ::peg::RuleResult::Error(..) => panic!()
             }
         } {
             ::peg::RuleResult::Matched(__newpos, __value) => {
                 ::peg::RuleResult::Matched(__newpos, Some(__value))
             }
             ::peg::RuleResult::Failed => ::peg::RuleResult::Matched(__pos, None),
+            ::peg::RuleResult::Error(..) => panic!()
         }
     }
     fn __parse_rust_visibility<'input>(
@@ -983,23 +1064,27 @@ pub mod peg {
                                     ::peg::RuleResult::Matched(pos, ())
                                 }
                                 ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
+                                ::peg::RuleResult::Error(..) => panic!()
                             } {
                                 ::peg::RuleResult::Matched(__newpos, _) => {
                                     ::peg::RuleResult::Matched(__newpos, ())
                                 }
                                 ::peg::RuleResult::Failed => ::peg::RuleResult::Matched(__pos, ()),
+                                ::peg::RuleResult::Error(..) => panic!()
                             };
                             match __seq_res {
                                 ::peg::RuleResult::Matched(__pos, _) => {
                                     ::peg::RuleResult::Matched(__pos, ())
                                 }
                                 ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
+                                ::peg::RuleResult::Error(..) => panic!()
                             }
                         }
                         ::peg::RuleResult::Failed => {
                             __err_state.mark_failure(__pos, "\"pub\"");
                             ::peg::RuleResult::Failed
                         }
+                        ::peg::RuleResult::Error(..) => panic!()
                     };
                 match __choice_res {
                     ::peg::RuleResult::Matched(__pos, __value) => {
@@ -1014,8 +1099,10 @@ pub mod peg {
                                 __err_state.mark_failure(__pos, "\"crate\"");
                                 ::peg::RuleResult::Failed
                             }
+                            ::peg::RuleResult::Error(..) => panic!()
                         }
                     }
+                    ::peg::RuleResult::Error(..) => panic!()
                 }
             } {
                 ::peg::RuleResult::Matched(__newpos, _) => ::peg::RuleResult::Matched(
@@ -1023,12 +1110,14 @@ pub mod peg {
                     ::peg::ParseSlice::parse_slice(__input, str_start, __newpos),
                 ),
                 ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
+                ::peg::RuleResult::Error(..) => panic!()
             }
         } {
             ::peg::RuleResult::Matched(__newpos, __value) => {
                 ::peg::RuleResult::Matched(__newpos, Some(__value))
             }
             ::peg::RuleResult::Failed => ::peg::RuleResult::Matched(__pos, None),
+            ::peg::RuleResult::Error(..) => panic!()
         }
     }
     fn __parse_rust_use<'input>(
@@ -1049,6 +1138,7 @@ pub mod peg {
                                     ::peg::RuleResult::Matched(pos, ())
                                 }
                                 ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
+                                ::peg::RuleResult::Error(..) => panic!()
                             };
                         match __seq_res {
                             ::peg::RuleResult::Matched(__pos, _) => {
@@ -1068,21 +1158,24 @@ pub mod peg {
                                                         __err_state.mark_failure(__pos, "\"*\"");
                                                         ::peg::RuleResult::Failed
                                                     }
+                                                    ::peg::RuleResult::Error(..) => panic!()
                                                 }
                                             }
                                             ::peg::RuleResult::Failed => {
                                                 __err_state.mark_failure(__pos, "\"::\"");
                                                 ::peg::RuleResult::Failed
                                             }
+                                            ::peg::RuleResult::Error(..) => panic!()
                                         };
                                     match __choice_res {
                                         ::peg::RuleResult::Matched(__pos, __value) => {
                                             ::peg::RuleResult::Matched(__pos, __value)
                                         }
                                         ::peg::RuleResult::Failed => {
-                                            let __choice_res = match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "::") { :: peg :: RuleResult :: Matched (__pos , __val) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "{") { :: peg :: RuleResult :: Matched (__pos , __val) => { { let __seq_res = { let mut __repeat_pos = __pos ; let mut __repeat_value = vec ! () ; loop { let __pos = __repeat_pos ; let __pos = if __repeat_value . is_empty () { __pos } else { let __sep_res = match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , ",") { :: peg :: RuleResult :: Matched (__pos , __val) => { :: peg :: RuleResult :: Matched (__pos , __val) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\",\"") ; :: peg :: RuleResult :: Failed } } ; match __sep_res { :: peg :: RuleResult :: Matched (__newpos , _) => { __newpos } , :: peg :: RuleResult :: Failed => break , } } ; let __step_res = { let __seq_res = match __parse_IDENT (__input , __state , __err_state , __pos) { :: peg :: RuleResult :: Matched (pos , _) => :: peg :: RuleResult :: Matched (pos , ()) , :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } ; match __seq_res { :: peg :: RuleResult :: Matched (__pos , _) => { { let __seq_res = match match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "as") { :: peg :: RuleResult :: Matched (__pos , __val) => { { let __seq_res = match __parse_IDENT (__input , __state , __err_state , __pos) { :: peg :: RuleResult :: Matched (pos , _) => :: peg :: RuleResult :: Matched (pos , ()) , :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } ; match __seq_res { :: peg :: RuleResult :: Matched (__pos , _) => { :: peg :: RuleResult :: Matched (__pos , ()) } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"as\"") ; :: peg :: RuleResult :: Failed } } { :: peg :: RuleResult :: Matched (__newpos , _) => { :: peg :: RuleResult :: Matched (__newpos , ()) } , :: peg :: RuleResult :: Failed => { :: peg :: RuleResult :: Matched (__pos , ()) } , } ; match __seq_res { :: peg :: RuleResult :: Matched (__pos , _) => { :: peg :: RuleResult :: Matched (__pos , ()) } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } ; match __step_res { :: peg :: RuleResult :: Matched (__newpos , __value) => { __repeat_pos = __newpos ; __repeat_value . push (__value) ; } , :: peg :: RuleResult :: Failed => { break ; } } } if __repeat_value . len () >= 1 { :: peg :: RuleResult :: Matched (__repeat_pos , ()) } else { :: peg :: RuleResult :: Failed } } ; match __seq_res { :: peg :: RuleResult :: Matched (__pos , _) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "}") { :: peg :: RuleResult :: Matched (__pos , __val) => { :: peg :: RuleResult :: Matched (__pos , ()) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"}\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"{\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"::\"") ; :: peg :: RuleResult :: Failed } } ;
-                                            match __choice_res { :: peg :: RuleResult :: Matched (__pos , __value) => :: peg :: RuleResult :: Matched (__pos , __value) , :: peg :: RuleResult :: Failed => match match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "as") { :: peg :: RuleResult :: Matched (__pos , __val) => { { let __seq_res = match __parse_IDENT (__input , __state , __err_state , __pos) { :: peg :: RuleResult :: Matched (pos , _) => :: peg :: RuleResult :: Matched (pos , ()) , :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } ; match __seq_res { :: peg :: RuleResult :: Matched (__pos , _) => { :: peg :: RuleResult :: Matched (__pos , ()) } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"as\"") ; :: peg :: RuleResult :: Failed } } { :: peg :: RuleResult :: Matched (__newpos , _) => { :: peg :: RuleResult :: Matched (__newpos , ()) } , :: peg :: RuleResult :: Failed => { :: peg :: RuleResult :: Matched (__pos , ()) } , } }
+                                            let __choice_res = match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "::") { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , __val) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "{") { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , __val) => { { let __seq_res = { let mut __repeat_pos = __pos ; let mut __repeat_value = vec ! () ; loop { let __pos = __repeat_pos ; let __pos = if __repeat_value . is_empty () { __pos } else { let __sep_res = match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , ",") { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , __val) => { :: peg :: RuleResult :: Matched (__pos , __val) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\",\"") ; :: peg :: RuleResult :: Failed } } ; match __sep_res { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__newpos , _) => { __newpos } , :: peg :: RuleResult :: Failed => break , } } ; let __step_res = { let __seq_res = match __parse_IDENT (__input , __state , __err_state , __pos) { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (pos , _) => :: peg :: RuleResult :: Matched (pos , ()) , :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } ; match __seq_res { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , _) => { { let __seq_res = match match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "as") { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , __val) => { { let __seq_res = match __parse_IDENT (__input , __state , __err_state , __pos) { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (pos , _) => :: peg :: RuleResult :: Matched (pos , ()) , :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } ; match __seq_res { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , _) => { :: peg :: RuleResult :: Matched (__pos , ()) } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"as\"") ; :: peg :: RuleResult :: Failed } } { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__newpos , _) => { :: peg :: RuleResult :: Matched (__newpos , ()) } , :: peg :: RuleResult :: Failed => { :: peg :: RuleResult :: Matched (__pos , ()) } , } ; match __seq_res { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , _) => { :: peg :: RuleResult :: Matched (__pos , ()) } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } ; match __step_res { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__newpos , __value) => { __repeat_pos = __newpos ; __repeat_value . push (__value) ; } , :: peg :: RuleResult :: Failed => { break ; } } } if __repeat_value . len () >= 1 { :: peg :: RuleResult :: Matched (__repeat_pos , ()) } else { :: peg :: RuleResult :: Failed } } ; match __seq_res { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , _) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "}") { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , __val) => { :: peg :: RuleResult :: Matched (__pos , ()) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"}\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"{\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"::\"") ; :: peg :: RuleResult :: Failed } } ;
+                                            match __choice_res { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , __value) => :: peg :: RuleResult :: Matched (__pos , __value) , :: peg :: RuleResult :: Failed => match match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "as") { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , __val) => { { let __seq_res = match __parse_IDENT (__input , __state , __err_state , __pos) { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (pos , _) => :: peg :: RuleResult :: Matched (pos , ()) , :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } ; match __seq_res { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , _) => { :: peg :: RuleResult :: Matched (__pos , ()) } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"as\"") ; :: peg :: RuleResult :: Failed } } { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__newpos , _) => { :: peg :: RuleResult :: Matched (__newpos , ()) } , :: peg :: RuleResult :: Failed => { :: peg :: RuleResult :: Matched (__pos , ()) } , } }
                                         }
+                                        ::peg::RuleResult::Error(..) => panic!()
                                     }
                                 };
                                 match __seq_res {
@@ -1097,24 +1190,29 @@ pub mod peg {
                                                 __err_state.mark_failure(__pos, "\";\"");
                                                 ::peg::RuleResult::Failed
                                             }
+                                            ::peg::RuleResult::Error(..) => panic!()
                                         }
                                     }
                                     ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
+                                    ::peg::RuleResult::Error(..) => panic!()
                                 }
                             }
                             ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
+                            ::peg::RuleResult::Error(..) => panic!()
                         }
                     }
                     ::peg::RuleResult::Failed => {
                         __err_state.mark_failure(__pos, "\"use\"");
                         ::peg::RuleResult::Failed
                     }
+                    ::peg::RuleResult::Error(..) => panic!()
                 } {
                     ::peg::RuleResult::Matched(__newpos, _) => ::peg::RuleResult::Matched(
                         __newpos,
                         ::peg::ParseSlice::parse_slice(__input, str_start, __newpos),
                     ),
                     ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
+                    ::peg::RuleResult::Error(..) => panic!()
                 }
             };
             match __seq_res {
@@ -1122,6 +1220,7 @@ pub mod peg {
                     ::peg::RuleResult::Matched(__pos, (|| v.to_owned())())
                 }
                 ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
+                ::peg::RuleResult::Error(..) => panic!()
             }
         }
     }
@@ -1144,17 +1243,20 @@ pub mod peg {
                                 __err_state.mark_failure(__pos, "\"::\"");
                                 ::peg::RuleResult::Failed
                             }
+                            ::peg::RuleResult::Error(..) => panic!()
                         }
                     }
                     ::peg::RuleResult::Failed => {
                         __err_state.mark_failure(__pos, "\"crate\"");
                         ::peg::RuleResult::Failed
                     }
+                    ::peg::RuleResult::Error(..) => panic!()
                 } {
                     ::peg::RuleResult::Matched(__newpos, _) => {
                         ::peg::RuleResult::Matched(__newpos, ())
                     }
                     ::peg::RuleResult::Failed => ::peg::RuleResult::Matched(__pos, ()),
+                    ::peg::RuleResult::Error(..) => panic!()
                 };
             match __seq_res {
                 ::peg::RuleResult::Matched(__pos, _) => {
@@ -1176,10 +1278,12 @@ pub mod peg {
                                         __err_state.mark_failure(__pos, "\"::\"");
                                         ::peg::RuleResult::Failed
                                     }
+                                    ::peg::RuleResult::Error(..) => panic!()
                                 };
                                 match __sep_res {
                                     ::peg::RuleResult::Matched(__newpos, _) => __newpos,
                                     ::peg::RuleResult::Failed => break,
+                                    ::peg::RuleResult::Error(..) => panic!()
                                 }
                             };
                             let __step_res =
@@ -1188,6 +1292,7 @@ pub mod peg {
                                         ::peg::RuleResult::Matched(pos, ())
                                     }
                                     ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
+                                    ::peg::RuleResult::Error(..) => panic!()
                                 };
                             match __step_res {
                                 ::peg::RuleResult::Matched(__newpos, __value) => {
@@ -1197,6 +1302,7 @@ pub mod peg {
                                 ::peg::RuleResult::Failed => {
                                     break;
                                 }
+                                ::peg::RuleResult::Error(..) => panic!()
                             }
                         }
                         if __repeat_value.len() >= 1 {
@@ -1210,9 +1316,11 @@ pub mod peg {
                             ::peg::RuleResult::Matched(__pos, ())
                         }
                         ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
+                        ::peg::RuleResult::Error(..) => panic!()
                     }
                 }
                 ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
+                ::peg::RuleResult::Error(..) => panic!()
             }
         }
     }
@@ -1227,6 +1335,7 @@ pub mod peg {
             let __choice_res = match __parse_BRACKET_GROUP(__input, __state, __err_state, __pos) {
                 ::peg::RuleResult::Matched(pos, _) => ::peg::RuleResult::Matched(pos, ()),
                 ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
+                ::peg::RuleResult::Error(..) => panic!()
             };
             match __choice_res {
                 ::peg::RuleResult::Matched(__pos, __value) => {
@@ -1247,6 +1356,7 @@ pub mod peg {
                                             __err_state.mark_failure(__pos, "\"mut\"");
                                             ::peg::RuleResult::Failed
                                         }
+                                        ::peg::RuleResult::Error(..) => panic!()
                                     } {
                                         ::peg::RuleResult::Matched(__newpos, _) => {
                                             ::peg::RuleResult::Matched(__newpos, ())
@@ -1254,6 +1364,7 @@ pub mod peg {
                                         ::peg::RuleResult::Failed => {
                                             ::peg::RuleResult::Matched(__pos, ())
                                         }
+                                        ::peg::RuleResult::Error(..) => panic!()
                                     };
                                 match __seq_res {
                                     ::peg::RuleResult::Matched(__pos, _) => {
@@ -1267,6 +1378,7 @@ pub mod peg {
                                                 ::peg::RuleResult::Matched(pos, ())
                                             }
                                             ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
+                                            ::peg::RuleResult::Error(..) => panic!()
                                         } {
                                             ::peg::RuleResult::Matched(__newpos, _) => {
                                                 ::peg::RuleResult::Matched(__newpos, ())
@@ -1274,6 +1386,7 @@ pub mod peg {
                                             ::peg::RuleResult::Failed => {
                                                 ::peg::RuleResult::Matched(__pos, ())
                                             }
+                                            ::peg::RuleResult::Error(..) => panic!()
                                         };
                                         match __seq_res {
                                             ::peg::RuleResult::Matched(__pos, _) => {
@@ -1289,6 +1402,7 @@ pub mod peg {
                                                     ::peg::RuleResult::Failed => {
                                                         ::peg::RuleResult::Failed
                                                     }
+                                                    ::peg::RuleResult::Error(..) => panic!()
                                                 };
                                                 match __seq_res {
                                                     ::peg::RuleResult::Matched(__pos, _) => {
@@ -1297,18 +1411,22 @@ pub mod peg {
                                                     ::peg::RuleResult::Failed => {
                                                         ::peg::RuleResult::Failed
                                                     }
+                                                    ::peg::RuleResult::Error(..) => panic!()
                                                 }
                                             }
                                             ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
+                                            ::peg::RuleResult::Error(..) => panic!()
                                         }
                                     }
                                     ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
+                                    ::peg::RuleResult::Error(..) => panic!()
                                 }
                             }
                             ::peg::RuleResult::Failed => {
                                 __err_state.mark_failure(__pos, "\"&\"");
                                 ::peg::RuleResult::Failed
                             }
+                            ::peg::RuleResult::Error(..) => panic!()
                         };
                     match __choice_res {
                         ::peg::RuleResult::Matched(__pos, __value) => {
@@ -1329,18 +1447,21 @@ pub mod peg {
                                             ::peg::RuleResult::Matched(pos, ())
                                         }
                                         ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
+                                        ::peg::RuleResult::Error(..) => panic!()
                                     };
                                     match __seq_res {
                                         ::peg::RuleResult::Matched(__pos, _) => {
                                             ::peg::RuleResult::Matched(__pos, ())
                                         }
                                         ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
+                                        ::peg::RuleResult::Error(..) => panic!()
                                     }
                                 }
                                 ::peg::RuleResult::Failed => {
                                     __err_state.mark_failure(__pos, "\"dyn\"");
                                     ::peg::RuleResult::Failed
                                 }
+                                ::peg::RuleResult::Error(..) => panic!()
                             };
                             match __choice_res {
                                 ::peg::RuleResult::Matched(__pos, __value) => {
@@ -1364,6 +1485,7 @@ pub mod peg {
                                                     ::peg::RuleResult::Failed => {
                                                         ::peg::RuleResult::Failed
                                                     }
+                                                    ::peg::RuleResult::Error(..) => panic!()
                                                 };
                                                 match __seq_res {
                                                     ::peg::RuleResult::Matched(__pos, _) => {
@@ -1372,12 +1494,14 @@ pub mod peg {
                                                     ::peg::RuleResult::Failed => {
                                                         ::peg::RuleResult::Failed
                                                     }
+                                                    ::peg::RuleResult::Error(..) => panic!()
                                                 }
                                             }
                                             ::peg::RuleResult::Failed => {
                                                 __err_state.mark_failure(__pos, "\"impl\"");
                                                 ::peg::RuleResult::Failed
                                             }
+                                            ::peg::RuleResult::Error(..) => panic!()
                                         };
                                     match __choice_res {
                                         ::peg::RuleResult::Matched(__pos, __value) => {
@@ -1399,10 +1523,10 @@ pub mod peg {
                                                                 {
                                                                     __pos
                                                                 } else {
-                                                                    let __sep_res = match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , ",") { :: peg :: RuleResult :: Matched (__pos , __val) => { :: peg :: RuleResult :: Matched (__pos , __val) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\",\"") ; :: peg :: RuleResult :: Failed } } ;
-                                                                    match __sep_res { :: peg :: RuleResult :: Matched (__newpos , _) => { __newpos } , :: peg :: RuleResult :: Failed => break , }
+                                                                    let __sep_res = match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , ",") { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , __val) => { :: peg :: RuleResult :: Matched (__pos , __val) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\",\"") ; :: peg :: RuleResult :: Failed } } ;
+                                                                    match __sep_res { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__newpos , _) => { __newpos } , :: peg :: RuleResult :: Failed => break , }
                                                                 };
-                                                                let __step_res = match __parse_rust_type (__input , __state , __err_state , __pos) { :: peg :: RuleResult :: Matched (pos , _) => :: peg :: RuleResult :: Matched (pos , ()) , :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } ;
+                                                                let __step_res = match __parse_rust_type (__input , __state , __err_state , __pos) { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (pos , _) => :: peg :: RuleResult :: Matched (pos , ()) , :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } ;
                                                                 match __step_res {
                                                                     ::peg::RuleResult::Matched(
                                                                         __newpos,
@@ -1415,6 +1539,7 @@ pub mod peg {
                                                                     ::peg::RuleResult::Failed => {
                                                                         break;
                                                                     }
+                                                                    ::peg::RuleResult::Error(..) => panic!()
                                                                 }
                                                             }
                                                             ::peg::RuleResult::Matched(
@@ -1422,12 +1547,13 @@ pub mod peg {
                                                                 (),
                                                             )
                                                         };
-                                                        match __seq_res { :: peg :: RuleResult :: Matched (__pos , _) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , ")") { :: peg :: RuleResult :: Matched (__pos , __val) => { :: peg :: RuleResult :: Matched (__pos , ()) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\")\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , }
+                                                        match __seq_res { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , _) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , ")") { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , __val) => { :: peg :: RuleResult :: Matched (__pos , ()) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\")\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , }
                                                     }
                                                     ::peg::RuleResult::Failed => {
                                                         __err_state.mark_failure(__pos, "\"(\"");
                                                         ::peg::RuleResult::Failed
                                                     }
+                                                    ::peg::RuleResult::Error(..) => panic!()
                                                 };
                                             match __choice_res {
                                                 ::peg::RuleResult::Matched(__pos, __value) => {
@@ -1446,16 +1572,22 @@ pub mod peg {
                                                         ::peg::RuleResult::Failed => {
                                                             ::peg::RuleResult::Failed
                                                         }
+                                                        ::peg::RuleResult::Error(..) => panic!()
                                                     }
                                                 }
+                                                ::peg::RuleResult::Error(..) => panic!()
                                             }
                                         }
+                                        ::peg::RuleResult::Error(..) => panic!()
                                     }
                                 }
+                                ::peg::RuleResult::Error(..) => panic!()
                             }
                         }
+                        ::peg::RuleResult::Error(..) => panic!()
                     }
                 }
+                ::peg::RuleResult::Error(..) => panic!()
             }
         }
     }
@@ -1476,11 +1608,13 @@ pub mod peg {
                         __err_state.mark_failure(__pos, "\"::\"");
                         ::peg::RuleResult::Failed
                     }
+                    ::peg::RuleResult::Error(..) => panic!()
                 } {
                     ::peg::RuleResult::Matched(__newpos, _) => {
                         ::peg::RuleResult::Matched(__newpos, ())
                     }
                     ::peg::RuleResult::Failed => ::peg::RuleResult::Matched(__pos, ()),
+                    ::peg::RuleResult::Error(..) => panic!()
                 };
             match __seq_res {
                 ::peg::RuleResult::Matched(__pos, _) => {
@@ -1502,10 +1636,12 @@ pub mod peg {
                                         __err_state.mark_failure(__pos, "\"::\"");
                                         ::peg::RuleResult::Failed
                                     }
+                                    ::peg::RuleResult::Error(..) => panic!()
                                 };
                                 match __sep_res {
                                     ::peg::RuleResult::Matched(__newpos, _) => __newpos,
                                     ::peg::RuleResult::Failed => break,
+                                    ::peg::RuleResult::Error(..) => panic!()
                                 }
                             };
                             let __step_res = {
@@ -1515,11 +1651,12 @@ pub mod peg {
                                             ::peg::RuleResult::Matched(pos, ())
                                         }
                                         ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
+                                        ::peg::RuleResult::Error(..) => panic!()
                                     };
                                 match __seq_res {
                                     ::peg::RuleResult::Matched(__pos, _) => {
                                         let __seq_res = match {
-                                            let __seq_res = match match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "::") { :: peg :: RuleResult :: Matched (__pos , __val) => { :: peg :: RuleResult :: Matched (__pos , __val) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"::\"") ; :: peg :: RuleResult :: Failed } } { :: peg :: RuleResult :: Matched (__newpos , _) => { :: peg :: RuleResult :: Matched (__newpos , ()) } , :: peg :: RuleResult :: Failed => { :: peg :: RuleResult :: Matched (__pos , ()) } , } ;
+                                            let __seq_res = match match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "::") { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , __val) => { :: peg :: RuleResult :: Matched (__pos , __val) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"::\"") ; :: peg :: RuleResult :: Failed } } { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__newpos , _) => { :: peg :: RuleResult :: Matched (__newpos , ()) } , :: peg :: RuleResult :: Failed => { :: peg :: RuleResult :: Matched (__pos , ()) } , } ;
                                             match __seq_res {
                                                 ::peg::RuleResult::Matched(__pos, _) => {
                                                     match ::peg::ParseLiteral::parse_string_literal(
@@ -1539,14 +1676,14 @@ pub mod peg {
                                                                     {
                                                                         __pos
                                                                     } else {
-                                                                        let __sep_res = match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , ",") { :: peg :: RuleResult :: Matched (__pos , __val) => { :: peg :: RuleResult :: Matched (__pos , __val) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\",\"") ; :: peg :: RuleResult :: Failed } } ;
-                                                                        match __sep_res { :: peg :: RuleResult :: Matched (__newpos , _) => { __newpos } , :: peg :: RuleResult :: Failed => break , }
+                                                                        let __sep_res = match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , ",") { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , __val) => { :: peg :: RuleResult :: Matched (__pos , __val) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\",\"") ; :: peg :: RuleResult :: Failed } } ;
+                                                                        match __sep_res { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__newpos , _) => { __newpos } , :: peg :: RuleResult :: Failed => break , }
                                                                     };
                                                                     let __step_res = {
-                                                                        let __choice_res = match __parse_LIFETIME (__input , __state , __err_state , __pos) { :: peg :: RuleResult :: Matched (pos , _) => :: peg :: RuleResult :: Matched (pos , ()) , :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } ;
-                                                                        match __choice_res { :: peg :: RuleResult :: Matched (__pos , __value) => :: peg :: RuleResult :: Matched (__pos , __value) , :: peg :: RuleResult :: Failed => { let __choice_res = match __parse_rust_type (__input , __state , __err_state , __pos) { :: peg :: RuleResult :: Matched (pos , _) => :: peg :: RuleResult :: Matched (pos , ()) , :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } ; match __choice_res { :: peg :: RuleResult :: Matched (__pos , __value) => :: peg :: RuleResult :: Matched (__pos , __value) , :: peg :: RuleResult :: Failed => { let __choice_res = match __parse_BRACE_GROUP (__input , __state , __err_state , __pos) { :: peg :: RuleResult :: Matched (pos , _) => :: peg :: RuleResult :: Matched (pos , ()) , :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } ; match __choice_res { :: peg :: RuleResult :: Matched (__pos , __value) => :: peg :: RuleResult :: Matched (__pos , __value) , :: peg :: RuleResult :: Failed => match __parse_LITERAL (__input , __state , __err_state , __pos) { :: peg :: RuleResult :: Matched (pos , _) => :: peg :: RuleResult :: Matched (pos , ()) , :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } } } } }
+                                                                        let __choice_res = match __parse_LIFETIME (__input , __state , __err_state , __pos) { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (pos , _) => :: peg :: RuleResult :: Matched (pos , ()) , :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } ;
+                                                                        match __choice_res { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , __value) => :: peg :: RuleResult :: Matched (__pos , __value) , :: peg :: RuleResult :: Failed => { let __choice_res = match __parse_rust_type (__input , __state , __err_state , __pos) { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (pos , _) => :: peg :: RuleResult :: Matched (pos , ()) , :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } ; match __choice_res { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , __value) => :: peg :: RuleResult :: Matched (__pos , __value) , :: peg :: RuleResult :: Failed => { let __choice_res = match __parse_BRACE_GROUP (__input , __state , __err_state , __pos) { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (pos , _) => :: peg :: RuleResult :: Matched (pos , ()) , :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } ; match __choice_res { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , __value) => :: peg :: RuleResult :: Matched (__pos , __value) , :: peg :: RuleResult :: Failed => match __parse_LITERAL (__input , __state , __err_state , __pos) { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (pos , _) => :: peg :: RuleResult :: Matched (pos , ()) , :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } } } } }
                                                                     };
-                                                                    match __step_res { :: peg :: RuleResult :: Matched (__newpos , __value) => { __repeat_pos = __newpos ; __repeat_value . push (__value) ; } , :: peg :: RuleResult :: Failed => { break ; } }
+                                                                    match __step_res { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__newpos , __value) => { __repeat_pos = __newpos ; __repeat_value . push (__value) ; } , :: peg :: RuleResult :: Failed => { break ; } }
                                                                 }
                                                                 if __repeat_value.len() >= 1 {
                                                                     ::peg::RuleResult::Matched(
@@ -1557,18 +1694,20 @@ pub mod peg {
                                                                     ::peg::RuleResult::Failed
                                                                 }
                                                             };
-                                                            match __seq_res { :: peg :: RuleResult :: Matched (__pos , _) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , ">") { :: peg :: RuleResult :: Matched (__pos , __val) => { :: peg :: RuleResult :: Matched (__pos , ()) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\">\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , }
+                                                            match __seq_res { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , _) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , ">") { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , __val) => { :: peg :: RuleResult :: Matched (__pos , ()) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\">\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , }
                                                         }
                                                         ::peg::RuleResult::Failed => {
                                                             __err_state
                                                                 .mark_failure(__pos, "\"<\"");
                                                             ::peg::RuleResult::Failed
                                                         }
+                                                        ::peg::RuleResult::Error(..) => panic!()
                                                     }
                                                 }
                                                 ::peg::RuleResult::Failed => {
                                                     ::peg::RuleResult::Failed
                                                 }
+                                                ::peg::RuleResult::Error(..) => panic!()
                                             }
                                         } {
                                             ::peg::RuleResult::Matched(__newpos, _) => {
@@ -1577,15 +1716,18 @@ pub mod peg {
                                             ::peg::RuleResult::Failed => {
                                                 ::peg::RuleResult::Matched(__pos, ())
                                             }
+                                            ::peg::RuleResult::Error(..) => panic!()
                                         };
                                         match __seq_res {
                                             ::peg::RuleResult::Matched(__pos, _) => {
                                                 ::peg::RuleResult::Matched(__pos, ())
                                             }
                                             ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
+                                            ::peg::RuleResult::Error(..) => panic!()
                                         }
                                     }
                                     ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
+                                    ::peg::RuleResult::Error(..) => panic!()
                                 }
                             };
                             match __step_res {
@@ -1596,6 +1738,7 @@ pub mod peg {
                                 ::peg::RuleResult::Failed => {
                                     break;
                                 }
+                                ::peg::RuleResult::Error(..) => panic!()
                             }
                         }
                         if __repeat_value.len() >= 1 {
@@ -1609,9 +1752,11 @@ pub mod peg {
                             ::peg::RuleResult::Matched(__pos, ())
                         }
                         ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
+                        ::peg::RuleResult::Error(..) => panic!()
                     }
                 }
                 ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
+                ::peg::RuleResult::Error(..) => panic!()
             }
         }
     }
@@ -1642,10 +1787,12 @@ pub mod peg {
                                     __err_state.mark_failure(__pos, "\",\"");
                                     ::peg::RuleResult::Failed
                                 }
+                                ::peg::RuleResult::Error(..) => panic!()
                             };
                             match __sep_res {
                                 ::peg::RuleResult::Matched(__newpos, _) => __newpos,
                                 ::peg::RuleResult::Failed => break,
+                                ::peg::RuleResult::Error(..) => panic!()
                             }
                         };
                         let __step_res = {
@@ -1660,6 +1807,7 @@ pub mod peg {
                                     ::peg::RuleResult::Matched(pos, ())
                                 }
                                 ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
+                                ::peg::RuleResult::Error(..) => panic!()
                             } {
                                 ::peg::RuleResult::Matched(__newpos, _) => {
                                     ::peg::RuleResult::Matched(
@@ -1670,6 +1818,7 @@ pub mod peg {
                                     )
                                 }
                                 ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
+                                ::peg::RuleResult::Error(..) => panic!()
                             }
                         };
                         match __step_res {
@@ -1680,6 +1829,7 @@ pub mod peg {
                             ::peg::RuleResult::Failed => {
                                 break;
                             }
+                            ::peg::RuleResult::Error(..) => panic!()
                         }
                     }
                     if __repeat_value.len() >= 1 {
@@ -1698,15 +1848,18 @@ pub mod peg {
                                 __err_state.mark_failure(__pos, "\">\"");
                                 ::peg::RuleResult::Failed
                             }
+                            ::peg::RuleResult::Error(..) => panic!()
                         }
                     }
                     ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
+                    ::peg::RuleResult::Error(..) => panic!()
                 }
             }
             ::peg::RuleResult::Failed => {
                 __err_state.mark_failure(__pos, "\"<\"");
                 ::peg::RuleResult::Failed
             }
+            ::peg::RuleResult::Error(..) => panic!()
         }
     }
     fn __parse_rust_generic_param<'input>(
@@ -1721,6 +1874,7 @@ pub mod peg {
                 let __seq_res = match __parse_LIFETIME(__input, __state, __err_state, __pos) {
                     ::peg::RuleResult::Matched(pos, _) => ::peg::RuleResult::Matched(pos, ()),
                     ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
+                    ::peg::RuleResult::Error(..) => panic!()
                 };
                 match __seq_res {
                     ::peg::RuleResult::Matched(__pos, _) => {
@@ -1747,10 +1901,12 @@ pub mod peg {
                                                         __err_state.mark_failure(__pos, "\"+\"");
                                                         ::peg::RuleResult::Failed
                                                     }
+                                                    ::peg::RuleResult::Error(..) => panic!()
                                                 };
                                             match __sep_res {
                                                 ::peg::RuleResult::Matched(__newpos, _) => __newpos,
                                                 ::peg::RuleResult::Failed => break,
+                                                ::peg::RuleResult::Error(..) => panic!()
                                             }
                                         };
                                         let __step_res = match __parse_LIFETIME(
@@ -1763,6 +1919,7 @@ pub mod peg {
                                                 ::peg::RuleResult::Matched(pos, ())
                                             }
                                             ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
+                                            ::peg::RuleResult::Error(..) => panic!()
                                         };
                                         match __step_res {
                                             ::peg::RuleResult::Matched(__newpos, __value) => {
@@ -1772,6 +1929,7 @@ pub mod peg {
                                             ::peg::RuleResult::Failed => {
                                                 break;
                                             }
+                                            ::peg::RuleResult::Error(..) => panic!()
                                         }
                                     }
                                     if __repeat_value.len() >= 1 {
@@ -1785,26 +1943,31 @@ pub mod peg {
                                         ::peg::RuleResult::Matched(__pos, ())
                                     }
                                     ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
+                                    ::peg::RuleResult::Error(..) => panic!()
                                 }
                             }
                             ::peg::RuleResult::Failed => {
                                 __err_state.mark_failure(__pos, "\":\"");
                                 ::peg::RuleResult::Failed
                             }
+                            ::peg::RuleResult::Error(..) => panic!()
                         } {
                             ::peg::RuleResult::Matched(__newpos, _) => {
                                 ::peg::RuleResult::Matched(__newpos, ())
                             }
                             ::peg::RuleResult::Failed => ::peg::RuleResult::Matched(__pos, ()),
+                            ::peg::RuleResult::Error(..) => panic!()
                         };
                         match __seq_res {
                             ::peg::RuleResult::Matched(__pos, _) => {
                                 ::peg::RuleResult::Matched(__pos, ())
                             }
                             ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
+                            ::peg::RuleResult::Error(..) => panic!()
                         }
                     }
                     ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
+                    ::peg::RuleResult::Error(..) => panic!()
                 }
             };
             match __choice_res {
@@ -1815,6 +1978,7 @@ pub mod peg {
                     let __seq_res = match __parse_IDENT(__input, __state, __err_state, __pos) {
                         ::peg::RuleResult::Matched(pos, _) => ::peg::RuleResult::Matched(pos, ()),
                         ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
+                        ::peg::RuleResult::Error(..) => panic!()
                     };
                     match __seq_res {
                         ::peg::RuleResult::Matched(__pos, _) => {
@@ -1845,12 +2009,14 @@ pub mod peg {
                                                                 .mark_failure(__pos, "\"+\"");
                                                             ::peg::RuleResult::Failed
                                                         }
+                                                        ::peg::RuleResult::Error(..) => panic!()
                                                     };
                                                 match __sep_res {
                                                     ::peg::RuleResult::Matched(__newpos, _) => {
                                                         __newpos
                                                     }
                                                     ::peg::RuleResult::Failed => break,
+                                                    ::peg::RuleResult::Error(..) => panic!()
                                                 }
                                             };
                                             let __step_res = {
@@ -1866,19 +2032,20 @@ pub mod peg {
                                                     ::peg::RuleResult::Failed => {
                                                         ::peg::RuleResult::Failed
                                                     }
+                                                    ::peg::RuleResult::Error(..) => panic!()
                                                 };
                                                 match __choice_res {
                                                     ::peg::RuleResult::Matched(__pos, __value) => {
                                                         ::peg::RuleResult::Matched(__pos, __value)
                                                     }
                                                     ::peg::RuleResult::Failed => {
-                                                        let __seq_res = match match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "?") { :: peg :: RuleResult :: Matched (__pos , __val) => { :: peg :: RuleResult :: Matched (__pos , __val) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"?\"") ; :: peg :: RuleResult :: Failed } } { :: peg :: RuleResult :: Matched (__newpos , _) => { :: peg :: RuleResult :: Matched (__newpos , ()) } , :: peg :: RuleResult :: Failed => { :: peg :: RuleResult :: Matched (__pos , ()) } , } ;
+                                                        let __seq_res = match match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "?") { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , __val) => { :: peg :: RuleResult :: Matched (__pos , __val) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"?\"") ; :: peg :: RuleResult :: Failed } } { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__newpos , _) => { :: peg :: RuleResult :: Matched (__newpos , ()) } , :: peg :: RuleResult :: Failed => { :: peg :: RuleResult :: Matched (__pos , ()) } , } ;
                                                         match __seq_res {
                                                             ::peg::RuleResult::Matched(
                                                                 __pos,
                                                                 _,
                                                             ) => {
-                                                                let __seq_res = match __parse_rust_ty_path (__input , __state , __err_state , __pos) { :: peg :: RuleResult :: Matched (pos , _) => :: peg :: RuleResult :: Matched (pos , ()) , :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } ;
+                                                                let __seq_res = match __parse_rust_ty_path (__input , __state , __err_state , __pos) { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (pos , _) => :: peg :: RuleResult :: Matched (pos , ()) , :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } ;
                                                                 match __seq_res {
                                                                     ::peg::RuleResult::Matched(
                                                                         __pos,
@@ -1892,13 +2059,16 @@ pub mod peg {
                                                                     ::peg::RuleResult::Failed => {
                                                                         ::peg::RuleResult::Failed
                                                                     }
+                                                                    ::peg::RuleResult::Error(..) => panic!()
                                                                 }
                                                             }
                                                             ::peg::RuleResult::Failed => {
                                                                 ::peg::RuleResult::Failed
                                                             }
+                                                            ::peg::RuleResult::Error(..) => panic!()
                                                         }
                                                     }
+                                                    ::peg::RuleResult::Error(..) => panic!()
                                                 }
                                             };
                                             match __step_res {
@@ -1909,6 +2079,7 @@ pub mod peg {
                                                 ::peg::RuleResult::Failed => {
                                                     break;
                                                 }
+                                                ::peg::RuleResult::Error(..) => panic!()
                                             }
                                         }
                                         if __repeat_value.len() >= 1 {
@@ -1922,28 +2093,34 @@ pub mod peg {
                                             ::peg::RuleResult::Matched(__pos, ())
                                         }
                                         ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
+                                        ::peg::RuleResult::Error(..) => panic!()
                                     }
                                 }
                                 ::peg::RuleResult::Failed => {
                                     __err_state.mark_failure(__pos, "\":\"");
                                     ::peg::RuleResult::Failed
                                 }
+                                ::peg::RuleResult::Error(..) => panic!()
                             } {
                                 ::peg::RuleResult::Matched(__newpos, _) => {
                                     ::peg::RuleResult::Matched(__newpos, ())
                                 }
                                 ::peg::RuleResult::Failed => ::peg::RuleResult::Matched(__pos, ()),
+                                ::peg::RuleResult::Error(..) => panic!()
                             };
                             match __seq_res {
                                 ::peg::RuleResult::Matched(__pos, _) => {
                                     ::peg::RuleResult::Matched(__pos, ())
                                 }
                                 ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
+                                ::peg::RuleResult::Error(..) => panic!()
                             }
                         }
                         ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
+                        ::peg::RuleResult::Error(..) => panic!()
                     }
                 }
+                ::peg::RuleResult::Error(..) => panic!()
             }
         }
     }
@@ -1985,10 +2162,12 @@ pub mod peg {
                                         __err_state.mark_failure(__pos, "\"/\"");
                                         ::peg::RuleResult::Failed
                                     }
+                                    ::peg::RuleResult::Error(..) => panic!()
                                 };
                                 match __sep_res {
                                     ::peg::RuleResult::Matched(__newpos, _) => __newpos,
                                     ::peg::RuleResult::Failed => break,
+                                    ::peg::RuleResult::Error(..) => panic!()
                                 }
                             };
                             let __step_res = __parse_sequence(__input, __state, __err_state, __pos);
@@ -2000,6 +2179,7 @@ pub mod peg {
                                 ::peg::RuleResult::Failed => {
                                     break;
                                 }
+                                ::peg::RuleResult::Error(..) => panic!()
                             }
                         }
                         if __repeat_value.len() >= 1 {
@@ -2020,9 +2200,11 @@ pub mod peg {
                             })(),
                         ),
                         ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
+                        ::peg::RuleResult::Error(..) => panic!()
                     }
                 }
                 ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
+                ::peg::RuleResult::Error(..) => panic!()
             }
         }
     }
@@ -2051,6 +2233,7 @@ pub mod peg {
                                 ::peg::RuleResult::Failed => {
                                     break;
                                 }
+                                ::peg::RuleResult::Error(..) => panic!()
                             }
                         }
                         ::peg::RuleResult::Matched(__repeat_pos, __repeat_value)
@@ -2065,6 +2248,7 @@ pub mod peg {
                                     ::peg::RuleResult::Failed => {
                                         ::peg::RuleResult::Matched(__pos, None)
                                     }
+                                    ::peg::RuleResult::Error(..) => panic!()
                                 };
                             match __seq_res {
                                 ::peg::RuleResult::Matched(__pos, code) => {
@@ -2082,12 +2266,15 @@ pub mod peg {
                                     )
                                 }
                                 ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
+                                ::peg::RuleResult::Error(..) => panic!()
                             }
                         }
                         ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
+                        ::peg::RuleResult::Error(..) => panic!()
                     }
                 }
                 ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
+                ::peg::RuleResult::Error(..) => panic!()
             }
         }
     }
@@ -2111,15 +2298,18 @@ pub mod peg {
                                 __err_state.mark_failure(__pos, "\":\"");
                                 ::peg::RuleResult::Failed
                             }
+                            ::peg::RuleResult::Error(..) => panic!()
                         }
                     }
                     ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
+                    ::peg::RuleResult::Error(..) => panic!()
                 }
             } {
                 ::peg::RuleResult::Matched(__newpos, __value) => {
                     ::peg::RuleResult::Matched(__newpos, Some(__value))
                 }
                 ::peg::RuleResult::Failed => ::peg::RuleResult::Matched(__pos, None),
+                ::peg::RuleResult::Error(..) => panic!()
             };
             match __seq_res {
                 ::peg::RuleResult::Matched(__pos, label) => {
@@ -2135,9 +2325,11 @@ pub mod peg {
                             )
                         }
                         ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
+                        ::peg::RuleResult::Error(..) => panic!()
                     }
                 }
                 ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
+                ::peg::RuleResult::Error(..) => panic!()
             }
         }
     }
@@ -2168,12 +2360,15 @@ pub mod peg {
                                         __err_state.mark_failure(__pos, "\"?\"");
                                         ::peg::RuleResult::Failed
                                     }
+                                    ::peg::RuleResult::Error(..) => panic!()
                                 }
                             }
                             ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
+                            ::peg::RuleResult::Error(..) => panic!()
                         }
                     }
                     ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
+                    ::peg::RuleResult::Error(..) => panic!()
                 }
             };
             match __choice_res {
@@ -2225,23 +2420,28 @@ pub mod peg {
                                                             ::peg::RuleResult::Failed => {
                                                                 ::peg::RuleResult::Failed
                                                             }
+                                                            ::peg::RuleResult::Error(..) => panic!()
                                                         }
                                                     }
                                                     ::peg::RuleResult::Failed => {
                                                         ::peg::RuleResult::Failed
                                                     }
+                                                    ::peg::RuleResult::Error(..) => panic!()
                                                 }
                                             }
                                             ::peg::RuleResult::Failed => {
                                                 __err_state.mark_failure(__pos, "\"**\"");
                                                 ::peg::RuleResult::Failed
                                             }
+                                            ::peg::RuleResult::Error(..) => panic!()
                                         }
                                     }
                                     ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
+                                    ::peg::RuleResult::Error(..) => panic!()
                                 }
                             }
                             ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
+                            ::peg::RuleResult::Error(..) => panic!()
                         }
                     };
                     match __choice_res {
@@ -2287,18 +2487,22 @@ pub mod peg {
                                                             ::peg::RuleResult::Failed => {
                                                                 ::peg::RuleResult::Failed
                                                             }
+                                                            ::peg::RuleResult::Error(..) => panic!()
                                                         }
                                                     }
                                                     ::peg::RuleResult::Failed => {
                                                         __err_state.mark_failure(__pos, "\"++\"");
                                                         ::peg::RuleResult::Failed
                                                     }
+                                                    ::peg::RuleResult::Error(..) => panic!()
                                                 }
                                             }
                                             ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
+                                            ::peg::RuleResult::Error(..) => panic!()
                                         }
                                     }
                                     ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
+                                    ::peg::RuleResult::Error(..) => panic!()
                                 }
                             };
                             match __choice_res {
@@ -2317,9 +2521,10 @@ pub mod peg {
                                                     __err_state,
                                                     __pos,
                                                 );
-                                                match __seq_res { :: peg :: RuleResult :: Matched (__pos , sp) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "*") { :: peg :: RuleResult :: Matched (__pos , __val) => { { let __seq_res = __parse_repeatcount (__input , __state , __err_state , __pos) ; match __seq_res { :: peg :: RuleResult :: Matched (__pos , count) => { :: peg :: RuleResult :: Matched (__pos , (|| { Repeat { inner : Box :: new (e) , bound : count , sep : None } . at (sp) }) ()) } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"*\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , }
+                                                match __seq_res { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , sp) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "*") { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , __val) => { { let __seq_res = __parse_repeatcount (__input , __state , __err_state , __pos) ; match __seq_res { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , count) => { :: peg :: RuleResult :: Matched (__pos , (|| { Repeat { inner : Box :: new (e) , bound : count , sep : None } . at (sp) }) ()) } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"*\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , }
                                             }
                                             ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
+                                            ::peg::RuleResult::Error(..) => panic!()
                                         }
                                     };
                                     match __choice_res {
@@ -2342,11 +2547,12 @@ pub mod peg {
                                                             __err_state,
                                                             __pos,
                                                         );
-                                                        match __seq_res { :: peg :: RuleResult :: Matched (__pos , sp) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "+") { :: peg :: RuleResult :: Matched (__pos , __val) => { :: peg :: RuleResult :: Matched (__pos , (|| { Repeat { inner : Box :: new (e) , bound : BoundedRepeat :: Plus , sep : None } . at (sp) }) ()) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"+\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , }
+                                                        match __seq_res { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , sp) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "+") { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , __val) => { :: peg :: RuleResult :: Matched (__pos , (|| { Repeat { inner : Box :: new (e) , bound : BoundedRepeat :: Plus , sep : None } . at (sp) }) ()) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"+\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , }
                                                     }
                                                     ::peg::RuleResult::Failed => {
                                                         ::peg::RuleResult::Failed
                                                     }
+                                                    ::peg::RuleResult::Error(..) => panic!()
                                                 }
                                             };
                                             match __choice_res {
@@ -2359,14 +2565,19 @@ pub mod peg {
                                                     __err_state,
                                                     __pos,
                                                 ),
+                                                ::peg::RuleResult::Error(..) => panic!()
                                             }
                                         }
+                                        ::peg::RuleResult::Error(..) => panic!()
                                     }
                                 }
+                                ::peg::RuleResult::Error(..) => panic!()
                             }
                         }
+                        ::peg::RuleResult::Error(..) => panic!()
                     }
                 }
+                ::peg::RuleResult::Error(..) => panic!()
             }
         }
     }
@@ -2395,15 +2606,18 @@ pub mod peg {
                                     __err_state.mark_failure(__pos, "\">\"");
                                     ::peg::RuleResult::Failed
                                 }
+                                ::peg::RuleResult::Error(..) => panic!()
                             }
                         }
                         ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
+                        ::peg::RuleResult::Error(..) => panic!()
                     }
                 }
                 ::peg::RuleResult::Failed => {
                     __err_state.mark_failure(__pos, "\"<\"");
                     ::peg::RuleResult::Failed
                 }
+                ::peg::RuleResult::Error(..) => panic!()
             };
             match __choice_res {
                 ::peg::RuleResult::Matched(__pos, __value) => {
@@ -2422,6 +2636,7 @@ pub mod peg {
                                     ::peg::RuleResult::Failed => {
                                         ::peg::RuleResult::Matched(__pos, None)
                                     }
+                                    ::peg::RuleResult::Error(..) => panic!()
                                 };
                             match __seq_res {
                                 ::peg::RuleResult::Matched(__pos, min) => {
@@ -2444,6 +2659,7 @@ pub mod peg {
                                                 ::peg::RuleResult::Failed => {
                                                     ::peg::RuleResult::Matched(__pos, None)
                                                 }
+                                                ::peg::RuleResult::Error(..) => panic!()
                                             };
                                             match __seq_res {
                                                 ::peg::RuleResult::Matched(__pos, max) => {
@@ -2462,26 +2678,31 @@ pub mod peg {
                                                                 .mark_failure(__pos, "\">\"");
                                                             ::peg::RuleResult::Failed
                                                         }
+                                                        ::peg::RuleResult::Error(..) => panic!()
                                                     }
                                                 }
                                                 ::peg::RuleResult::Failed => {
                                                     ::peg::RuleResult::Failed
                                                 }
+                                                ::peg::RuleResult::Error(..) => panic!()
                                             }
                                         }
                                         ::peg::RuleResult::Failed => {
                                             __err_state.mark_failure(__pos, "\",\"");
                                             ::peg::RuleResult::Failed
                                         }
+                                        ::peg::RuleResult::Error(..) => panic!()
                                     }
                                 }
                                 ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
+                                ::peg::RuleResult::Error(..) => panic!()
                             }
                         }
                         ::peg::RuleResult::Failed => {
                             __err_state.mark_failure(__pos, "\"<\"");
                             ::peg::RuleResult::Failed
                         }
+                        ::peg::RuleResult::Error(..) => panic!()
                     };
                     match __choice_res {
                         ::peg::RuleResult::Matched(__pos, __value) => {
@@ -2490,8 +2711,10 @@ pub mod peg {
                         ::peg::RuleResult::Failed => {
                             ::peg::RuleResult::Matched(__pos, (|| BoundedRepeat::None)())
                         }
+                        ::peg::RuleResult::Error(..) => panic!()
                     }
                 }
+                ::peg::RuleResult::Error(..) => panic!()
             }
         }
     }
@@ -2508,6 +2731,7 @@ pub mod peg {
                 let __choice_res = match __parse_INTEGER(__input, __state, __err_state, __pos) {
                     ::peg::RuleResult::Matched(pos, _) => ::peg::RuleResult::Matched(pos, ()),
                     ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
+                    ::peg::RuleResult::Error(..) => panic!()
                 };
                 match __choice_res {
                     ::peg::RuleResult::Matched(__pos, __value) => {
@@ -2519,8 +2743,10 @@ pub mod peg {
                                 ::peg::RuleResult::Matched(pos, ())
                             }
                             ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
+                            ::peg::RuleResult::Error(..) => panic!()
                         }
                     }
+                    ::peg::RuleResult::Error(..) => panic!()
                 }
             } {
                 ::peg::RuleResult::Matched(__newpos, _) => ::peg::RuleResult::Matched(
@@ -2528,6 +2754,7 @@ pub mod peg {
                     ::peg::ParseSlice::parse_slice(__input, str_start, __newpos),
                 ),
                 ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
+                ::peg::RuleResult::Error(..) => panic!()
             }
         }
     }
@@ -2555,15 +2782,18 @@ pub mod peg {
                                         )
                                     }
                                     ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
+                                    ::peg::RuleResult::Error(..) => panic!()
                                 }
                             }
                             ::peg::RuleResult::Failed => {
                                 __err_state.mark_failure(__pos, "\"$\"");
                                 ::peg::RuleResult::Failed
                             }
+                            ::peg::RuleResult::Error(..) => panic!()
                         }
                     }
                     ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
+                    ::peg::RuleResult::Error(..) => panic!()
                 }
             };
             match __choice_res {
@@ -2589,15 +2819,18 @@ pub mod peg {
                                                 )
                                             }
                                             ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
+                                            ::peg::RuleResult::Error(..) => panic!()
                                         }
                                     }
                                     ::peg::RuleResult::Failed => {
                                         __err_state.mark_failure(__pos, "\"&\"");
                                         ::peg::RuleResult::Failed
                                     }
+                                    ::peg::RuleResult::Error(..) => panic!()
                                 }
                             }
                             ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
+                            ::peg::RuleResult::Error(..) => panic!()
                         }
                     };
                     match __choice_res {
@@ -2634,15 +2867,18 @@ pub mod peg {
                                                     ::peg::RuleResult::Failed => {
                                                         ::peg::RuleResult::Failed
                                                     }
+                                                    ::peg::RuleResult::Error(..) => panic!()
                                                 }
                                             }
                                             ::peg::RuleResult::Failed => {
                                                 __err_state.mark_failure(__pos, "\"!\"");
                                                 ::peg::RuleResult::Failed
                                             }
+                                            ::peg::RuleResult::Error(..) => panic!()
                                         }
                                     }
                                     ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
+                                    ::peg::RuleResult::Error(..) => panic!()
                                 }
                             };
                             match __choice_res {
@@ -2652,10 +2888,13 @@ pub mod peg {
                                 ::peg::RuleResult::Failed => {
                                     __parse_primary(__input, __state, __err_state, __pos)
                                 }
+                                ::peg::RuleResult::Error(..) => panic!()
                             }
                         }
+                        ::peg::RuleResult::Error(..) => panic!()
                     }
                 }
+                ::peg::RuleResult::Error(..) => panic!()
             }
         }
     }
@@ -2695,13 +2934,14 @@ pub mod peg {
                                                         let __pos = if __repeat_value.is_empty() {
                                                             __pos
                                                         } else {
-                                                            let __sep_res = match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "--") { :: peg :: RuleResult :: Matched (__pos , __val) => { :: peg :: RuleResult :: Matched (__pos , __val) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"--\"") ; :: peg :: RuleResult :: Failed } } ;
+                                                            let __sep_res = match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "--") { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , __val) => { :: peg :: RuleResult :: Matched (__pos , __val) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"--\"") ; :: peg :: RuleResult :: Failed } } ;
                                                             match __sep_res {
                                                                 ::peg::RuleResult::Matched(
                                                                     __newpos,
                                                                     _,
                                                                 ) => __newpos,
                                                                 ::peg::RuleResult::Failed => break,
+                                                                ::peg::RuleResult::Error(..) => panic!()
                                                             }
                                                         };
                                                         let __step_res = __parse_precedence_level(
@@ -2721,6 +2961,7 @@ pub mod peg {
                                                             ::peg::RuleResult::Failed => {
                                                                 break;
                                                             }
+                                                            ::peg::RuleResult::Error(..) => panic!()
                                                         }
                                                     }
                                                     ::peg::RuleResult::Matched(
@@ -2728,27 +2969,31 @@ pub mod peg {
                                                         __repeat_value,
                                                     )
                                                 };
-                                                match __seq_res { :: peg :: RuleResult :: Matched (__pos , levels) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "}") { :: peg :: RuleResult :: Matched (__pos , __val) => { :: peg :: RuleResult :: Matched (__pos , (|| { PrecedenceExpr { levels : levels } . at (sp) }) ()) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"}\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , }
+                                                match __seq_res { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , levels) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "}") { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , __val) => { :: peg :: RuleResult :: Matched (__pos , (|| { PrecedenceExpr { levels : levels } . at (sp) }) ()) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"}\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , }
                                             }
                                             ::peg::RuleResult::Failed => {
                                                 __err_state.mark_failure(__pos, "\"{\"");
                                                 ::peg::RuleResult::Failed
                                             }
+                                            ::peg::RuleResult::Error(..) => panic!()
                                         }
                                     }
                                     ::peg::RuleResult::Failed => {
                                         __err_state.mark_failure(__pos, "\"!\"");
                                         ::peg::RuleResult::Failed
                                     }
+                                    ::peg::RuleResult::Error(..) => panic!()
                                 }
                             }
                             ::peg::RuleResult::Failed => {
                                 __err_state.mark_failure(__pos, "\"precedence\"");
                                 ::peg::RuleResult::Failed
                             }
+                            ::peg::RuleResult::Error(..) => panic!()
                         }
                     }
                     ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
+                    ::peg::RuleResult::Error(..) => panic!()
                 }
             };
             match __choice_res {
@@ -2758,7 +3003,7 @@ pub mod peg {
                 ::peg::RuleResult::Failed => {
                     let __choice_res = {
                         let __seq_res = __parse_sp(__input, __state, __err_state, __pos);
-                        match __seq_res { :: peg :: RuleResult :: Matched (__pos , sp) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "position") { :: peg :: RuleResult :: Matched (__pos , __val) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "!") { :: peg :: RuleResult :: Matched (__pos , __val) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "(") { :: peg :: RuleResult :: Matched (__pos , __val) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , ")") { :: peg :: RuleResult :: Matched (__pos , __val) => { :: peg :: RuleResult :: Matched (__pos , (|| { PositionExpr . at (sp) }) ()) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\")\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"(\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"!\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"position\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , }
+                        match __seq_res { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , sp) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "position") { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , __val) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "!") { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , __val) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "(") { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , __val) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , ")") { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , __val) => { :: peg :: RuleResult :: Matched (__pos , (|| { PositionExpr . at (sp) }) ()) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\")\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"(\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"!\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"position\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , }
                     };
                     match __choice_res {
                         ::peg::RuleResult::Matched(__pos, __value) => {
@@ -2767,7 +3012,7 @@ pub mod peg {
                         ::peg::RuleResult::Failed => {
                             let __choice_res = {
                                 let __seq_res = __parse_sp(__input, __state, __err_state, __pos);
-                                match __seq_res { :: peg :: RuleResult :: Matched (__pos , sp) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "quiet") { :: peg :: RuleResult :: Matched (__pos , __val) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "!") { :: peg :: RuleResult :: Matched (__pos , __val) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "{") { :: peg :: RuleResult :: Matched (__pos , __val) => { { let __seq_res = __parse_expression (__input , __state , __err_state , __pos) ; match __seq_res { :: peg :: RuleResult :: Matched (__pos , e) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "}") { :: peg :: RuleResult :: Matched (__pos , __val) => { :: peg :: RuleResult :: Matched (__pos , (|| { QuietExpr (Box :: new (e)) . at (sp) }) ()) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"}\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"{\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"!\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"quiet\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , }
+                                match __seq_res { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , sp) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "quiet") { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , __val) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "!") { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , __val) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "{") { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , __val) => { { let __seq_res = __parse_expression (__input , __state , __err_state , __pos) ; match __seq_res { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , e) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "}") { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , __val) => { :: peg :: RuleResult :: Matched (__pos , (|| { QuietExpr (Box :: new (e)) . at (sp) }) ()) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"}\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"{\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"!\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"quiet\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , }
                             };
                             match __choice_res {
                                 ::peg::RuleResult::Matched(__pos, __value) => {
@@ -2777,7 +3022,7 @@ pub mod peg {
                                     let __choice_res = {
                                         let __seq_res =
                                             __parse_sp(__input, __state, __err_state, __pos);
-                                        match __seq_res { :: peg :: RuleResult :: Matched (__pos , sp) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "expected") { :: peg :: RuleResult :: Matched (__pos , __val) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "!") { :: peg :: RuleResult :: Matched (__pos , __val) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "(") { :: peg :: RuleResult :: Matched (__pos , __val) => { { let __seq_res = __parse_LITERAL (__input , __state , __err_state , __pos) ; match __seq_res { :: peg :: RuleResult :: Matched (__pos , s) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , ")") { :: peg :: RuleResult :: Matched (__pos , __val) => { :: peg :: RuleResult :: Matched (__pos , (|| { FailExpr (s) . at (sp) }) ()) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\")\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"(\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"!\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"expected\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , }
+                                        match __seq_res { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , sp) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "expected") { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , __val) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "!") { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , __val) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "(") { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , __val) => { { let __seq_res = __parse_LITERAL (__input , __state , __err_state , __pos) ; match __seq_res { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , s) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , ")") { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , __val) => { :: peg :: RuleResult :: Matched (__pos , (|| { FailExpr (s) . at (sp) }) ()) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\")\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"(\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"!\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"expected\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , }
                                     };
                                     match __choice_res {
                                         ::peg::RuleResult::Matched(__pos, __value) => {
@@ -2788,7 +3033,7 @@ pub mod peg {
                                                 let __seq_res = {
                                                     __err_state.suppress_fail += 1;
                                                     let __assert_res = {
-                                                        let __choice_res = match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "_") { :: peg :: RuleResult :: Matched (__pos , __val) => { :: peg :: RuleResult :: Matched (__pos , __val) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"_\"") ; :: peg :: RuleResult :: Failed } } ;
+                                                        let __choice_res = match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "_") { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , __val) => { :: peg :: RuleResult :: Matched (__pos , __val) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"_\"") ; :: peg :: RuleResult :: Failed } } ;
                                                         match __choice_res {
                                                             ::peg::RuleResult::Matched(
                                                                 __pos,
@@ -2797,9 +3042,10 @@ pub mod peg {
                                                                 __pos, __value,
                                                             ),
                                                             ::peg::RuleResult::Failed => {
-                                                                let __choice_res = match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "__") { :: peg :: RuleResult :: Matched (__pos , __val) => { :: peg :: RuleResult :: Matched (__pos , __val) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"__\"") ; :: peg :: RuleResult :: Failed } } ;
-                                                                match __choice_res { :: peg :: RuleResult :: Matched (__pos , __value) => :: peg :: RuleResult :: Matched (__pos , __value) , :: peg :: RuleResult :: Failed => match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "___") { :: peg :: RuleResult :: Matched (__pos , __val) => { :: peg :: RuleResult :: Matched (__pos , __val) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"___\"") ; :: peg :: RuleResult :: Failed } } }
+                                                                let __choice_res = match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "__") { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , __val) => { :: peg :: RuleResult :: Matched (__pos , __val) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"__\"") ; :: peg :: RuleResult :: Failed } } ;
+                                                                match __choice_res { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , __value) => :: peg :: RuleResult :: Matched (__pos , __value) , :: peg :: RuleResult :: Failed => match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "___") { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , __val) => { :: peg :: RuleResult :: Matched (__pos , __val) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"___\"") ; :: peg :: RuleResult :: Failed } } }
                                                             }
+                                                            ::peg::RuleResult::Error(..) => panic!()
                                                         }
                                                     };
                                                     __err_state.suppress_fail -= 1;
@@ -2812,6 +3058,7 @@ pub mod peg {
                                                         ::peg::RuleResult::Failed => {
                                                             ::peg::RuleResult::Failed
                                                         }
+                                                        ::peg::RuleResult::Error(..) => panic!()
                                                     }
                                                 };
                                                 match __seq_res {
@@ -2853,16 +3100,19 @@ pub mod peg {
                                                                     ::peg::RuleResult::Failed => {
                                                                         ::peg::RuleResult::Failed
                                                                     }
+                                                                    ::peg::RuleResult::Error(..) => panic!()
                                                                 }
                                                             }
                                                             ::peg::RuleResult::Failed => {
                                                                 ::peg::RuleResult::Failed
                                                             }
+                                                            ::peg::RuleResult::Error(..) => panic!()
                                                         }
                                                     }
                                                     ::peg::RuleResult::Failed => {
                                                         ::peg::RuleResult::Failed
                                                     }
+                                                    ::peg::RuleResult::Error(..) => panic!()
                                                 }
                                             };
                                             match __choice_res {
@@ -2888,11 +3138,12 @@ pub mod peg {
                                                                     __err_state,
                                                                     __pos,
                                                                 );
-                                                                match __seq_res { :: peg :: RuleResult :: Matched (__pos , name) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "(") { :: peg :: RuleResult :: Matched (__pos , __val) => { { let __seq_res = { let mut __repeat_pos = __pos ; let mut __repeat_value = vec ! () ; loop { let __pos = __repeat_pos ; let __pos = if __repeat_value . is_empty () { __pos } else { let __sep_res = match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , ",") { :: peg :: RuleResult :: Matched (__pos , __val) => { :: peg :: RuleResult :: Matched (__pos , __val) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\",\"") ; :: peg :: RuleResult :: Failed } } ; match __sep_res { :: peg :: RuleResult :: Matched (__newpos , _) => { __newpos } , :: peg :: RuleResult :: Failed => break , } } ; let __step_res = __parse_rule_arg (__input , __state , __err_state , __pos) ; match __step_res { :: peg :: RuleResult :: Matched (__newpos , __value) => { __repeat_pos = __newpos ; __repeat_value . push (__value) ; } , :: peg :: RuleResult :: Failed => { break ; } } } :: peg :: RuleResult :: Matched (__repeat_pos , __repeat_value) } ; match __seq_res { :: peg :: RuleResult :: Matched (__pos , args) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , ")") { :: peg :: RuleResult :: Matched (__pos , __val) => { :: peg :: RuleResult :: Matched (__pos , (|| { RuleExpr (name , args) . at (sp) }) ()) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\")\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"(\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , }
+                                                                match __seq_res { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , name) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "(") { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , __val) => { { let __seq_res = { let mut __repeat_pos = __pos ; let mut __repeat_value = vec ! () ; loop { let __pos = __repeat_pos ; let __pos = if __repeat_value . is_empty () { __pos } else { let __sep_res = match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , ",") { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , __val) => { :: peg :: RuleResult :: Matched (__pos , __val) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\",\"") ; :: peg :: RuleResult :: Failed } } ; match __sep_res { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__newpos , _) => { __newpos } , :: peg :: RuleResult :: Failed => break , } } ; let __step_res = __parse_rule_arg (__input , __state , __err_state , __pos) ; match __step_res { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__newpos , __value) => { __repeat_pos = __newpos ; __repeat_value . push (__value) ; } , :: peg :: RuleResult :: Failed => { break ; } } } :: peg :: RuleResult :: Matched (__repeat_pos , __repeat_value) } ; match __seq_res { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , args) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , ")") { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , __val) => { :: peg :: RuleResult :: Matched (__pos , (|| { RuleExpr (name , args) . at (sp) }) ()) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\")\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"(\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , }
                                                             }
                                                             ::peg::RuleResult::Failed => {
                                                                 ::peg::RuleResult::Failed
                                                             }
+                                                            ::peg::RuleResult::Error(..) => panic!()
                                                         }
                                                     };
                                                     match __choice_res {
@@ -2922,11 +3173,12 @@ pub mod peg {
                                                                                 __err_state,
                                                                                 __pos,
                                                                             );
-                                                                        match __seq_res { :: peg :: RuleResult :: Matched (__pos , l) => { :: peg :: RuleResult :: Matched (__pos , (|| { LiteralExpr (l) . at (sp) }) ()) } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , }
+                                                                        match __seq_res { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , l) => { :: peg :: RuleResult :: Matched (__pos , (|| { LiteralExpr (l) . at (sp) }) ()) } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , }
                                                                     }
                                                                     ::peg::RuleResult::Failed => {
                                                                         ::peg::RuleResult::Failed
                                                                     }
+                                                                    ::peg::RuleResult::Error(..) => panic!()
                                                                 }
                                                             };
                                                             match __choice_res {
@@ -2944,22 +3196,29 @@ pub mod peg {
                                                                             __err_state,
                                                                             __pos,
                                                                         );
-                                                                        match __seq_res { :: peg :: RuleResult :: Matched (__pos , sp) => { { let __seq_res = __parse_BRACKET_GROUP (__input , __state , __err_state , __pos) ; match __seq_res { :: peg :: RuleResult :: Matched (__pos , p) => { :: peg :: RuleResult :: Matched (__pos , (|| { PatternExpr (p) . at (sp) }) ()) } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , }
+                                                                        match __seq_res { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , sp) => { { let __seq_res = __parse_BRACKET_GROUP (__input , __state , __err_state , __pos) ; match __seq_res { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , p) => { :: peg :: RuleResult :: Matched (__pos , (|| { PatternExpr (p) . at (sp) }) ()) } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , }
                                                                     };
-                                                                    match __choice_res { :: peg :: RuleResult :: Matched (__pos , __value) => :: peg :: RuleResult :: Matched (__pos , __value) , :: peg :: RuleResult :: Failed => { let __choice_res = match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "(") { :: peg :: RuleResult :: Matched (__pos , __val) => { { let __seq_res = __parse_sp (__input , __state , __err_state , __pos) ; match __seq_res { :: peg :: RuleResult :: Matched (__pos , sp) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "@") { :: peg :: RuleResult :: Matched (__pos , __val) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , ")") { :: peg :: RuleResult :: Matched (__pos , __val) => { :: peg :: RuleResult :: Matched (__pos , (|| { MarkerExpr (true) . at (sp) }) ()) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\")\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"@\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"(\"") ; :: peg :: RuleResult :: Failed } } ; match __choice_res { :: peg :: RuleResult :: Matched (__pos , __value) => :: peg :: RuleResult :: Matched (__pos , __value) , :: peg :: RuleResult :: Failed => { let __choice_res = { let __seq_res = __parse_sp (__input , __state , __err_state , __pos) ; match __seq_res { :: peg :: RuleResult :: Matched (__pos , sp) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "@") { :: peg :: RuleResult :: Matched (__pos , __val) => { :: peg :: RuleResult :: Matched (__pos , (|| { MarkerExpr (false) . at (sp) }) ()) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"@\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } ; match __choice_res { :: peg :: RuleResult :: Matched (__pos , __value) => :: peg :: RuleResult :: Matched (__pos , __value) , :: peg :: RuleResult :: Failed => { let __choice_res = { let __seq_res = __parse_sp (__input , __state , __err_state , __pos) ; match __seq_res { :: peg :: RuleResult :: Matched (__pos , sp) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "##") { :: peg :: RuleResult :: Matched (__pos , __val) => { { let __seq_res = __parse_IDENT (__input , __state , __err_state , __pos) ; match __seq_res { :: peg :: RuleResult :: Matched (__pos , method) => { { let __seq_res = __parse_PAREN_GROUP (__input , __state , __err_state , __pos) ; match __seq_res { :: peg :: RuleResult :: Matched (__pos , args) => { :: peg :: RuleResult :: Matched (__pos , (|| { MethodExpr (method , args . stream ()) . at (sp) }) ()) } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"##\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } ; match __choice_res { :: peg :: RuleResult :: Matched (__pos , __value) => :: peg :: RuleResult :: Matched (__pos , __value) , :: peg :: RuleResult :: Failed => match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "(") { :: peg :: RuleResult :: Matched (__pos , __val) => { { let __seq_res = __parse_expression (__input , __state , __err_state , __pos) ; match __seq_res { :: peg :: RuleResult :: Matched (__pos , expression) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , ")") { :: peg :: RuleResult :: Matched (__pos , __val) => { :: peg :: RuleResult :: Matched (__pos , (|| { expression }) ()) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\")\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"(\"") ; :: peg :: RuleResult :: Failed } } } } } } } } }
+                                                                    match __choice_res { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , __value) => :: peg :: RuleResult :: Matched (__pos , __value) , :: peg :: RuleResult :: Failed => { let __choice_res = match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "(") { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , __val) => { { let __seq_res = __parse_sp (__input , __state , __err_state , __pos) ; match __seq_res { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , sp) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "@") { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , __val) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , ")") { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , __val) => { :: peg :: RuleResult :: Matched (__pos , (|| { MarkerExpr (true) . at (sp) }) ()) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\")\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"@\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"(\"") ; :: peg :: RuleResult :: Failed } } ; match __choice_res { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , __value) => :: peg :: RuleResult :: Matched (__pos , __value) , :: peg :: RuleResult :: Failed => { let __choice_res = { let __seq_res = __parse_sp (__input , __state , __err_state , __pos) ; match __seq_res { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , sp) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "@") { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , __val) => { :: peg :: RuleResult :: Matched (__pos , (|| { MarkerExpr (false) . at (sp) }) ()) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"@\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } ; match __choice_res { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , __value) => :: peg :: RuleResult :: Matched (__pos , __value) , :: peg :: RuleResult :: Failed => { let __choice_res = { let __seq_res = __parse_sp (__input , __state , __err_state , __pos) ; match __seq_res { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , sp) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "##") { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , __val) => { { let __seq_res = __parse_IDENT (__input , __state , __err_state , __pos) ; match __seq_res { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , method) => { { let __seq_res = __parse_PAREN_GROUP (__input , __state , __err_state , __pos) ; match __seq_res { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , args) => { :: peg :: RuleResult :: Matched (__pos , (|| { MethodExpr (method , args . stream ()) . at (sp) }) ()) } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"##\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } ; match __choice_res { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , __value) => :: peg :: RuleResult :: Matched (__pos , __value) , :: peg :: RuleResult :: Failed => match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "(") { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , __val) => { { let __seq_res = __parse_expression (__input , __state , __err_state , __pos) ; match __seq_res { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , expression) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , ")") { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , __val) => { :: peg :: RuleResult :: Matched (__pos , (|| { expression }) ()) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\")\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"(\"") ; :: peg :: RuleResult :: Failed } } } } } } } } }
                                                                 }
+                                                                ::peg::RuleResult::Error(..) => panic!()
                                                             }
                                                         }
+                                                        ::peg::RuleResult::Error(..) => panic!()
                                                     }
                                                 }
+                                                ::peg::RuleResult::Error(..) => panic!()
                                             }
                                         }
+                                        ::peg::RuleResult::Error(..) => panic!()
                                     }
                                 }
+                                ::peg::RuleResult::Error(..) => panic!()
                             }
                         }
+                        ::peg::RuleResult::Error(..) => panic!()
                     }
                 }
+                ::peg::RuleResult::Error(..) => panic!()
             }
         };
         __state.primary_cache.insert(__pos, __rule_result.clone());
@@ -2987,15 +3246,18 @@ pub mod peg {
                                     __err_state.mark_failure(__pos, "\">\"");
                                     ::peg::RuleResult::Failed
                                 }
+                                ::peg::RuleResult::Error(..) => panic!()
                             }
                         }
                         ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
+                        ::peg::RuleResult::Error(..) => panic!()
                     }
                 }
                 ::peg::RuleResult::Failed => {
                     __err_state.mark_failure(__pos, "\"<\"");
                     ::peg::RuleResult::Failed
                 }
+                ::peg::RuleResult::Error(..) => panic!()
             };
             match __choice_res {
                 ::peg::RuleResult::Matched(__pos, __value) => {
@@ -3018,6 +3280,7 @@ pub mod peg {
                                     ::peg::RuleResult::Failed => {
                                         break;
                                     }
+                                    ::peg::RuleResult::Error(..) => panic!()
                                 }
                             }
                             if __repeat_value.len() >= 1 {
@@ -3031,6 +3294,7 @@ pub mod peg {
                                 ::peg::ParseSlice::parse_slice(__input, str_start, __newpos),
                             ),
                             ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
+                            ::peg::RuleResult::Error(..) => panic!()
                         }
                     };
                     match __seq_res {
@@ -3038,8 +3302,10 @@ pub mod peg {
                             ::peg::RuleResult::Matched(__pos, (|| RuleArg::Rust(tt))())
                         }
                         ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
+                        ::peg::RuleResult::Error(..) => panic!()
                     }
                 }
+                ::peg::RuleResult::Error(..) => panic!()
             }
         }
     }
@@ -3065,6 +3331,7 @@ pub mod peg {
                         ::peg::RuleResult::Failed => {
                             break;
                         }
+                        ::peg::RuleResult::Error(..) => panic!()
                     }
                 }
                 if __repeat_value.len() >= 1 {
@@ -3081,6 +3348,7 @@ pub mod peg {
                     })(),
                 ),
                 ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
+                ::peg::RuleResult::Error(..) => panic!()
             }
         }
     }
@@ -3109,6 +3377,7 @@ pub mod peg {
                                 ::peg::RuleResult::Failed => {
                                     break;
                                 }
+                                ::peg::RuleResult::Error(..) => panic!()
                             }
                         }
                         ::peg::RuleResult::Matched(__repeat_pos, __repeat_value)
@@ -3129,12 +3398,15 @@ pub mod peg {
                                     )
                                 }
                                 ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
+                                ::peg::RuleResult::Error(..) => panic!()
                             }
                         }
                         ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
+                        ::peg::RuleResult::Error(..) => panic!()
                     }
                 }
                 ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
+                ::peg::RuleResult::Error(..) => panic!()
             }
         }
     }
@@ -3164,6 +3436,7 @@ pub mod peg {
                         __err_state.mark_failure(__pos, "\"pub\"");
                         ::peg::RuleResult::Failed
                     }
+                    ::peg::RuleResult::Error(..) => panic!()
                 };
             match __choice_res {
                 ::peg::RuleResult::Matched(__pos, __value) => {
@@ -3179,6 +3452,7 @@ pub mod peg {
                                 __err_state.mark_failure(__pos, "\"crate\"");
                                 ::peg::RuleResult::Failed
                             }
+                            ::peg::RuleResult::Error(..) => panic!()
                         };
                     match __choice_res {
                         ::peg::RuleResult::Matched(__pos, __value) => {
@@ -3195,6 +3469,7 @@ pub mod peg {
                                     __err_state.mark_failure(__pos, "\"rule\"");
                                     ::peg::RuleResult::Failed
                                 }
+                                ::peg::RuleResult::Error(..) => panic!()
                             };
                             match __choice_res {
                                 ::peg::RuleResult::Matched(__pos, __value) => {
@@ -3212,6 +3487,7 @@ pub mod peg {
                                                 __err_state.mark_failure(__pos, "\"use\"");
                                                 ::peg::RuleResult::Failed
                                             }
+                                            ::peg::RuleResult::Error(..) => panic!()
                                         };
                                     match __choice_res {
                                         ::peg::RuleResult::Matched(__pos, __value) => {
@@ -3228,14 +3504,19 @@ pub mod peg {
                                                     __err_state.mark_failure(__pos, "\"type\"");
                                                     ::peg::RuleResult::Failed
                                                 }
+                                                ::peg::RuleResult::Error(..) => panic!()
                                             }
                                         }
+                                        ::peg::RuleResult::Error(..) => panic!()
                                     }
                                 }
+                                ::peg::RuleResult::Error(..) => panic!()
                             }
                         }
+                        ::peg::RuleResult::Error(..) => panic!()
                     }
                 }
+                ::peg::RuleResult::Error(..) => panic!()
             }
         }
     }
@@ -3252,11 +3533,13 @@ pub mod peg {
                 let __assert_res = match __parse_KEYWORD(__input, __state, __err_state, __pos) {
                     ::peg::RuleResult::Matched(pos, _) => ::peg::RuleResult::Matched(pos, ()),
                     ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
+                    ::peg::RuleResult::Error(..) => panic!()
                 };
                 __err_state.suppress_fail -= 1;
                 match __assert_res {
                     ::peg::RuleResult::Failed => ::peg::RuleResult::Matched(__pos, ()),
                     ::peg::RuleResult::Matched(..) => __err_state.mark_failure(__pos, "mismatch"),
+                    ::peg::RuleResult::Error(..) => panic!()
                 }
             };
             match __seq_res {
@@ -3267,9 +3550,11 @@ pub mod peg {
                             ::peg::RuleResult::Matched(__pos, (|| i)())
                         }
                         ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
+                        ::peg::RuleResult::Error(..) => panic!()
                     }
                 }
                 ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
+                ::peg::RuleResult::Error(..) => panic!()
             }
         }
     }
@@ -3321,16 +3606,19 @@ pub mod peg {
                 let __seq_res = match __parse_IDENT(__input, __state, __err_state, __pos) {
                     ::peg::RuleResult::Matched(pos, _) => ::peg::RuleResult::Matched(pos, ()),
                     ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
+                    ::peg::RuleResult::Error(..) => panic!()
                 };
                 match __seq_res {
                     ::peg::RuleResult::Matched(__pos, _) => ::peg::RuleResult::Matched(__pos, ()),
                     ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
+                    ::peg::RuleResult::Error(..) => panic!()
                 }
             }
             ::peg::RuleResult::Failed => {
                 __err_state.mark_failure(__pos, "\"'\"");
                 ::peg::RuleResult::Failed
             }
+            ::peg::RuleResult::Error(..) => panic!()
         }
     }
     fn __parse_INTEGER<'input>(
@@ -3343,6 +3631,7 @@ pub mod peg {
         match __parse_LITERAL(__input, __state, __err_state, __pos) {
             ::peg::RuleResult::Matched(pos, _) => ::peg::RuleResult::Matched(pos, ()),
             ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
-        }
+            ::peg::RuleResult::Error(..) => panic!()
+         }
     }
 }

--- a/peg-macros/grammar.rs
+++ b/peg-macros/grammar.rs
@@ -40,7 +40,8 @@ pub mod peg {
                     __err_state.mark_failure(__pos, "EOF");
                 }
             }
-            _ => (),
+            ::peg::RuleResult::Error(__e) => return __err_state.into_error(__e, __input),
+            ::peg::RuleResult::Failed => (),
         }
         __state = ParseState::new();
         __err_state.reparse_for_failure();
@@ -100,7 +101,9 @@ pub mod peg {
                                                 ::peg::RuleResult::Failed => {
                                                     ::peg::RuleResult::Matched(__pos, None)
                                                 }
-                                                ::peg::RuleResult::Error(..) => panic!()
+                                                ::peg::RuleResult::Error(__e) => {
+                                                    ::peg::RuleResult::Error(__e)
+                                                }
                                             };
                                             match __seq_res {
                                                 ::peg::RuleResult::Matched(
@@ -113,31 +116,38 @@ pub mod peg {
                                                         __err_state,
                                                         __pos,
                                                     );
-                                                    match __seq_res { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , args) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "for") { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , __val) => { { let __seq_res = { let str_start = __pos ; match match __parse_rust_type (__input , __state , __err_state , __pos) { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (pos , _) => :: peg :: RuleResult :: Matched (pos , ()) , :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , ::peg::RuleResult::Error(..) => panic!() } { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__newpos , _) => { :: peg :: RuleResult :: Matched (__newpos , :: peg :: ParseSlice :: parse_slice (__input , str_start , __newpos)) } , :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , ::peg::RuleResult::Error(..) => panic!() } } ; match __seq_res { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , input_type) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "{") { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , __val) => { { let __seq_res = { let mut __repeat_pos = __pos ; let mut __repeat_value = vec ! () ; loop { let __pos = __repeat_pos ; let __step_res = __parse_item (__input , __state , __err_state , __pos) ; match __step_res { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__newpos , __value) => { __repeat_pos = __newpos ; __repeat_value . push (__value) ; } , :: peg :: RuleResult :: Failed => { break ; }, ::peg::RuleResult::Error(..) => panic!() } } :: peg :: RuleResult :: Matched (__repeat_pos , __repeat_value) } ; match __seq_res { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , items) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "}") { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , __val) => { :: peg :: RuleResult :: Matched (__pos , (|| { Grammar { doc , visibility , name , lifetime_params , args , input_type , items } }) ()) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"}\"") ; :: peg :: RuleResult :: Failed }, ::peg::RuleResult::Error(..) => panic!() } } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , ::peg::RuleResult::Error(..) => panic!() } } } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"{\"") ; :: peg :: RuleResult :: Failed } , ::peg::RuleResult::Error(..) => panic!() } } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , ::peg::RuleResult::Error(..) => panic!() } } } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"for\"") ; :: peg :: RuleResult :: Failed } , ::peg::RuleResult::Error(..) => panic!() } } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , ::peg::RuleResult::Error(..) => panic!() }
+                                                    match __seq_res { :: peg :: RuleResult :: Matched (__pos , args) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "for") { :: peg :: RuleResult :: Matched (__pos , __val) => { { let __seq_res = { let str_start = __pos ; match match __parse_rust_type (__input , __state , __err_state , __pos) { :: peg :: RuleResult :: Matched (pos , _) => :: peg :: RuleResult :: Matched (pos , ()) , :: peg :: RuleResult :: Error (e) => :: peg :: RuleResult :: Error (e) , :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } { :: peg :: RuleResult :: Matched (__newpos , _) => { :: peg :: RuleResult :: Matched (__newpos , :: peg :: ParseSlice :: parse_slice (__input , str_start , __newpos)) } , :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , :: peg :: RuleResult :: Error (__e) => :: peg :: RuleResult :: Error (__e) , } } ; match __seq_res { :: peg :: RuleResult :: Matched (__pos , input_type) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "{") { :: peg :: RuleResult :: Matched (__pos , __val) => { { let __seq_res = { let mut __repeat_pos = __pos ; let mut __maybe_err = None ; let mut __repeat_value = vec ! () ; loop { let __pos = __repeat_pos ; let __step_res = __parse_item (__input , __state , __err_state , __pos) ; match __step_res { :: peg :: RuleResult :: Matched (__newpos , __value) => { __repeat_pos = __newpos ; __repeat_value . push (__value) ; } , :: peg :: RuleResult :: Failed => { break ; } :: peg :: RuleResult :: Error (__e) => { __maybe_err = Some (__e) ; break ; } } } :: peg :: RuleResult :: Matched (__repeat_pos , __repeat_value) } ; match __seq_res { :: peg :: RuleResult :: Matched (__pos , items) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "}") { :: peg :: RuleResult :: Matched (__pos , __val) => { :: peg :: RuleResult :: Matched (__pos , (|| { Grammar { doc , visibility , name , lifetime_params , args , input_type , items } }) ()) } :: peg :: RuleResult :: Error (__e) => { __err_state . mark_error (__e) ; :: peg :: RuleResult :: Error (__e) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"}\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Error (__e) => :: peg :: RuleResult :: Error (__e) , :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } } :: peg :: RuleResult :: Error (__e) => { __err_state . mark_error (__e) ; :: peg :: RuleResult :: Error (__e) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"{\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Error (__e) => :: peg :: RuleResult :: Error (__e) , :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } } :: peg :: RuleResult :: Error (__e) => { __err_state . mark_error (__e) ; :: peg :: RuleResult :: Error (__e) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"for\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Error (__e) => :: peg :: RuleResult :: Error (__e) , :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , }
+                                                }
+                                                ::peg::RuleResult::Error(__e) => {
+                                                    ::peg::RuleResult::Error(__e)
                                                 }
                                                 ::peg::RuleResult::Failed => {
                                                     ::peg::RuleResult::Failed
                                                 }
-                                                ::peg::RuleResult::Error(..) => panic!()
                                             }
                                         }
+                                        ::peg::RuleResult::Error(__e) => {
+                                            ::peg::RuleResult::Error(__e)
+                                        }
                                         ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
-                                        ::peg::RuleResult::Error(..) => panic!()
                                     }
+                                }
+                                ::peg::RuleResult::Error(__e) => {
+                                    __err_state.mark_error(__e);
+                                    ::peg::RuleResult::Error(__e)
                                 }
                                 ::peg::RuleResult::Failed => {
                                     __err_state.mark_failure(__pos, "\"grammar\"");
                                     ::peg::RuleResult::Failed
                                 }
-                                ::peg::RuleResult::Error(..) => panic!()
                             }
                         }
+                        ::peg::RuleResult::Error(__e) => ::peg::RuleResult::Error(__e),
                         ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
-                        ::peg::RuleResult::Error(..) => panic!()
                     }
                 }
+                ::peg::RuleResult::Error(__e) => ::peg::RuleResult::Error(__e),
                 ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
-                ::peg::RuleResult::Error(..) => panic!()
             }
         }
     }
@@ -152,6 +162,7 @@ pub mod peg {
             ::peg::RuleResult::Matched(__pos, __val) => {
                 let __seq_res = {
                     let mut __repeat_pos = __pos;
+                    let mut __maybe_err = None;
                     let mut __repeat_value = vec![];
                     loop {
                         let __pos = __repeat_pos;
@@ -164,16 +175,22 @@ pub mod peg {
                                 ::peg::RuleResult::Matched(__pos, __val) => {
                                     ::peg::RuleResult::Matched(__pos, __val)
                                 }
+                                ::peg::RuleResult::Error(__e) => {
+                                    __err_state.mark_error(__e);
+                                    ::peg::RuleResult::Error(__e)
+                                }
                                 ::peg::RuleResult::Failed => {
                                     __err_state.mark_failure(__pos, "\",\"");
                                     ::peg::RuleResult::Failed
                                 }
-                                ::peg::RuleResult::Error(..) => panic!()
                             };
                             match __sep_res {
                                 ::peg::RuleResult::Matched(__newpos, _) => __newpos,
                                 ::peg::RuleResult::Failed => break,
-                                ::peg::RuleResult::Error(..) => panic!()
+                                ::peg::RuleResult::Error(__e) => {
+                                    __maybe_err = Some(__e);
+                                    break;
+                                }
                             }
                         };
                         let __step_res = {
@@ -182,8 +199,8 @@ pub mod peg {
                                 ::peg::RuleResult::Matched(pos, _) => {
                                     ::peg::RuleResult::Matched(pos, ())
                                 }
+                                ::peg::RuleResult::Error(e) => ::peg::RuleResult::Error(e),
                                 ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
-                                ::peg::RuleResult::Error(..) => panic!()
                             } {
                                 ::peg::RuleResult::Matched(__newpos, _) => {
                                     ::peg::RuleResult::Matched(
@@ -194,7 +211,7 @@ pub mod peg {
                                     )
                                 }
                                 ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
-                                ::peg::RuleResult::Error(..) => panic!()
+                                ::peg::RuleResult::Error(__e) => ::peg::RuleResult::Error(__e),
                             }
                         };
                         match __step_res {
@@ -205,10 +222,15 @@ pub mod peg {
                             ::peg::RuleResult::Failed => {
                                 break;
                             }
-                            ::peg::RuleResult::Error(..) => panic!()
+                            ::peg::RuleResult::Error(__e) => {
+                                __maybe_err = Some(__e);
+                                break;
+                            }
                         }
                     }
-                    if __repeat_value.len() >= 1 {
+                    if let Some(__e) = __maybe_err {
+                        ::peg::RuleResult::Error(__e)
+                    } else if __repeat_value.len() >= 1 {
                         ::peg::RuleResult::Matched(__repeat_pos, __repeat_value)
                     } else {
                         ::peg::RuleResult::Failed
@@ -220,22 +242,28 @@ pub mod peg {
                             ::peg::RuleResult::Matched(__pos, __val) => {
                                 ::peg::RuleResult::Matched(__pos, (|| p)())
                             }
+                            ::peg::RuleResult::Error(__e) => {
+                                __err_state.mark_error(__e);
+                                ::peg::RuleResult::Error(__e)
+                            }
                             ::peg::RuleResult::Failed => {
                                 __err_state.mark_failure(__pos, "\">\"");
                                 ::peg::RuleResult::Failed
                             }
-                            ::peg::RuleResult::Error(..) => panic!()
                         }
                     }
+                    ::peg::RuleResult::Error(__e) => ::peg::RuleResult::Error(__e),
                     ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
-                    ::peg::RuleResult::Error(..) => panic!()
                 }
+            }
+            ::peg::RuleResult::Error(__e) => {
+                __err_state.mark_error(__e);
+                ::peg::RuleResult::Error(__e)
             }
             ::peg::RuleResult::Failed => {
                 __err_state.mark_failure(__pos, "\"<\"");
                 ::peg::RuleResult::Failed
             }
-            ::peg::RuleResult::Error(..) => panic!()
         }
     }
     fn __parse_grammar_args<'input>(
@@ -249,6 +277,7 @@ pub mod peg {
             ::peg::RuleResult::Matched(__pos, __val) => {
                 let __seq_res = {
                     let mut __repeat_pos = __pos;
+                    let mut __maybe_err = None;
                     let mut __repeat_value = vec![];
                     loop {
                         let __pos = __repeat_pos;
@@ -261,16 +290,22 @@ pub mod peg {
                                 ::peg::RuleResult::Matched(__pos, __val) => {
                                     ::peg::RuleResult::Matched(__pos, __val)
                                 }
+                                ::peg::RuleResult::Error(__e) => {
+                                    __err_state.mark_error(__e);
+                                    ::peg::RuleResult::Error(__e)
+                                }
                                 ::peg::RuleResult::Failed => {
                                     __err_state.mark_failure(__pos, "\",\"");
                                     ::peg::RuleResult::Failed
                                 }
-                                ::peg::RuleResult::Error(..) => panic!()
                             };
                             match __sep_res {
                                 ::peg::RuleResult::Matched(__newpos, _) => __newpos,
                                 ::peg::RuleResult::Failed => break,
-                                ::peg::RuleResult::Error(..) => panic!()
+                                ::peg::RuleResult::Error(__e) => {
+                                    __maybe_err = Some(__e);
+                                    break;
+                                }
                             }
                         };
                         let __step_res = {
@@ -292,10 +327,12 @@ pub mod peg {
                                                     ::peg::RuleResult::Matched(pos, _) => {
                                                         ::peg::RuleResult::Matched(pos, ())
                                                     }
+                                                    ::peg::RuleResult::Error(e) => {
+                                                        ::peg::RuleResult::Error(e)
+                                                    }
                                                     ::peg::RuleResult::Failed => {
                                                         ::peg::RuleResult::Failed
                                                     }
-                                                    ::peg::RuleResult::Error(..) => panic!()
                                                 } {
                                                     ::peg::RuleResult::Matched(__newpos, _) => {
                                                         ::peg::RuleResult::Matched(
@@ -308,28 +345,35 @@ pub mod peg {
                                                     ::peg::RuleResult::Failed => {
                                                         ::peg::RuleResult::Failed
                                                     }
-                                                    ::peg::RuleResult::Error(..) => panic!()
+                                                    ::peg::RuleResult::Error(__e) => {
+                                                        ::peg::RuleResult::Error(__e)
+                                                    }
                                                 }
                                             };
                                             match __seq_res {
                                                 ::peg::RuleResult::Matched(__pos, t) => {
                                                     ::peg::RuleResult::Matched(__pos, (|| (i, t))())
                                                 }
+                                                ::peg::RuleResult::Error(__e) => {
+                                                    ::peg::RuleResult::Error(__e)
+                                                }
                                                 ::peg::RuleResult::Failed => {
                                                     ::peg::RuleResult::Failed
                                                 }
-                                                ::peg::RuleResult::Error(..) => panic!()
                                             }
+                                        }
+                                        ::peg::RuleResult::Error(__e) => {
+                                            __err_state.mark_error(__e);
+                                            ::peg::RuleResult::Error(__e)
                                         }
                                         ::peg::RuleResult::Failed => {
                                             __err_state.mark_failure(__pos, "\":\"");
                                             ::peg::RuleResult::Failed
                                         }
-                                        ::peg::RuleResult::Error(..) => panic!()
                                     }
                                 }
+                                ::peg::RuleResult::Error(__e) => ::peg::RuleResult::Error(__e),
                                 ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
-                                ::peg::RuleResult::Error(..) => panic!()
                             }
                         };
                         match __step_res {
@@ -340,7 +384,10 @@ pub mod peg {
                             ::peg::RuleResult::Failed => {
                                 break;
                             }
-                            ::peg::RuleResult::Error(..) => panic!()
+                            ::peg::RuleResult::Error(__e) => {
+                                __maybe_err = Some(__e);
+                                break;
+                            }
                         }
                     }
                     ::peg::RuleResult::Matched(__repeat_pos, __repeat_value)
@@ -353,17 +400,20 @@ pub mod peg {
                             ::peg::RuleResult::Matched(__pos, __val) => {
                                 ::peg::RuleResult::Matched(__pos, __val)
                             }
+                            ::peg::RuleResult::Error(__e) => {
+                                __err_state.mark_error(__e);
+                                ::peg::RuleResult::Error(__e)
+                            }
                             ::peg::RuleResult::Failed => {
                                 __err_state.mark_failure(__pos, "\",\"");
                                 ::peg::RuleResult::Failed
                             }
-                            ::peg::RuleResult::Error(..) => panic!()
                         } {
                             ::peg::RuleResult::Matched(__newpos, _) => {
                                 ::peg::RuleResult::Matched(__newpos, ())
                             }
                             ::peg::RuleResult::Failed => ::peg::RuleResult::Matched(__pos, ()),
-                            ::peg::RuleResult::Error(..) => panic!()
+                            ::peg::RuleResult::Error(__e) => ::peg::RuleResult::Error(__e),
                         };
                         match __seq_res {
                             ::peg::RuleResult::Matched(__pos, _) => {
@@ -372,26 +422,32 @@ pub mod peg {
                                     ::peg::RuleResult::Matched(__pos, __val) => {
                                         ::peg::RuleResult::Matched(__pos, (|| args)())
                                     }
+                                    ::peg::RuleResult::Error(__e) => {
+                                        __err_state.mark_error(__e);
+                                        ::peg::RuleResult::Error(__e)
+                                    }
                                     ::peg::RuleResult::Failed => {
                                         __err_state.mark_failure(__pos, "\")\"");
                                         ::peg::RuleResult::Failed
                                     }
-                                    ::peg::RuleResult::Error(..) => panic!()
                                 }
                             }
+                            ::peg::RuleResult::Error(__e) => ::peg::RuleResult::Error(__e),
                             ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
-                            ::peg::RuleResult::Error(..) => panic!()
                         }
                     }
+                    ::peg::RuleResult::Error(__e) => ::peg::RuleResult::Error(__e),
                     ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
-                    ::peg::RuleResult::Error(..) => panic!()
                 }
+            }
+            ::peg::RuleResult::Error(__e) => {
+                __err_state.mark_error(__e);
+                ::peg::RuleResult::Error(__e)
             }
             ::peg::RuleResult::Failed => {
                 __err_state.mark_failure(__pos, "\"(\"");
                 ::peg::RuleResult::Failed
             }
-            ::peg::RuleResult::Error(..) => panic!()
         }
     }
     fn __parse_peg_rule<'input>(
@@ -437,14 +493,14 @@ pub mod peg {
                                                                         __err_state
                                                                             .suppress_fail += 1;
                                                                         let __assert_res = {
-                                                                            let __choice_res = match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "_") { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , __val) => { :: peg :: RuleResult :: Matched (__pos , __val) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"_\"") ; :: peg :: RuleResult :: Failed }, ::peg::RuleResult::Error(..) => panic!() } ;
-                                                                            match __choice_res { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , __value) => :: peg :: RuleResult :: Matched (__pos , __value) , :: peg :: RuleResult :: Failed => { let __choice_res = match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "__") { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , __val) => { :: peg :: RuleResult :: Matched (__pos , __val) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"__\"") ; :: peg :: RuleResult :: Failed }, ::peg::RuleResult::Error(..) => panic!()  } ; match __choice_res { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , __value) => :: peg :: RuleResult :: Matched (__pos , __value) , :: peg :: RuleResult :: Failed => match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "___") { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , __val) => { :: peg :: RuleResult :: Matched (__pos , __val) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"___\"") ; :: peg :: RuleResult :: Failed }, ::peg::RuleResult::Error(..) => panic!()  } } }, ::peg::RuleResult::Error(..) => panic!()  }
+                                                                            let __choice_res = match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "_") { :: peg :: RuleResult :: Matched (__pos , __val) => { :: peg :: RuleResult :: Matched (__pos , __val) } :: peg :: RuleResult :: Error (__e) => { __err_state . mark_error (__e) ; :: peg :: RuleResult :: Error (__e) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"_\"") ; :: peg :: RuleResult :: Failed } } ;
+                                                                            match __choice_res { :: peg :: RuleResult :: Matched (__pos , __value) => :: peg :: RuleResult :: Matched (__pos , __value) , :: peg :: RuleResult :: Error (__e) => :: peg :: RuleResult :: Error (__e) , :: peg :: RuleResult :: Failed => { let __choice_res = match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "__") { :: peg :: RuleResult :: Matched (__pos , __val) => { :: peg :: RuleResult :: Matched (__pos , __val) } :: peg :: RuleResult :: Error (__e) => { __err_state . mark_error (__e) ; :: peg :: RuleResult :: Error (__e) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"__\"") ; :: peg :: RuleResult :: Failed } } ; match __choice_res { :: peg :: RuleResult :: Matched (__pos , __value) => :: peg :: RuleResult :: Matched (__pos , __value) , :: peg :: RuleResult :: Error (__e) => :: peg :: RuleResult :: Error (__e) , :: peg :: RuleResult :: Failed => match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "___") { :: peg :: RuleResult :: Matched (__pos , __val) => { :: peg :: RuleResult :: Matched (__pos , __val) } :: peg :: RuleResult :: Error (__e) => { __err_state . mark_error (__e) ; :: peg :: RuleResult :: Error (__e) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"___\"") ; :: peg :: RuleResult :: Failed } } } } }
                                                                         };
                                                                         __err_state
                                                                             .suppress_fail -= 1;
-                                                                        match __assert_res { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (_ , __value) => :: peg :: RuleResult :: Matched (__pos , __value) , :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , }
+                                                                        match __assert_res { :: peg :: RuleResult :: Matched (_ , __value) => :: peg :: RuleResult :: Matched (__pos , __value) , :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , :: peg :: RuleResult :: Error (..) => :: peg :: RuleResult :: Failed , }
                                                                     };
-                                                                    match __seq_res { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , _) => { { let __seq_res = __parse_IDENT (__input , __state , __err_state , __pos) ; match __seq_res { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , name) => { { let __seq_res = match match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "(") { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , __val) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , ")") { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , __val) => { :: peg :: RuleResult :: Matched (__pos , ()) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\")\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"(\"") ; :: peg :: RuleResult :: Failed } } { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__newpos , _) => { :: peg :: RuleResult :: Matched (__newpos , ()) } , :: peg :: RuleResult :: Failed => { :: peg :: RuleResult :: Matched (__pos , ()) } , } ; match __seq_res { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , _) => { :: peg :: RuleResult :: Matched (__pos , (|| { (name , None , Vec :: new ()) }) ()) } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , }
+                                                                    match __seq_res { :: peg :: RuleResult :: Matched (__pos , _) => { { let __seq_res = __parse_IDENT (__input , __state , __err_state , __pos) ; match __seq_res { :: peg :: RuleResult :: Matched (__pos , name) => { { let __seq_res = match match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "(") { :: peg :: RuleResult :: Matched (__pos , __val) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , ")") { :: peg :: RuleResult :: Matched (__pos , __val) => { :: peg :: RuleResult :: Matched (__pos , ()) } :: peg :: RuleResult :: Error (__e) => { __err_state . mark_error (__e) ; :: peg :: RuleResult :: Error (__e) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\")\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Error (__e) => { __err_state . mark_error (__e) ; :: peg :: RuleResult :: Error (__e) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"(\"") ; :: peg :: RuleResult :: Failed } } { :: peg :: RuleResult :: Matched (__newpos , _) => { :: peg :: RuleResult :: Matched (__newpos , ()) } , :: peg :: RuleResult :: Failed => { :: peg :: RuleResult :: Matched (__pos , ()) } , :: peg :: RuleResult :: Error (__e) => { :: peg :: RuleResult :: Error (__e) } , } ; match __seq_res { :: peg :: RuleResult :: Matched (__pos , _) => { :: peg :: RuleResult :: Matched (__pos , (|| { (name , None , Vec :: new ()) }) ()) } :: peg :: RuleResult :: Error (__e) => :: peg :: RuleResult :: Error (__e) , :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } } :: peg :: RuleResult :: Error (__e) => :: peg :: RuleResult :: Error (__e) , :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } } :: peg :: RuleResult :: Error (__e) => :: peg :: RuleResult :: Error (__e) , :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , }
                                                                 };
                                                                 match __choice_res {
                                                                     ::peg::RuleResult::Matched(
@@ -455,6 +511,11 @@ pub mod peg {
                                                                             __pos, __value,
                                                                         )
                                                                     }
+                                                                    ::peg::RuleResult::Error(
+                                                                        __e,
+                                                                    ) => ::peg::RuleResult::Error(
+                                                                        __e,
+                                                                    ),
                                                                     ::peg::RuleResult::Failed => {
                                                                         let __seq_res =
                                                                             __parse_IDENT(
@@ -463,9 +524,8 @@ pub mod peg {
                                                                                 __err_state,
                                                                                 __pos,
                                                                             );
-                                                                        match __seq_res { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , name) => { { let __seq_res = match __parse_rust_ty_params (__input , __state , __err_state , __pos) { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__newpos , __value) => { :: peg :: RuleResult :: Matched (__newpos , Some (__value)) } , :: peg :: RuleResult :: Failed => { :: peg :: RuleResult :: Matched (__pos , None) } , } ; match __seq_res { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , ty_params) => { { let __seq_res = __parse_rule_params (__input , __state , __err_state , __pos) ; match __seq_res { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , params) => { :: peg :: RuleResult :: Matched (__pos , (|| { (name , ty_params , params) }) ()) } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , }
+                                                                        match __seq_res { :: peg :: RuleResult :: Matched (__pos , name) => { { let __seq_res = match __parse_rust_ty_params (__input , __state , __err_state , __pos) { :: peg :: RuleResult :: Matched (__newpos , __value) => { :: peg :: RuleResult :: Matched (__newpos , Some (__value)) } , :: peg :: RuleResult :: Failed => { :: peg :: RuleResult :: Matched (__pos , None) } , :: peg :: RuleResult :: Error (__e) => { :: peg :: RuleResult :: Error (__e) } , } ; match __seq_res { :: peg :: RuleResult :: Matched (__pos , ty_params) => { { let __seq_res = __parse_rule_params (__input , __state , __err_state , __pos) ; match __seq_res { :: peg :: RuleResult :: Matched (__pos , params) => { :: peg :: RuleResult :: Matched (__pos , (|| { (name , ty_params , params) }) ()) } :: peg :: RuleResult :: Error (__e) => :: peg :: RuleResult :: Error (__e) , :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } } :: peg :: RuleResult :: Error (__e) => :: peg :: RuleResult :: Error (__e) , :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } } :: peg :: RuleResult :: Error (__e) => :: peg :: RuleResult :: Error (__e) , :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , }
                                                                     }
-                                                                    ::peg::RuleResult::Error(..) => panic!()
                                                                 }
                                                             };
                                                             match __seq_res {
@@ -473,43 +533,52 @@ pub mod peg {
                                                                     __pos,
                                                                     header,
                                                                 ) => {
-                                                                    let __seq_res = match match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "->") { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , __val) => { { let __seq_res = { let str_start = __pos ; match match __parse_rust_type (__input , __state , __err_state , __pos) { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (pos , _) => :: peg :: RuleResult :: Matched (pos , ()) , :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__newpos , _) => { :: peg :: RuleResult :: Matched (__newpos , :: peg :: ParseSlice :: parse_slice (__input , str_start , __newpos)) } , :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } ; match __seq_res { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , t) => { :: peg :: RuleResult :: Matched (__pos , (|| { t }) ()) } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"->\"") ; :: peg :: RuleResult :: Failed } } { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__newpos , __value) => { :: peg :: RuleResult :: Matched (__newpos , Some (__value)) } , :: peg :: RuleResult :: Failed => { :: peg :: RuleResult :: Matched (__pos , None) } , } ;
-                                                                    match __seq_res { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , ret_type) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "=") { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , __val) => { { let __seq_res = __parse_expression (__input , __state , __err_state , __pos) ; match __seq_res { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , expr) => { { let __seq_res = match match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , ";") { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , __val) => { :: peg :: RuleResult :: Matched (__pos , __val) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\";\"") ; :: peg :: RuleResult :: Failed } } { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__newpos , _) => { :: peg :: RuleResult :: Matched (__newpos , ()) } , :: peg :: RuleResult :: Failed => { :: peg :: RuleResult :: Matched (__pos , ()) } , } ; match __seq_res { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , _) => { :: peg :: RuleResult :: Matched (__pos , (|| { Rule { span , doc , name : header . 0 , ty_params : header . 1 , params : header . 2 , expr , ret_type , visibility , no_eof , cache } }) ()) } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"=\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , }
+                                                                    let __seq_res = match match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "->") { :: peg :: RuleResult :: Matched (__pos , __val) => { { let __seq_res = { let str_start = __pos ; match match __parse_rust_type (__input , __state , __err_state , __pos) { :: peg :: RuleResult :: Matched (pos , _) => :: peg :: RuleResult :: Matched (pos , ()) , :: peg :: RuleResult :: Error (e) => :: peg :: RuleResult :: Error (e) , :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } { :: peg :: RuleResult :: Matched (__newpos , _) => { :: peg :: RuleResult :: Matched (__newpos , :: peg :: ParseSlice :: parse_slice (__input , str_start , __newpos)) } , :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , :: peg :: RuleResult :: Error (__e) => :: peg :: RuleResult :: Error (__e) , } } ; match __seq_res { :: peg :: RuleResult :: Matched (__pos , t) => { :: peg :: RuleResult :: Matched (__pos , (|| { t }) ()) } :: peg :: RuleResult :: Error (__e) => :: peg :: RuleResult :: Error (__e) , :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } } :: peg :: RuleResult :: Error (__e) => { __err_state . mark_error (__e) ; :: peg :: RuleResult :: Error (__e) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"->\"") ; :: peg :: RuleResult :: Failed } } { :: peg :: RuleResult :: Matched (__newpos , __value) => { :: peg :: RuleResult :: Matched (__newpos , Some (__value)) } , :: peg :: RuleResult :: Failed => { :: peg :: RuleResult :: Matched (__pos , None) } , :: peg :: RuleResult :: Error (__e) => { :: peg :: RuleResult :: Error (__e) } , } ;
+                                                                    match __seq_res { :: peg :: RuleResult :: Matched (__pos , ret_type) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "=") { :: peg :: RuleResult :: Matched (__pos , __val) => { { let __seq_res = __parse_expression (__input , __state , __err_state , __pos) ; match __seq_res { :: peg :: RuleResult :: Matched (__pos , expr) => { { let __seq_res = match match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , ";") { :: peg :: RuleResult :: Matched (__pos , __val) => { :: peg :: RuleResult :: Matched (__pos , __val) } :: peg :: RuleResult :: Error (__e) => { __err_state . mark_error (__e) ; :: peg :: RuleResult :: Error (__e) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\";\"") ; :: peg :: RuleResult :: Failed } } { :: peg :: RuleResult :: Matched (__newpos , _) => { :: peg :: RuleResult :: Matched (__newpos , ()) } , :: peg :: RuleResult :: Failed => { :: peg :: RuleResult :: Matched (__pos , ()) } , :: peg :: RuleResult :: Error (__e) => { :: peg :: RuleResult :: Error (__e) } , } ; match __seq_res { :: peg :: RuleResult :: Matched (__pos , _) => { :: peg :: RuleResult :: Matched (__pos , (|| { Rule { span , doc , name : header . 0 , ty_params : header . 1 , params : header . 2 , expr , ret_type , visibility , no_eof , cache } }) ()) } :: peg :: RuleResult :: Error (__e) => :: peg :: RuleResult :: Error (__e) , :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } } :: peg :: RuleResult :: Error (__e) => :: peg :: RuleResult :: Error (__e) , :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } } :: peg :: RuleResult :: Error (__e) => { __err_state . mark_error (__e) ; :: peg :: RuleResult :: Error (__e) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"=\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Error (__e) => :: peg :: RuleResult :: Error (__e) , :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , }
+                                                                }
+                                                                ::peg::RuleResult::Error(__e) => {
+                                                                    ::peg::RuleResult::Error(__e)
                                                                 }
                                                                 ::peg::RuleResult::Failed => {
                                                                     ::peg::RuleResult::Failed
                                                                 }
-                                                                ::peg::RuleResult::Error(..) => panic!()
                                                             }
+                                                        }
+                                                        ::peg::RuleResult::Error(__e) => {
+                                                            __err_state.mark_error(__e);
+                                                            ::peg::RuleResult::Error(__e)
                                                         }
                                                         ::peg::RuleResult::Failed => {
                                                             __err_state
                                                                 .mark_failure(__pos, "\"rule\"");
                                                             ::peg::RuleResult::Failed
                                                         }
-                                                        ::peg::RuleResult::Error(..) => panic!()
                                                     }
+                                                }
+                                                ::peg::RuleResult::Error(__e) => {
+                                                    ::peg::RuleResult::Error(__e)
                                                 }
                                                 ::peg::RuleResult::Failed => {
                                                     ::peg::RuleResult::Failed
                                                 }
-                                                ::peg::RuleResult::Error(..) => panic!()
                                             }
                                         }
+                                        ::peg::RuleResult::Error(__e) => {
+                                            ::peg::RuleResult::Error(__e)
+                                        }
                                         ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
-                                        ::peg::RuleResult::Error(..) => panic!()
                                     }
                                 }
+                                ::peg::RuleResult::Error(__e) => ::peg::RuleResult::Error(__e),
                                 ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
-                                ::peg::RuleResult::Error(..) => panic!()
                             }
                         }
+                        ::peg::RuleResult::Error(__e) => ::peg::RuleResult::Error(__e),
                         ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
-                        ::peg::RuleResult::Error(..) => panic!()
                     }
                 }
+                ::peg::RuleResult::Error(__e) => ::peg::RuleResult::Error(__e),
                 ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
-                ::peg::RuleResult::Error(..) => panic!()
             }
         }
     }
@@ -538,37 +607,50 @@ pub mod peg {
                                                 (|| Some(Cache::Simple))(),
                                             )
                                         }
+                                        ::peg::RuleResult::Error(__e) => {
+                                            __err_state.mark_error(__e);
+                                            ::peg::RuleResult::Error(__e)
+                                        }
                                         ::peg::RuleResult::Failed => {
                                             __err_state.mark_failure(__pos, "\"]\"");
                                             ::peg::RuleResult::Failed
                                         }
-                                        ::peg::RuleResult::Error(..) => panic!()
                                     }
+                                }
+                                ::peg::RuleResult::Error(__e) => {
+                                    __err_state.mark_error(__e);
+                                    ::peg::RuleResult::Error(__e)
                                 }
                                 ::peg::RuleResult::Failed => {
                                     __err_state.mark_failure(__pos, "\"cache\"");
                                     ::peg::RuleResult::Failed
                                 }
-                                ::peg::RuleResult::Error(..) => panic!()
                             }
+                        }
+                        ::peg::RuleResult::Error(__e) => {
+                            __err_state.mark_error(__e);
+                            ::peg::RuleResult::Error(__e)
                         }
                         ::peg::RuleResult::Failed => {
                             __err_state.mark_failure(__pos, "\"[\"");
                             ::peg::RuleResult::Failed
                         }
-                        ::peg::RuleResult::Error(..) => panic!()
                     }
+                }
+                ::peg::RuleResult::Error(__e) => {
+                    __err_state.mark_error(__e);
+                    ::peg::RuleResult::Error(__e)
                 }
                 ::peg::RuleResult::Failed => {
                     __err_state.mark_failure(__pos, "\"#\"");
                     ::peg::RuleResult::Failed
                 }
-                ::peg::RuleResult::Error(..) => panic!()
             };
             match __choice_res {
                 ::peg::RuleResult::Matched(__pos, __value) => {
                     ::peg::RuleResult::Matched(__pos, __value)
                 }
+                ::peg::RuleResult::Error(__e) => ::peg::RuleResult::Error(__e),
                 ::peg::RuleResult::Failed => {
                     let __choice_res =
                         match ::peg::ParseLiteral::parse_string_literal(__input, __pos, "#") {
@@ -591,43 +673,54 @@ pub mod peg {
                                                             (|| Some(Cache::Recursive))(),
                                                         )
                                                     }
+                                                    ::peg::RuleResult::Error(__e) => {
+                                                        __err_state.mark_error(__e);
+                                                        ::peg::RuleResult::Error(__e)
+                                                    }
                                                     ::peg::RuleResult::Failed => {
                                                         __err_state.mark_failure(__pos, "\"]\"");
                                                         ::peg::RuleResult::Failed
                                                     }
-                                                    ::peg::RuleResult::Error(..) => panic!()
                                                 }
+                                            }
+                                            ::peg::RuleResult::Error(__e) => {
+                                                __err_state.mark_error(__e);
+                                                ::peg::RuleResult::Error(__e)
                                             }
                                             ::peg::RuleResult::Failed => {
                                                 __err_state
                                                     .mark_failure(__pos, "\"cache_left_rec\"");
                                                 ::peg::RuleResult::Failed
                                             }
-                                            ::peg::RuleResult::Error(..) => panic!()
                                         }
+                                    }
+                                    ::peg::RuleResult::Error(__e) => {
+                                        __err_state.mark_error(__e);
+                                        ::peg::RuleResult::Error(__e)
                                     }
                                     ::peg::RuleResult::Failed => {
                                         __err_state.mark_failure(__pos, "\"[\"");
                                         ::peg::RuleResult::Failed
                                     }
-                                    ::peg::RuleResult::Error(..) => panic!()
                                 }
+                            }
+                            ::peg::RuleResult::Error(__e) => {
+                                __err_state.mark_error(__e);
+                                ::peg::RuleResult::Error(__e)
                             }
                             ::peg::RuleResult::Failed => {
                                 __err_state.mark_failure(__pos, "\"#\"");
                                 ::peg::RuleResult::Failed
                             }
-                            ::peg::RuleResult::Error(..) => panic!()
                         };
                     match __choice_res {
                         ::peg::RuleResult::Matched(__pos, __value) => {
                             ::peg::RuleResult::Matched(__pos, __value)
                         }
+                        ::peg::RuleResult::Error(__e) => ::peg::RuleResult::Error(__e),
                         ::peg::RuleResult::Failed => ::peg::RuleResult::Matched(__pos, (|| None)()),
-                        ::peg::RuleResult::Error(..) => panic!()
                     }
                 }
-                ::peg::RuleResult::Error(..) => panic!()
             }
         }
     }
@@ -654,39 +747,51 @@ pub mod peg {
                                         ::peg::RuleResult::Matched(__pos, __val) => {
                                             ::peg::RuleResult::Matched(__pos, (|| true)())
                                         }
+                                        ::peg::RuleResult::Error(__e) => {
+                                            __err_state.mark_error(__e);
+                                            ::peg::RuleResult::Error(__e)
+                                        }
                                         ::peg::RuleResult::Failed => {
                                             __err_state.mark_failure(__pos, "\"]\"");
                                             ::peg::RuleResult::Failed
                                         }
-                                        ::peg::RuleResult::Error(..) => panic!()
                                     }
+                                }
+                                ::peg::RuleResult::Error(__e) => {
+                                    __err_state.mark_error(__e);
+                                    ::peg::RuleResult::Error(__e)
                                 }
                                 ::peg::RuleResult::Failed => {
                                     __err_state.mark_failure(__pos, "\"no_eof\"");
                                     ::peg::RuleResult::Failed
                                 }
-                                ::peg::RuleResult::Error(..) => panic!()
                             }
+                        }
+                        ::peg::RuleResult::Error(__e) => {
+                            __err_state.mark_error(__e);
+                            ::peg::RuleResult::Error(__e)
                         }
                         ::peg::RuleResult::Failed => {
                             __err_state.mark_failure(__pos, "\"[\"");
                             ::peg::RuleResult::Failed
                         }
-                        ::peg::RuleResult::Error(..) => panic!()
                     }
+                }
+                ::peg::RuleResult::Error(__e) => {
+                    __err_state.mark_error(__e);
+                    ::peg::RuleResult::Error(__e)
                 }
                 ::peg::RuleResult::Failed => {
                     __err_state.mark_failure(__pos, "\"#\"");
                     ::peg::RuleResult::Failed
                 }
-                ::peg::RuleResult::Error(..) => panic!()
             };
             match __choice_res {
                 ::peg::RuleResult::Matched(__pos, __value) => {
                     ::peg::RuleResult::Matched(__pos, __value)
                 }
+                ::peg::RuleResult::Error(__e) => ::peg::RuleResult::Error(__e),
                 ::peg::RuleResult::Failed => ::peg::RuleResult::Matched(__pos, (|| false)()),
-                ::peg::RuleResult::Error(..) => panic!()
             }
         }
     }
@@ -714,8 +819,8 @@ pub mod peg {
                                         ::peg::RuleResult::Matched(pos, _) => {
                                             ::peg::RuleResult::Matched(pos, ())
                                         }
+                                        ::peg::RuleResult::Error(e) => ::peg::RuleResult::Error(e),
                                         ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
-                                        ::peg::RuleResult::Error(..) => panic!()
                                     } {
                                         ::peg::RuleResult::Matched(__newpos, _) => {
                                             ::peg::RuleResult::Matched(
@@ -726,7 +831,9 @@ pub mod peg {
                                             )
                                         }
                                         ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
-                                        ::peg::RuleResult::Error(..) => panic!()
+                                        ::peg::RuleResult::Error(__e) => {
+                                            ::peg::RuleResult::Error(__e)
+                                        }
                                     }
                                 };
                                 match __seq_res {
@@ -740,34 +847,44 @@ pub mod peg {
                                                     (|| RuleParamTy::Rule(r))(),
                                                 )
                                             }
+                                            ::peg::RuleResult::Error(__e) => {
+                                                __err_state.mark_error(__e);
+                                                ::peg::RuleResult::Error(__e)
+                                            }
                                             ::peg::RuleResult::Failed => {
                                                 __err_state.mark_failure(__pos, "\">\"");
                                                 ::peg::RuleResult::Failed
                                             }
-                                            ::peg::RuleResult::Error(..) => panic!()
                                         }
                                     }
+                                    ::peg::RuleResult::Error(__e) => ::peg::RuleResult::Error(__e),
                                     ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
-                                    ::peg::RuleResult::Error(..) => panic!()
                                 }
+                            }
+                            ::peg::RuleResult::Error(__e) => {
+                                __err_state.mark_error(__e);
+                                ::peg::RuleResult::Error(__e)
                             }
                             ::peg::RuleResult::Failed => {
                                 __err_state.mark_failure(__pos, "\"<\"");
                                 ::peg::RuleResult::Failed
                             }
-                            ::peg::RuleResult::Error(..) => panic!()
                         }
+                    }
+                    ::peg::RuleResult::Error(__e) => {
+                        __err_state.mark_error(__e);
+                        ::peg::RuleResult::Error(__e)
                     }
                     ::peg::RuleResult::Failed => {
                         __err_state.mark_failure(__pos, "\"rule\"");
                         ::peg::RuleResult::Failed
                     }
-                    ::peg::RuleResult::Error(..) => panic!()
                 };
             match __choice_res {
                 ::peg::RuleResult::Matched(__pos, __value) => {
                     ::peg::RuleResult::Matched(__pos, __value)
                 }
+                ::peg::RuleResult::Error(__e) => ::peg::RuleResult::Error(__e),
                 ::peg::RuleResult::Failed => {
                     let __seq_res = {
                         let str_start = __pos;
@@ -775,26 +892,25 @@ pub mod peg {
                             ::peg::RuleResult::Matched(pos, _) => {
                                 ::peg::RuleResult::Matched(pos, ())
                             }
+                            ::peg::RuleResult::Error(e) => ::peg::RuleResult::Error(e),
                             ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
-                            ::peg::RuleResult::Error(..) => panic!()
                         } {
                             ::peg::RuleResult::Matched(__newpos, _) => ::peg::RuleResult::Matched(
                                 __newpos,
                                 ::peg::ParseSlice::parse_slice(__input, str_start, __newpos),
                             ),
                             ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
-                            ::peg::RuleResult::Error(..) => panic!()
+                            ::peg::RuleResult::Error(__e) => ::peg::RuleResult::Error(__e),
                         }
                     };
                     match __seq_res {
                         ::peg::RuleResult::Matched(__pos, t) => {
                             ::peg::RuleResult::Matched(__pos, (|| RuleParamTy::Rust(t))())
                         }
+                        ::peg::RuleResult::Error(__e) => ::peg::RuleResult::Error(__e),
                         ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
-                        ::peg::RuleResult::Error(..) => panic!()
                     }
                 }
-                ::peg::RuleResult::Error(..) => panic!()
             }
         }
     }
@@ -809,6 +925,7 @@ pub mod peg {
             ::peg::RuleResult::Matched(__pos, __val) => {
                 let __seq_res = {
                     let mut __repeat_pos = __pos;
+                    let mut __maybe_err = None;
                     let mut __repeat_value = vec![];
                     loop {
                         let __pos = __repeat_pos;
@@ -821,16 +938,22 @@ pub mod peg {
                                 ::peg::RuleResult::Matched(__pos, __val) => {
                                     ::peg::RuleResult::Matched(__pos, __val)
                                 }
+                                ::peg::RuleResult::Error(__e) => {
+                                    __err_state.mark_error(__e);
+                                    ::peg::RuleResult::Error(__e)
+                                }
                                 ::peg::RuleResult::Failed => {
                                     __err_state.mark_failure(__pos, "\",\"");
                                     ::peg::RuleResult::Failed
                                 }
-                                ::peg::RuleResult::Error(..) => panic!()
                             };
                             match __sep_res {
                                 ::peg::RuleResult::Matched(__newpos, _) => __newpos,
                                 ::peg::RuleResult::Failed => break,
-                                ::peg::RuleResult::Error(..) => panic!()
+                                ::peg::RuleResult::Error(__e) => {
+                                    __maybe_err = Some(__e);
+                                    break;
+                                }
                             }
                         };
                         let __step_res = {
@@ -854,21 +977,26 @@ pub mod peg {
                                                         (|| RuleParam { name, ty })(),
                                                     )
                                                 }
+                                                ::peg::RuleResult::Error(__e) => {
+                                                    ::peg::RuleResult::Error(__e)
+                                                }
                                                 ::peg::RuleResult::Failed => {
                                                     ::peg::RuleResult::Failed
                                                 }
-                                                ::peg::RuleResult::Error(..) => panic!()
                                             }
+                                        }
+                                        ::peg::RuleResult::Error(__e) => {
+                                            __err_state.mark_error(__e);
+                                            ::peg::RuleResult::Error(__e)
                                         }
                                         ::peg::RuleResult::Failed => {
                                             __err_state.mark_failure(__pos, "\":\"");
                                             ::peg::RuleResult::Failed
                                         }
-                                        ::peg::RuleResult::Error(..) => panic!()
                                     }
                                 }
+                                ::peg::RuleResult::Error(__e) => ::peg::RuleResult::Error(__e),
                                 ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
-                                ::peg::RuleResult::Error(..) => panic!()
                             }
                         };
                         match __step_res {
@@ -879,7 +1007,10 @@ pub mod peg {
                             ::peg::RuleResult::Failed => {
                                 break;
                             }
-                            ::peg::RuleResult::Error(..) => panic!()
+                            ::peg::RuleResult::Error(__e) => {
+                                __maybe_err = Some(__e);
+                                break;
+                            }
                         }
                     }
                     ::peg::RuleResult::Matched(__repeat_pos, __repeat_value)
@@ -890,22 +1021,28 @@ pub mod peg {
                             ::peg::RuleResult::Matched(__pos, __val) => {
                                 ::peg::RuleResult::Matched(__pos, (|| params)())
                             }
+                            ::peg::RuleResult::Error(__e) => {
+                                __err_state.mark_error(__e);
+                                ::peg::RuleResult::Error(__e)
+                            }
                             ::peg::RuleResult::Failed => {
                                 __err_state.mark_failure(__pos, "\")\"");
                                 ::peg::RuleResult::Failed
                             }
-                            ::peg::RuleResult::Error(..) => panic!()
                         }
                     }
+                    ::peg::RuleResult::Error(__e) => ::peg::RuleResult::Error(__e),
                     ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
-                    ::peg::RuleResult::Error(..) => panic!()
                 }
+            }
+            ::peg::RuleResult::Error(__e) => {
+                __err_state.mark_error(__e);
+                ::peg::RuleResult::Error(__e)
             }
             ::peg::RuleResult::Failed => {
                 __err_state.mark_failure(__pos, "\"(\"");
                 ::peg::RuleResult::Failed
             }
-            ::peg::RuleResult::Error(..) => panic!()
         }
     }
     fn __parse_item<'input>(
@@ -922,25 +1059,25 @@ pub mod peg {
                     ::peg::RuleResult::Matched(__pos, u) => {
                         ::peg::RuleResult::Matched(__pos, (|| Item::Use(u))())
                     }
+                    ::peg::RuleResult::Error(__e) => ::peg::RuleResult::Error(__e),
                     ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
-                    ::peg::RuleResult::Error(..) => panic!()
                 }
             };
             match __choice_res {
                 ::peg::RuleResult::Matched(__pos, __value) => {
                     ::peg::RuleResult::Matched(__pos, __value)
                 }
+                ::peg::RuleResult::Error(__e) => ::peg::RuleResult::Error(__e),
                 ::peg::RuleResult::Failed => {
                     let __seq_res = __parse_peg_rule(__input, __state, __err_state, __pos);
                     match __seq_res {
                         ::peg::RuleResult::Matched(__pos, r) => {
                             ::peg::RuleResult::Matched(__pos, (|| Item::Rule(r))())
                         }
+                        ::peg::RuleResult::Error(__e) => ::peg::RuleResult::Error(__e),
                         ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
-                        ::peg::RuleResult::Error(..) => panic!()
                     }
                 }
-                ::peg::RuleResult::Error(..) => panic!()
             }
         }
     }
@@ -955,6 +1092,7 @@ pub mod peg {
             let str_start = __pos;
             match {
                 let mut __repeat_pos = __pos;
+                let mut __maybe_err = None;
                 loop {
                     let __pos = __repeat_pos;
                     let __step_res = match ::peg::ParseLiteral::parse_string_literal(
@@ -980,39 +1118,53 @@ pub mod peg {
                                                         ::peg::RuleResult::Matched(pos, _) => {
                                                             ::peg::RuleResult::Matched(pos, ())
                                                         }
+                                                        ::peg::RuleResult::Error(e) => {
+                                                            ::peg::RuleResult::Error(e)
+                                                        }
                                                         ::peg::RuleResult::Failed => {
                                                             ::peg::RuleResult::Failed
                                                         }
-                                                        ::peg::RuleResult::Error(..) => panic!()
                                                     };
-                                                    match __seq_res { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , _) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "]") { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , __val) => { :: peg :: RuleResult :: Matched (__pos , ()) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"]\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , }
+                                                    match __seq_res { :: peg :: RuleResult :: Matched (__pos , _) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "]") { :: peg :: RuleResult :: Matched (__pos , __val) => { :: peg :: RuleResult :: Matched (__pos , ()) } :: peg :: RuleResult :: Error (__e) => { __err_state . mark_error (__e) ; :: peg :: RuleResult :: Error (__e) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"]\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Error (__e) => :: peg :: RuleResult :: Error (__e) , :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , }
+                                                }
+                                                ::peg::RuleResult::Error(__e) => {
+                                                    __err_state.mark_error(__e);
+                                                    ::peg::RuleResult::Error(__e)
                                                 }
                                                 ::peg::RuleResult::Failed => {
                                                     __err_state.mark_failure(__pos, "\"=\"");
                                                     ::peg::RuleResult::Failed
                                                 }
-                                                ::peg::RuleResult::Error(..) => panic!()
                                             }
+                                        }
+                                        ::peg::RuleResult::Error(__e) => {
+                                            __err_state.mark_error(__e);
+                                            ::peg::RuleResult::Error(__e)
                                         }
                                         ::peg::RuleResult::Failed => {
                                             __err_state.mark_failure(__pos, "\"doc\"");
                                             ::peg::RuleResult::Failed
                                         }
-                                        ::peg::RuleResult::Error(..) => panic!()
                                     }
+                                }
+                                ::peg::RuleResult::Error(__e) => {
+                                    __err_state.mark_error(__e);
+                                    ::peg::RuleResult::Error(__e)
                                 }
                                 ::peg::RuleResult::Failed => {
                                     __err_state.mark_failure(__pos, "\"[\"");
                                     ::peg::RuleResult::Failed
                                 }
-                                ::peg::RuleResult::Error(..) => panic!()
                             }
+                        }
+                        ::peg::RuleResult::Error(__e) => {
+                            __err_state.mark_error(__e);
+                            ::peg::RuleResult::Error(__e)
                         }
                         ::peg::RuleResult::Failed => {
                             __err_state.mark_failure(__pos, "\"#\"");
                             ::peg::RuleResult::Failed
                         }
-                        ::peg::RuleResult::Error(..) => panic!()
                     };
                     match __step_res {
                         ::peg::RuleResult::Matched(__newpos, __value) => {
@@ -1021,7 +1173,10 @@ pub mod peg {
                         ::peg::RuleResult::Failed => {
                             break;
                         }
-                        ::peg::RuleResult::Error(..) => panic!()
+                        ::peg::RuleResult::Error(__e) => {
+                            __maybe_err = Some(__e);
+                            break;
+                        }
                     }
                 }
                 ::peg::RuleResult::Matched(__repeat_pos, ())
@@ -1031,14 +1186,14 @@ pub mod peg {
                     ::peg::ParseSlice::parse_slice(__input, str_start, __newpos),
                 ),
                 ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
-                ::peg::RuleResult::Error(..) => panic!()
+                ::peg::RuleResult::Error(__e) => ::peg::RuleResult::Error(__e),
             }
         } {
             ::peg::RuleResult::Matched(__newpos, __value) => {
                 ::peg::RuleResult::Matched(__newpos, Some(__value))
             }
             ::peg::RuleResult::Failed => ::peg::RuleResult::Matched(__pos, None),
-            ::peg::RuleResult::Error(..) => panic!()
+            ::peg::RuleResult::Error(__e) => ::peg::RuleResult::Error(__e),
         }
     }
     fn __parse_rust_visibility<'input>(
@@ -1063,46 +1218,52 @@ pub mod peg {
                                 ::peg::RuleResult::Matched(pos, _) => {
                                     ::peg::RuleResult::Matched(pos, ())
                                 }
+                                ::peg::RuleResult::Error(e) => ::peg::RuleResult::Error(e),
                                 ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
-                                ::peg::RuleResult::Error(..) => panic!()
                             } {
                                 ::peg::RuleResult::Matched(__newpos, _) => {
                                     ::peg::RuleResult::Matched(__newpos, ())
                                 }
                                 ::peg::RuleResult::Failed => ::peg::RuleResult::Matched(__pos, ()),
-                                ::peg::RuleResult::Error(..) => panic!()
+                                ::peg::RuleResult::Error(__e) => ::peg::RuleResult::Error(__e),
                             };
                             match __seq_res {
                                 ::peg::RuleResult::Matched(__pos, _) => {
                                     ::peg::RuleResult::Matched(__pos, ())
                                 }
+                                ::peg::RuleResult::Error(__e) => ::peg::RuleResult::Error(__e),
                                 ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
-                                ::peg::RuleResult::Error(..) => panic!()
                             }
+                        }
+                        ::peg::RuleResult::Error(__e) => {
+                            __err_state.mark_error(__e);
+                            ::peg::RuleResult::Error(__e)
                         }
                         ::peg::RuleResult::Failed => {
                             __err_state.mark_failure(__pos, "\"pub\"");
                             ::peg::RuleResult::Failed
                         }
-                        ::peg::RuleResult::Error(..) => panic!()
                     };
                 match __choice_res {
                     ::peg::RuleResult::Matched(__pos, __value) => {
                         ::peg::RuleResult::Matched(__pos, __value)
                     }
+                    ::peg::RuleResult::Error(__e) => ::peg::RuleResult::Error(__e),
                     ::peg::RuleResult::Failed => {
                         match ::peg::ParseLiteral::parse_string_literal(__input, __pos, "crate") {
                             ::peg::RuleResult::Matched(__pos, __val) => {
                                 ::peg::RuleResult::Matched(__pos, __val)
                             }
+                            ::peg::RuleResult::Error(__e) => {
+                                __err_state.mark_error(__e);
+                                ::peg::RuleResult::Error(__e)
+                            }
                             ::peg::RuleResult::Failed => {
                                 __err_state.mark_failure(__pos, "\"crate\"");
                                 ::peg::RuleResult::Failed
                             }
-                            ::peg::RuleResult::Error(..) => panic!()
                         }
                     }
-                    ::peg::RuleResult::Error(..) => panic!()
                 }
             } {
                 ::peg::RuleResult::Matched(__newpos, _) => ::peg::RuleResult::Matched(
@@ -1110,14 +1271,14 @@ pub mod peg {
                     ::peg::ParseSlice::parse_slice(__input, str_start, __newpos),
                 ),
                 ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
-                ::peg::RuleResult::Error(..) => panic!()
+                ::peg::RuleResult::Error(__e) => ::peg::RuleResult::Error(__e),
             }
         } {
             ::peg::RuleResult::Matched(__newpos, __value) => {
                 ::peg::RuleResult::Matched(__newpos, Some(__value))
             }
             ::peg::RuleResult::Failed => ::peg::RuleResult::Matched(__pos, None),
-            ::peg::RuleResult::Error(..) => panic!()
+            ::peg::RuleResult::Error(__e) => ::peg::RuleResult::Error(__e),
         }
     }
     fn __parse_rust_use<'input>(
@@ -1137,8 +1298,8 @@ pub mod peg {
                                 ::peg::RuleResult::Matched(pos, _) => {
                                     ::peg::RuleResult::Matched(pos, ())
                                 }
+                                ::peg::RuleResult::Error(e) => ::peg::RuleResult::Error(e),
                                 ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
-                                ::peg::RuleResult::Error(..) => panic!()
                             };
                         match __seq_res {
                             ::peg::RuleResult::Matched(__pos, _) => {
@@ -1154,28 +1315,36 @@ pub mod peg {
                                                     ::peg::RuleResult::Matched(__pos, __val) => {
                                                         ::peg::RuleResult::Matched(__pos, ())
                                                     }
+                                                    ::peg::RuleResult::Error(__e) => {
+                                                        __err_state.mark_error(__e);
+                                                        ::peg::RuleResult::Error(__e)
+                                                    }
                                                     ::peg::RuleResult::Failed => {
                                                         __err_state.mark_failure(__pos, "\"*\"");
                                                         ::peg::RuleResult::Failed
                                                     }
-                                                    ::peg::RuleResult::Error(..) => panic!()
                                                 }
+                                            }
+                                            ::peg::RuleResult::Error(__e) => {
+                                                __err_state.mark_error(__e);
+                                                ::peg::RuleResult::Error(__e)
                                             }
                                             ::peg::RuleResult::Failed => {
                                                 __err_state.mark_failure(__pos, "\"::\"");
                                                 ::peg::RuleResult::Failed
                                             }
-                                            ::peg::RuleResult::Error(..) => panic!()
                                         };
                                     match __choice_res {
                                         ::peg::RuleResult::Matched(__pos, __value) => {
                                             ::peg::RuleResult::Matched(__pos, __value)
                                         }
-                                        ::peg::RuleResult::Failed => {
-                                            let __choice_res = match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "::") { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , __val) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "{") { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , __val) => { { let __seq_res = { let mut __repeat_pos = __pos ; let mut __repeat_value = vec ! () ; loop { let __pos = __repeat_pos ; let __pos = if __repeat_value . is_empty () { __pos } else { let __sep_res = match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , ",") { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , __val) => { :: peg :: RuleResult :: Matched (__pos , __val) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\",\"") ; :: peg :: RuleResult :: Failed } } ; match __sep_res { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__newpos , _) => { __newpos } , :: peg :: RuleResult :: Failed => break , } } ; let __step_res = { let __seq_res = match __parse_IDENT (__input , __state , __err_state , __pos) { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (pos , _) => :: peg :: RuleResult :: Matched (pos , ()) , :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } ; match __seq_res { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , _) => { { let __seq_res = match match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "as") { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , __val) => { { let __seq_res = match __parse_IDENT (__input , __state , __err_state , __pos) { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (pos , _) => :: peg :: RuleResult :: Matched (pos , ()) , :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } ; match __seq_res { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , _) => { :: peg :: RuleResult :: Matched (__pos , ()) } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"as\"") ; :: peg :: RuleResult :: Failed } } { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__newpos , _) => { :: peg :: RuleResult :: Matched (__newpos , ()) } , :: peg :: RuleResult :: Failed => { :: peg :: RuleResult :: Matched (__pos , ()) } , } ; match __seq_res { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , _) => { :: peg :: RuleResult :: Matched (__pos , ()) } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } ; match __step_res { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__newpos , __value) => { __repeat_pos = __newpos ; __repeat_value . push (__value) ; } , :: peg :: RuleResult :: Failed => { break ; } } } if __repeat_value . len () >= 1 { :: peg :: RuleResult :: Matched (__repeat_pos , ()) } else { :: peg :: RuleResult :: Failed } } ; match __seq_res { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , _) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "}") { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , __val) => { :: peg :: RuleResult :: Matched (__pos , ()) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"}\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"{\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"::\"") ; :: peg :: RuleResult :: Failed } } ;
-                                            match __choice_res { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , __value) => :: peg :: RuleResult :: Matched (__pos , __value) , :: peg :: RuleResult :: Failed => match match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "as") { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , __val) => { { let __seq_res = match __parse_IDENT (__input , __state , __err_state , __pos) { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (pos , _) => :: peg :: RuleResult :: Matched (pos , ()) , :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } ; match __seq_res { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , _) => { :: peg :: RuleResult :: Matched (__pos , ()) } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"as\"") ; :: peg :: RuleResult :: Failed } } { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__newpos , _) => { :: peg :: RuleResult :: Matched (__newpos , ()) } , :: peg :: RuleResult :: Failed => { :: peg :: RuleResult :: Matched (__pos , ()) } , } }
+                                        ::peg::RuleResult::Error(__e) => {
+                                            ::peg::RuleResult::Error(__e)
                                         }
-                                        ::peg::RuleResult::Error(..) => panic!()
+                                        ::peg::RuleResult::Failed => {
+                                            let __choice_res = match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "::") { :: peg :: RuleResult :: Matched (__pos , __val) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "{") { :: peg :: RuleResult :: Matched (__pos , __val) => { { let __seq_res = { let mut __repeat_pos = __pos ; let mut __maybe_err = None ; let mut __repeat_value = vec ! () ; loop { let __pos = __repeat_pos ; let __pos = if __repeat_value . is_empty () { __pos } else { let __sep_res = match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , ",") { :: peg :: RuleResult :: Matched (__pos , __val) => { :: peg :: RuleResult :: Matched (__pos , __val) } :: peg :: RuleResult :: Error (__e) => { __err_state . mark_error (__e) ; :: peg :: RuleResult :: Error (__e) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\",\"") ; :: peg :: RuleResult :: Failed } } ; match __sep_res { :: peg :: RuleResult :: Matched (__newpos , _) => { __newpos } , :: peg :: RuleResult :: Failed => break , :: peg :: RuleResult :: Error (__e) => { __maybe_err = Some (__e) ; break } } } ; let __step_res = { let __seq_res = match __parse_IDENT (__input , __state , __err_state , __pos) { :: peg :: RuleResult :: Matched (pos , _) => :: peg :: RuleResult :: Matched (pos , ()) , :: peg :: RuleResult :: Error (e) => :: peg :: RuleResult :: Error (e) , :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } ; match __seq_res { :: peg :: RuleResult :: Matched (__pos , _) => { { let __seq_res = match match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "as") { :: peg :: RuleResult :: Matched (__pos , __val) => { { let __seq_res = match __parse_IDENT (__input , __state , __err_state , __pos) { :: peg :: RuleResult :: Matched (pos , _) => :: peg :: RuleResult :: Matched (pos , ()) , :: peg :: RuleResult :: Error (e) => :: peg :: RuleResult :: Error (e) , :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } ; match __seq_res { :: peg :: RuleResult :: Matched (__pos , _) => { :: peg :: RuleResult :: Matched (__pos , ()) } :: peg :: RuleResult :: Error (__e) => :: peg :: RuleResult :: Error (__e) , :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } } :: peg :: RuleResult :: Error (__e) => { __err_state . mark_error (__e) ; :: peg :: RuleResult :: Error (__e) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"as\"") ; :: peg :: RuleResult :: Failed } } { :: peg :: RuleResult :: Matched (__newpos , _) => { :: peg :: RuleResult :: Matched (__newpos , ()) } , :: peg :: RuleResult :: Failed => { :: peg :: RuleResult :: Matched (__pos , ()) } , :: peg :: RuleResult :: Error (__e) => { :: peg :: RuleResult :: Error (__e) } , } ; match __seq_res { :: peg :: RuleResult :: Matched (__pos , _) => { :: peg :: RuleResult :: Matched (__pos , ()) } :: peg :: RuleResult :: Error (__e) => :: peg :: RuleResult :: Error (__e) , :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } } :: peg :: RuleResult :: Error (__e) => :: peg :: RuleResult :: Error (__e) , :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } ; match __step_res { :: peg :: RuleResult :: Matched (__newpos , __value) => { __repeat_pos = __newpos ; __repeat_value . push (__value) ; } , :: peg :: RuleResult :: Failed => { break ; } :: peg :: RuleResult :: Error (__e) => { __maybe_err = Some (__e) ; break ; } } } if let Some (__e) = __maybe_err { :: peg :: RuleResult :: Error (__e) } else if __repeat_value . len () >= 1 { :: peg :: RuleResult :: Matched (__repeat_pos , ()) } else { :: peg :: RuleResult :: Failed } } ; match __seq_res { :: peg :: RuleResult :: Matched (__pos , _) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "}") { :: peg :: RuleResult :: Matched (__pos , __val) => { :: peg :: RuleResult :: Matched (__pos , ()) } :: peg :: RuleResult :: Error (__e) => { __err_state . mark_error (__e) ; :: peg :: RuleResult :: Error (__e) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"}\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Error (__e) => :: peg :: RuleResult :: Error (__e) , :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } } :: peg :: RuleResult :: Error (__e) => { __err_state . mark_error (__e) ; :: peg :: RuleResult :: Error (__e) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"{\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Error (__e) => { __err_state . mark_error (__e) ; :: peg :: RuleResult :: Error (__e) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"::\"") ; :: peg :: RuleResult :: Failed } } ;
+                                            match __choice_res { :: peg :: RuleResult :: Matched (__pos , __value) => :: peg :: RuleResult :: Matched (__pos , __value) , :: peg :: RuleResult :: Error (__e) => :: peg :: RuleResult :: Error (__e) , :: peg :: RuleResult :: Failed => match match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "as") { :: peg :: RuleResult :: Matched (__pos , __val) => { { let __seq_res = match __parse_IDENT (__input , __state , __err_state , __pos) { :: peg :: RuleResult :: Matched (pos , _) => :: peg :: RuleResult :: Matched (pos , ()) , :: peg :: RuleResult :: Error (e) => :: peg :: RuleResult :: Error (e) , :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } ; match __seq_res { :: peg :: RuleResult :: Matched (__pos , _) => { :: peg :: RuleResult :: Matched (__pos , ()) } :: peg :: RuleResult :: Error (__e) => :: peg :: RuleResult :: Error (__e) , :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } } :: peg :: RuleResult :: Error (__e) => { __err_state . mark_error (__e) ; :: peg :: RuleResult :: Error (__e) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"as\"") ; :: peg :: RuleResult :: Failed } } { :: peg :: RuleResult :: Matched (__newpos , _) => { :: peg :: RuleResult :: Matched (__newpos , ()) } , :: peg :: RuleResult :: Failed => { :: peg :: RuleResult :: Matched (__pos , ()) } , :: peg :: RuleResult :: Error (__e) => { :: peg :: RuleResult :: Error (__e) } , } }
+                                        }
                                     }
                                 };
                                 match __seq_res {
@@ -1186,41 +1355,47 @@ pub mod peg {
                                             ::peg::RuleResult::Matched(__pos, __val) => {
                                                 ::peg::RuleResult::Matched(__pos, ())
                                             }
+                                            ::peg::RuleResult::Error(__e) => {
+                                                __err_state.mark_error(__e);
+                                                ::peg::RuleResult::Error(__e)
+                                            }
                                             ::peg::RuleResult::Failed => {
                                                 __err_state.mark_failure(__pos, "\";\"");
                                                 ::peg::RuleResult::Failed
                                             }
-                                            ::peg::RuleResult::Error(..) => panic!()
                                         }
                                     }
+                                    ::peg::RuleResult::Error(__e) => ::peg::RuleResult::Error(__e),
                                     ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
-                                    ::peg::RuleResult::Error(..) => panic!()
                                 }
                             }
+                            ::peg::RuleResult::Error(__e) => ::peg::RuleResult::Error(__e),
                             ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
-                            ::peg::RuleResult::Error(..) => panic!()
                         }
+                    }
+                    ::peg::RuleResult::Error(__e) => {
+                        __err_state.mark_error(__e);
+                        ::peg::RuleResult::Error(__e)
                     }
                     ::peg::RuleResult::Failed => {
                         __err_state.mark_failure(__pos, "\"use\"");
                         ::peg::RuleResult::Failed
                     }
-                    ::peg::RuleResult::Error(..) => panic!()
                 } {
                     ::peg::RuleResult::Matched(__newpos, _) => ::peg::RuleResult::Matched(
                         __newpos,
                         ::peg::ParseSlice::parse_slice(__input, str_start, __newpos),
                     ),
                     ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
-                    ::peg::RuleResult::Error(..) => panic!()
+                    ::peg::RuleResult::Error(__e) => ::peg::RuleResult::Error(__e),
                 }
             };
             match __seq_res {
                 ::peg::RuleResult::Matched(__pos, v) => {
                     ::peg::RuleResult::Matched(__pos, (|| v.to_owned())())
                 }
+                ::peg::RuleResult::Error(__e) => ::peg::RuleResult::Error(__e),
                 ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
-                ::peg::RuleResult::Error(..) => panic!()
             }
         }
     }
@@ -1239,29 +1414,36 @@ pub mod peg {
                             ::peg::RuleResult::Matched(__pos, __val) => {
                                 ::peg::RuleResult::Matched(__pos, ())
                             }
+                            ::peg::RuleResult::Error(__e) => {
+                                __err_state.mark_error(__e);
+                                ::peg::RuleResult::Error(__e)
+                            }
                             ::peg::RuleResult::Failed => {
                                 __err_state.mark_failure(__pos, "\"::\"");
                                 ::peg::RuleResult::Failed
                             }
-                            ::peg::RuleResult::Error(..) => panic!()
                         }
+                    }
+                    ::peg::RuleResult::Error(__e) => {
+                        __err_state.mark_error(__e);
+                        ::peg::RuleResult::Error(__e)
                     }
                     ::peg::RuleResult::Failed => {
                         __err_state.mark_failure(__pos, "\"crate\"");
                         ::peg::RuleResult::Failed
                     }
-                    ::peg::RuleResult::Error(..) => panic!()
                 } {
                     ::peg::RuleResult::Matched(__newpos, _) => {
                         ::peg::RuleResult::Matched(__newpos, ())
                     }
                     ::peg::RuleResult::Failed => ::peg::RuleResult::Matched(__pos, ()),
-                    ::peg::RuleResult::Error(..) => panic!()
+                    ::peg::RuleResult::Error(__e) => ::peg::RuleResult::Error(__e),
                 };
             match __seq_res {
                 ::peg::RuleResult::Matched(__pos, _) => {
                     let __seq_res = {
                         let mut __repeat_pos = __pos;
+                        let mut __maybe_err = None;
                         let mut __repeat_value = vec![];
                         loop {
                             let __pos = __repeat_pos;
@@ -1274,16 +1456,22 @@ pub mod peg {
                                     ::peg::RuleResult::Matched(__pos, __val) => {
                                         ::peg::RuleResult::Matched(__pos, __val)
                                     }
+                                    ::peg::RuleResult::Error(__e) => {
+                                        __err_state.mark_error(__e);
+                                        ::peg::RuleResult::Error(__e)
+                                    }
                                     ::peg::RuleResult::Failed => {
                                         __err_state.mark_failure(__pos, "\"::\"");
                                         ::peg::RuleResult::Failed
                                     }
-                                    ::peg::RuleResult::Error(..) => panic!()
                                 };
                                 match __sep_res {
                                     ::peg::RuleResult::Matched(__newpos, _) => __newpos,
                                     ::peg::RuleResult::Failed => break,
-                                    ::peg::RuleResult::Error(..) => panic!()
+                                    ::peg::RuleResult::Error(__e) => {
+                                        __maybe_err = Some(__e);
+                                        break;
+                                    }
                                 }
                             };
                             let __step_res =
@@ -1291,8 +1479,8 @@ pub mod peg {
                                     ::peg::RuleResult::Matched(pos, _) => {
                                         ::peg::RuleResult::Matched(pos, ())
                                     }
+                                    ::peg::RuleResult::Error(e) => ::peg::RuleResult::Error(e),
                                     ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
-                                    ::peg::RuleResult::Error(..) => panic!()
                                 };
                             match __step_res {
                                 ::peg::RuleResult::Matched(__newpos, __value) => {
@@ -1302,10 +1490,15 @@ pub mod peg {
                                 ::peg::RuleResult::Failed => {
                                     break;
                                 }
-                                ::peg::RuleResult::Error(..) => panic!()
+                                ::peg::RuleResult::Error(__e) => {
+                                    __maybe_err = Some(__e);
+                                    break;
+                                }
                             }
                         }
-                        if __repeat_value.len() >= 1 {
+                        if let Some(__e) = __maybe_err {
+                            ::peg::RuleResult::Error(__e)
+                        } else if __repeat_value.len() >= 1 {
                             ::peg::RuleResult::Matched(__repeat_pos, ())
                         } else {
                             ::peg::RuleResult::Failed
@@ -1315,12 +1508,12 @@ pub mod peg {
                         ::peg::RuleResult::Matched(__pos, _) => {
                             ::peg::RuleResult::Matched(__pos, ())
                         }
+                        ::peg::RuleResult::Error(__e) => ::peg::RuleResult::Error(__e),
                         ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
-                        ::peg::RuleResult::Error(..) => panic!()
                     }
                 }
+                ::peg::RuleResult::Error(__e) => ::peg::RuleResult::Error(__e),
                 ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
-                ::peg::RuleResult::Error(..) => panic!()
             }
         }
     }
@@ -1334,13 +1527,14 @@ pub mod peg {
         {
             let __choice_res = match __parse_BRACKET_GROUP(__input, __state, __err_state, __pos) {
                 ::peg::RuleResult::Matched(pos, _) => ::peg::RuleResult::Matched(pos, ()),
+                ::peg::RuleResult::Error(e) => ::peg::RuleResult::Error(e),
                 ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
-                ::peg::RuleResult::Error(..) => panic!()
             };
             match __choice_res {
                 ::peg::RuleResult::Matched(__pos, __value) => {
                     ::peg::RuleResult::Matched(__pos, __value)
                 }
+                ::peg::RuleResult::Error(__e) => ::peg::RuleResult::Error(__e),
                 ::peg::RuleResult::Failed => {
                     let __choice_res =
                         match ::peg::ParseLiteral::parse_string_literal(__input, __pos, "&") {
@@ -1352,11 +1546,14 @@ pub mod peg {
                                         ::peg::RuleResult::Matched(__pos, __val) => {
                                             ::peg::RuleResult::Matched(__pos, __val)
                                         }
+                                        ::peg::RuleResult::Error(__e) => {
+                                            __err_state.mark_error(__e);
+                                            ::peg::RuleResult::Error(__e)
+                                        }
                                         ::peg::RuleResult::Failed => {
                                             __err_state.mark_failure(__pos, "\"mut\"");
                                             ::peg::RuleResult::Failed
                                         }
-                                        ::peg::RuleResult::Error(..) => panic!()
                                     } {
                                         ::peg::RuleResult::Matched(__newpos, _) => {
                                             ::peg::RuleResult::Matched(__newpos, ())
@@ -1364,7 +1561,9 @@ pub mod peg {
                                         ::peg::RuleResult::Failed => {
                                             ::peg::RuleResult::Matched(__pos, ())
                                         }
-                                        ::peg::RuleResult::Error(..) => panic!()
+                                        ::peg::RuleResult::Error(__e) => {
+                                            ::peg::RuleResult::Error(__e)
+                                        }
                                     };
                                 match __seq_res {
                                     ::peg::RuleResult::Matched(__pos, _) => {
@@ -1377,8 +1576,10 @@ pub mod peg {
                                             ::peg::RuleResult::Matched(pos, _) => {
                                                 ::peg::RuleResult::Matched(pos, ())
                                             }
+                                            ::peg::RuleResult::Error(e) => {
+                                                ::peg::RuleResult::Error(e)
+                                            }
                                             ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
-                                            ::peg::RuleResult::Error(..) => panic!()
                                         } {
                                             ::peg::RuleResult::Matched(__newpos, _) => {
                                                 ::peg::RuleResult::Matched(__newpos, ())
@@ -1386,7 +1587,9 @@ pub mod peg {
                                             ::peg::RuleResult::Failed => {
                                                 ::peg::RuleResult::Matched(__pos, ())
                                             }
-                                            ::peg::RuleResult::Error(..) => panic!()
+                                            ::peg::RuleResult::Error(__e) => {
+                                                ::peg::RuleResult::Error(__e)
+                                            }
                                         };
                                         match __seq_res {
                                             ::peg::RuleResult::Matched(__pos, _) => {
@@ -1399,39 +1602,49 @@ pub mod peg {
                                                     ::peg::RuleResult::Matched(pos, _) => {
                                                         ::peg::RuleResult::Matched(pos, ())
                                                     }
+                                                    ::peg::RuleResult::Error(e) => {
+                                                        ::peg::RuleResult::Error(e)
+                                                    }
                                                     ::peg::RuleResult::Failed => {
                                                         ::peg::RuleResult::Failed
                                                     }
-                                                    ::peg::RuleResult::Error(..) => panic!()
                                                 };
                                                 match __seq_res {
                                                     ::peg::RuleResult::Matched(__pos, _) => {
                                                         ::peg::RuleResult::Matched(__pos, ())
                                                     }
+                                                    ::peg::RuleResult::Error(__e) => {
+                                                        ::peg::RuleResult::Error(__e)
+                                                    }
                                                     ::peg::RuleResult::Failed => {
                                                         ::peg::RuleResult::Failed
                                                     }
-                                                    ::peg::RuleResult::Error(..) => panic!()
                                                 }
                                             }
+                                            ::peg::RuleResult::Error(__e) => {
+                                                ::peg::RuleResult::Error(__e)
+                                            }
                                             ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
-                                            ::peg::RuleResult::Error(..) => panic!()
                                         }
                                     }
+                                    ::peg::RuleResult::Error(__e) => ::peg::RuleResult::Error(__e),
                                     ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
-                                    ::peg::RuleResult::Error(..) => panic!()
                                 }
+                            }
+                            ::peg::RuleResult::Error(__e) => {
+                                __err_state.mark_error(__e);
+                                ::peg::RuleResult::Error(__e)
                             }
                             ::peg::RuleResult::Failed => {
                                 __err_state.mark_failure(__pos, "\"&\"");
                                 ::peg::RuleResult::Failed
                             }
-                            ::peg::RuleResult::Error(..) => panic!()
                         };
                     match __choice_res {
                         ::peg::RuleResult::Matched(__pos, __value) => {
                             ::peg::RuleResult::Matched(__pos, __value)
                         }
+                        ::peg::RuleResult::Error(__e) => ::peg::RuleResult::Error(__e),
                         ::peg::RuleResult::Failed => {
                             let __choice_res = match ::peg::ParseLiteral::parse_string_literal(
                                 __input, __pos, "dyn",
@@ -1446,27 +1659,33 @@ pub mod peg {
                                         ::peg::RuleResult::Matched(pos, _) => {
                                             ::peg::RuleResult::Matched(pos, ())
                                         }
+                                        ::peg::RuleResult::Error(e) => ::peg::RuleResult::Error(e),
                                         ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
-                                        ::peg::RuleResult::Error(..) => panic!()
                                     };
                                     match __seq_res {
                                         ::peg::RuleResult::Matched(__pos, _) => {
                                             ::peg::RuleResult::Matched(__pos, ())
                                         }
+                                        ::peg::RuleResult::Error(__e) => {
+                                            ::peg::RuleResult::Error(__e)
+                                        }
                                         ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
-                                        ::peg::RuleResult::Error(..) => panic!()
                                     }
+                                }
+                                ::peg::RuleResult::Error(__e) => {
+                                    __err_state.mark_error(__e);
+                                    ::peg::RuleResult::Error(__e)
                                 }
                                 ::peg::RuleResult::Failed => {
                                     __err_state.mark_failure(__pos, "\"dyn\"");
                                     ::peg::RuleResult::Failed
                                 }
-                                ::peg::RuleResult::Error(..) => panic!()
                             };
                             match __choice_res {
                                 ::peg::RuleResult::Matched(__pos, __value) => {
                                     ::peg::RuleResult::Matched(__pos, __value)
                                 }
+                                ::peg::RuleResult::Error(__e) => ::peg::RuleResult::Error(__e),
                                 ::peg::RuleResult::Failed => {
                                     let __choice_res =
                                         match ::peg::ParseLiteral::parse_string_literal(
@@ -1482,30 +1701,40 @@ pub mod peg {
                                                     ::peg::RuleResult::Matched(pos, _) => {
                                                         ::peg::RuleResult::Matched(pos, ())
                                                     }
+                                                    ::peg::RuleResult::Error(e) => {
+                                                        ::peg::RuleResult::Error(e)
+                                                    }
                                                     ::peg::RuleResult::Failed => {
                                                         ::peg::RuleResult::Failed
                                                     }
-                                                    ::peg::RuleResult::Error(..) => panic!()
                                                 };
                                                 match __seq_res {
                                                     ::peg::RuleResult::Matched(__pos, _) => {
                                                         ::peg::RuleResult::Matched(__pos, ())
                                                     }
+                                                    ::peg::RuleResult::Error(__e) => {
+                                                        ::peg::RuleResult::Error(__e)
+                                                    }
                                                     ::peg::RuleResult::Failed => {
                                                         ::peg::RuleResult::Failed
                                                     }
-                                                    ::peg::RuleResult::Error(..) => panic!()
                                                 }
+                                            }
+                                            ::peg::RuleResult::Error(__e) => {
+                                                __err_state.mark_error(__e);
+                                                ::peg::RuleResult::Error(__e)
                                             }
                                             ::peg::RuleResult::Failed => {
                                                 __err_state.mark_failure(__pos, "\"impl\"");
                                                 ::peg::RuleResult::Failed
                                             }
-                                            ::peg::RuleResult::Error(..) => panic!()
                                         };
                                     match __choice_res {
                                         ::peg::RuleResult::Matched(__pos, __value) => {
                                             ::peg::RuleResult::Matched(__pos, __value)
+                                        }
+                                        ::peg::RuleResult::Error(__e) => {
+                                            ::peg::RuleResult::Error(__e)
                                         }
                                         ::peg::RuleResult::Failed => {
                                             let __choice_res =
@@ -1515,6 +1744,7 @@ pub mod peg {
                                                     ::peg::RuleResult::Matched(__pos, __val) => {
                                                         let __seq_res = {
                                                             let mut __repeat_pos = __pos;
+                                                            let mut __maybe_err = None;
                                                             let mut __repeat_value = vec![];
                                                             loop {
                                                                 let __pos = __repeat_pos;
@@ -1523,10 +1753,10 @@ pub mod peg {
                                                                 {
                                                                     __pos
                                                                 } else {
-                                                                    let __sep_res = match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , ",") { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , __val) => { :: peg :: RuleResult :: Matched (__pos , __val) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\",\"") ; :: peg :: RuleResult :: Failed } } ;
-                                                                    match __sep_res { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__newpos , _) => { __newpos } , :: peg :: RuleResult :: Failed => break , }
+                                                                    let __sep_res = match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , ",") { :: peg :: RuleResult :: Matched (__pos , __val) => { :: peg :: RuleResult :: Matched (__pos , __val) } :: peg :: RuleResult :: Error (__e) => { __err_state . mark_error (__e) ; :: peg :: RuleResult :: Error (__e) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\",\"") ; :: peg :: RuleResult :: Failed } } ;
+                                                                    match __sep_res { :: peg :: RuleResult :: Matched (__newpos , _) => { __newpos } , :: peg :: RuleResult :: Failed => break , :: peg :: RuleResult :: Error (__e) => { __maybe_err = Some (__e) ; break } }
                                                                 };
-                                                                let __step_res = match __parse_rust_type (__input , __state , __err_state , __pos) { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (pos , _) => :: peg :: RuleResult :: Matched (pos , ()) , :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } ;
+                                                                let __step_res = match __parse_rust_type (__input , __state , __err_state , __pos) { :: peg :: RuleResult :: Matched (pos , _) => :: peg :: RuleResult :: Matched (pos , ()) , :: peg :: RuleResult :: Error (e) => :: peg :: RuleResult :: Error (e) , :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } ;
                                                                 match __step_res {
                                                                     ::peg::RuleResult::Matched(
                                                                         __newpos,
@@ -1539,7 +1769,12 @@ pub mod peg {
                                                                     ::peg::RuleResult::Failed => {
                                                                         break;
                                                                     }
-                                                                    ::peg::RuleResult::Error(..) => panic!()
+                                                                    ::peg::RuleResult::Error(
+                                                                        __e,
+                                                                    ) => {
+                                                                        __maybe_err = Some(__e);
+                                                                        break;
+                                                                    }
                                                                 }
                                                             }
                                                             ::peg::RuleResult::Matched(
@@ -1547,17 +1782,23 @@ pub mod peg {
                                                                 (),
                                                             )
                                                         };
-                                                        match __seq_res { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , _) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , ")") { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , __val) => { :: peg :: RuleResult :: Matched (__pos , ()) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\")\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , }
+                                                        match __seq_res { :: peg :: RuleResult :: Matched (__pos , _) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , ")") { :: peg :: RuleResult :: Matched (__pos , __val) => { :: peg :: RuleResult :: Matched (__pos , ()) } :: peg :: RuleResult :: Error (__e) => { __err_state . mark_error (__e) ; :: peg :: RuleResult :: Error (__e) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\")\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Error (__e) => :: peg :: RuleResult :: Error (__e) , :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , }
+                                                    }
+                                                    ::peg::RuleResult::Error(__e) => {
+                                                        __err_state.mark_error(__e);
+                                                        ::peg::RuleResult::Error(__e)
                                                     }
                                                     ::peg::RuleResult::Failed => {
                                                         __err_state.mark_failure(__pos, "\"(\"");
                                                         ::peg::RuleResult::Failed
                                                     }
-                                                    ::peg::RuleResult::Error(..) => panic!()
                                                 };
                                             match __choice_res {
                                                 ::peg::RuleResult::Matched(__pos, __value) => {
                                                     ::peg::RuleResult::Matched(__pos, __value)
+                                                }
+                                                ::peg::RuleResult::Error(__e) => {
+                                                    ::peg::RuleResult::Error(__e)
                                                 }
                                                 ::peg::RuleResult::Failed => {
                                                     match __parse_rust_ty_path(
@@ -1569,25 +1810,22 @@ pub mod peg {
                                                         ::peg::RuleResult::Matched(pos, _) => {
                                                             ::peg::RuleResult::Matched(pos, ())
                                                         }
+                                                        ::peg::RuleResult::Error(e) => {
+                                                            ::peg::RuleResult::Error(e)
+                                                        }
                                                         ::peg::RuleResult::Failed => {
                                                             ::peg::RuleResult::Failed
                                                         }
-                                                        ::peg::RuleResult::Error(..) => panic!()
                                                     }
                                                 }
-                                                ::peg::RuleResult::Error(..) => panic!()
                                             }
                                         }
-                                        ::peg::RuleResult::Error(..) => panic!()
                                     }
                                 }
-                                ::peg::RuleResult::Error(..) => panic!()
                             }
                         }
-                        ::peg::RuleResult::Error(..) => panic!()
                     }
                 }
-                ::peg::RuleResult::Error(..) => panic!()
             }
         }
     }
@@ -1604,22 +1842,26 @@ pub mod peg {
                     ::peg::RuleResult::Matched(__pos, __val) => {
                         ::peg::RuleResult::Matched(__pos, __val)
                     }
+                    ::peg::RuleResult::Error(__e) => {
+                        __err_state.mark_error(__e);
+                        ::peg::RuleResult::Error(__e)
+                    }
                     ::peg::RuleResult::Failed => {
                         __err_state.mark_failure(__pos, "\"::\"");
                         ::peg::RuleResult::Failed
                     }
-                    ::peg::RuleResult::Error(..) => panic!()
                 } {
                     ::peg::RuleResult::Matched(__newpos, _) => {
                         ::peg::RuleResult::Matched(__newpos, ())
                     }
                     ::peg::RuleResult::Failed => ::peg::RuleResult::Matched(__pos, ()),
-                    ::peg::RuleResult::Error(..) => panic!()
+                    ::peg::RuleResult::Error(__e) => ::peg::RuleResult::Error(__e),
                 };
             match __seq_res {
                 ::peg::RuleResult::Matched(__pos, _) => {
                     let __seq_res = {
                         let mut __repeat_pos = __pos;
+                        let mut __maybe_err = None;
                         let mut __repeat_value = vec![];
                         loop {
                             let __pos = __repeat_pos;
@@ -1632,16 +1874,22 @@ pub mod peg {
                                     ::peg::RuleResult::Matched(__pos, __val) => {
                                         ::peg::RuleResult::Matched(__pos, __val)
                                     }
+                                    ::peg::RuleResult::Error(__e) => {
+                                        __err_state.mark_error(__e);
+                                        ::peg::RuleResult::Error(__e)
+                                    }
                                     ::peg::RuleResult::Failed => {
                                         __err_state.mark_failure(__pos, "\"::\"");
                                         ::peg::RuleResult::Failed
                                     }
-                                    ::peg::RuleResult::Error(..) => panic!()
                                 };
                                 match __sep_res {
                                     ::peg::RuleResult::Matched(__newpos, _) => __newpos,
                                     ::peg::RuleResult::Failed => break,
-                                    ::peg::RuleResult::Error(..) => panic!()
+                                    ::peg::RuleResult::Error(__e) => {
+                                        __maybe_err = Some(__e);
+                                        break;
+                                    }
                                 }
                             };
                             let __step_res = {
@@ -1650,13 +1898,13 @@ pub mod peg {
                                         ::peg::RuleResult::Matched(pos, _) => {
                                             ::peg::RuleResult::Matched(pos, ())
                                         }
+                                        ::peg::RuleResult::Error(e) => ::peg::RuleResult::Error(e),
                                         ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
-                                        ::peg::RuleResult::Error(..) => panic!()
                                     };
                                 match __seq_res {
                                     ::peg::RuleResult::Matched(__pos, _) => {
                                         let __seq_res = match {
-                                            let __seq_res = match match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "::") { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , __val) => { :: peg :: RuleResult :: Matched (__pos , __val) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"::\"") ; :: peg :: RuleResult :: Failed } } { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__newpos , _) => { :: peg :: RuleResult :: Matched (__newpos , ()) } , :: peg :: RuleResult :: Failed => { :: peg :: RuleResult :: Matched (__pos , ()) } , } ;
+                                            let __seq_res = match match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "::") { :: peg :: RuleResult :: Matched (__pos , __val) => { :: peg :: RuleResult :: Matched (__pos , __val) } :: peg :: RuleResult :: Error (__e) => { __err_state . mark_error (__e) ; :: peg :: RuleResult :: Error (__e) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"::\"") ; :: peg :: RuleResult :: Failed } } { :: peg :: RuleResult :: Matched (__newpos , _) => { :: peg :: RuleResult :: Matched (__newpos , ()) } , :: peg :: RuleResult :: Failed => { :: peg :: RuleResult :: Matched (__pos , ()) } , :: peg :: RuleResult :: Error (__e) => { :: peg :: RuleResult :: Error (__e) } , } ;
                                             match __seq_res {
                                                 ::peg::RuleResult::Matched(__pos, _) => {
                                                     match ::peg::ParseLiteral::parse_string_literal(
@@ -1668,6 +1916,7 @@ pub mod peg {
                                                         ) => {
                                                             let __seq_res = {
                                                                 let mut __repeat_pos = __pos;
+                                                                let mut __maybe_err = None;
                                                                 let mut __repeat_value = vec![];
                                                                 loop {
                                                                     let __pos = __repeat_pos;
@@ -1676,16 +1925,19 @@ pub mod peg {
                                                                     {
                                                                         __pos
                                                                     } else {
-                                                                        let __sep_res = match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , ",") { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , __val) => { :: peg :: RuleResult :: Matched (__pos , __val) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\",\"") ; :: peg :: RuleResult :: Failed } } ;
-                                                                        match __sep_res { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__newpos , _) => { __newpos } , :: peg :: RuleResult :: Failed => break , }
+                                                                        let __sep_res = match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , ",") { :: peg :: RuleResult :: Matched (__pos , __val) => { :: peg :: RuleResult :: Matched (__pos , __val) } :: peg :: RuleResult :: Error (__e) => { __err_state . mark_error (__e) ; :: peg :: RuleResult :: Error (__e) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\",\"") ; :: peg :: RuleResult :: Failed } } ;
+                                                                        match __sep_res { :: peg :: RuleResult :: Matched (__newpos , _) => { __newpos } , :: peg :: RuleResult :: Failed => break , :: peg :: RuleResult :: Error (__e) => { __maybe_err = Some (__e) ; break } }
                                                                     };
                                                                     let __step_res = {
-                                                                        let __choice_res = match __parse_LIFETIME (__input , __state , __err_state , __pos) { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (pos , _) => :: peg :: RuleResult :: Matched (pos , ()) , :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } ;
-                                                                        match __choice_res { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , __value) => :: peg :: RuleResult :: Matched (__pos , __value) , :: peg :: RuleResult :: Failed => { let __choice_res = match __parse_rust_type (__input , __state , __err_state , __pos) { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (pos , _) => :: peg :: RuleResult :: Matched (pos , ()) , :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } ; match __choice_res { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , __value) => :: peg :: RuleResult :: Matched (__pos , __value) , :: peg :: RuleResult :: Failed => { let __choice_res = match __parse_BRACE_GROUP (__input , __state , __err_state , __pos) { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (pos , _) => :: peg :: RuleResult :: Matched (pos , ()) , :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } ; match __choice_res { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , __value) => :: peg :: RuleResult :: Matched (__pos , __value) , :: peg :: RuleResult :: Failed => match __parse_LITERAL (__input , __state , __err_state , __pos) { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (pos , _) => :: peg :: RuleResult :: Matched (pos , ()) , :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } } } } }
+                                                                        let __choice_res = match __parse_LIFETIME (__input , __state , __err_state , __pos) { :: peg :: RuleResult :: Matched (pos , _) => :: peg :: RuleResult :: Matched (pos , ()) , :: peg :: RuleResult :: Error (e) => :: peg :: RuleResult :: Error (e) , :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } ;
+                                                                        match __choice_res { :: peg :: RuleResult :: Matched (__pos , __value) => :: peg :: RuleResult :: Matched (__pos , __value) , :: peg :: RuleResult :: Error (__e) => :: peg :: RuleResult :: Error (__e) , :: peg :: RuleResult :: Failed => { let __choice_res = match __parse_rust_type (__input , __state , __err_state , __pos) { :: peg :: RuleResult :: Matched (pos , _) => :: peg :: RuleResult :: Matched (pos , ()) , :: peg :: RuleResult :: Error (e) => :: peg :: RuleResult :: Error (e) , :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } ; match __choice_res { :: peg :: RuleResult :: Matched (__pos , __value) => :: peg :: RuleResult :: Matched (__pos , __value) , :: peg :: RuleResult :: Error (__e) => :: peg :: RuleResult :: Error (__e) , :: peg :: RuleResult :: Failed => { let __choice_res = match __parse_BRACE_GROUP (__input , __state , __err_state , __pos) { :: peg :: RuleResult :: Matched (pos , _) => :: peg :: RuleResult :: Matched (pos , ()) , :: peg :: RuleResult :: Error (e) => :: peg :: RuleResult :: Error (e) , :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } ; match __choice_res { :: peg :: RuleResult :: Matched (__pos , __value) => :: peg :: RuleResult :: Matched (__pos , __value) , :: peg :: RuleResult :: Error (__e) => :: peg :: RuleResult :: Error (__e) , :: peg :: RuleResult :: Failed => match __parse_LITERAL (__input , __state , __err_state , __pos) { :: peg :: RuleResult :: Matched (pos , _) => :: peg :: RuleResult :: Matched (pos , ()) , :: peg :: RuleResult :: Error (e) => :: peg :: RuleResult :: Error (e) , :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } } } } }
                                                                     };
-                                                                    match __step_res { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__newpos , __value) => { __repeat_pos = __newpos ; __repeat_value . push (__value) ; } , :: peg :: RuleResult :: Failed => { break ; } }
+                                                                    match __step_res { :: peg :: RuleResult :: Matched (__newpos , __value) => { __repeat_pos = __newpos ; __repeat_value . push (__value) ; } , :: peg :: RuleResult :: Failed => { break ; } :: peg :: RuleResult :: Error (__e) => { __maybe_err = Some (__e) ; break ; } }
                                                                 }
-                                                                if __repeat_value.len() >= 1 {
+                                                                if let Some(__e) = __maybe_err {
+                                                                    ::peg::RuleResult::Error(__e)
+                                                                } else if __repeat_value.len() >= 1
+                                                                {
                                                                     ::peg::RuleResult::Matched(
                                                                         __repeat_pos,
                                                                         (),
@@ -1694,20 +1946,25 @@ pub mod peg {
                                                                     ::peg::RuleResult::Failed
                                                                 }
                                                             };
-                                                            match __seq_res { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , _) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , ">") { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , __val) => { :: peg :: RuleResult :: Matched (__pos , ()) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\">\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , }
+                                                            match __seq_res { :: peg :: RuleResult :: Matched (__pos , _) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , ">") { :: peg :: RuleResult :: Matched (__pos , __val) => { :: peg :: RuleResult :: Matched (__pos , ()) } :: peg :: RuleResult :: Error (__e) => { __err_state . mark_error (__e) ; :: peg :: RuleResult :: Error (__e) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\">\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Error (__e) => :: peg :: RuleResult :: Error (__e) , :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , }
+                                                        }
+                                                        ::peg::RuleResult::Error(__e) => {
+                                                            __err_state.mark_error(__e);
+                                                            ::peg::RuleResult::Error(__e)
                                                         }
                                                         ::peg::RuleResult::Failed => {
                                                             __err_state
                                                                 .mark_failure(__pos, "\"<\"");
                                                             ::peg::RuleResult::Failed
                                                         }
-                                                        ::peg::RuleResult::Error(..) => panic!()
                                                     }
+                                                }
+                                                ::peg::RuleResult::Error(__e) => {
+                                                    ::peg::RuleResult::Error(__e)
                                                 }
                                                 ::peg::RuleResult::Failed => {
                                                     ::peg::RuleResult::Failed
                                                 }
-                                                ::peg::RuleResult::Error(..) => panic!()
                                             }
                                         } {
                                             ::peg::RuleResult::Matched(__newpos, _) => {
@@ -1716,18 +1973,22 @@ pub mod peg {
                                             ::peg::RuleResult::Failed => {
                                                 ::peg::RuleResult::Matched(__pos, ())
                                             }
-                                            ::peg::RuleResult::Error(..) => panic!()
+                                            ::peg::RuleResult::Error(__e) => {
+                                                ::peg::RuleResult::Error(__e)
+                                            }
                                         };
                                         match __seq_res {
                                             ::peg::RuleResult::Matched(__pos, _) => {
                                                 ::peg::RuleResult::Matched(__pos, ())
                                             }
+                                            ::peg::RuleResult::Error(__e) => {
+                                                ::peg::RuleResult::Error(__e)
+                                            }
                                             ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
-                                            ::peg::RuleResult::Error(..) => panic!()
                                         }
                                     }
+                                    ::peg::RuleResult::Error(__e) => ::peg::RuleResult::Error(__e),
                                     ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
-                                    ::peg::RuleResult::Error(..) => panic!()
                                 }
                             };
                             match __step_res {
@@ -1738,10 +1999,15 @@ pub mod peg {
                                 ::peg::RuleResult::Failed => {
                                     break;
                                 }
-                                ::peg::RuleResult::Error(..) => panic!()
+                                ::peg::RuleResult::Error(__e) => {
+                                    __maybe_err = Some(__e);
+                                    break;
+                                }
                             }
                         }
-                        if __repeat_value.len() >= 1 {
+                        if let Some(__e) = __maybe_err {
+                            ::peg::RuleResult::Error(__e)
+                        } else if __repeat_value.len() >= 1 {
                             ::peg::RuleResult::Matched(__repeat_pos, ())
                         } else {
                             ::peg::RuleResult::Failed
@@ -1751,12 +2017,12 @@ pub mod peg {
                         ::peg::RuleResult::Matched(__pos, _) => {
                             ::peg::RuleResult::Matched(__pos, ())
                         }
+                        ::peg::RuleResult::Error(__e) => ::peg::RuleResult::Error(__e),
                         ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
-                        ::peg::RuleResult::Error(..) => panic!()
                     }
                 }
+                ::peg::RuleResult::Error(__e) => ::peg::RuleResult::Error(__e),
                 ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
-                ::peg::RuleResult::Error(..) => panic!()
             }
         }
     }
@@ -1771,6 +2037,7 @@ pub mod peg {
             ::peg::RuleResult::Matched(__pos, __val) => {
                 let __seq_res = {
                     let mut __repeat_pos = __pos;
+                    let mut __maybe_err = None;
                     let mut __repeat_value = vec![];
                     loop {
                         let __pos = __repeat_pos;
@@ -1783,16 +2050,22 @@ pub mod peg {
                                 ::peg::RuleResult::Matched(__pos, __val) => {
                                     ::peg::RuleResult::Matched(__pos, __val)
                                 }
+                                ::peg::RuleResult::Error(__e) => {
+                                    __err_state.mark_error(__e);
+                                    ::peg::RuleResult::Error(__e)
+                                }
                                 ::peg::RuleResult::Failed => {
                                     __err_state.mark_failure(__pos, "\",\"");
                                     ::peg::RuleResult::Failed
                                 }
-                                ::peg::RuleResult::Error(..) => panic!()
                             };
                             match __sep_res {
                                 ::peg::RuleResult::Matched(__newpos, _) => __newpos,
                                 ::peg::RuleResult::Failed => break,
-                                ::peg::RuleResult::Error(..) => panic!()
+                                ::peg::RuleResult::Error(__e) => {
+                                    __maybe_err = Some(__e);
+                                    break;
+                                }
                             }
                         };
                         let __step_res = {
@@ -1806,8 +2079,8 @@ pub mod peg {
                                 ::peg::RuleResult::Matched(pos, _) => {
                                     ::peg::RuleResult::Matched(pos, ())
                                 }
+                                ::peg::RuleResult::Error(e) => ::peg::RuleResult::Error(e),
                                 ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
-                                ::peg::RuleResult::Error(..) => panic!()
                             } {
                                 ::peg::RuleResult::Matched(__newpos, _) => {
                                     ::peg::RuleResult::Matched(
@@ -1818,7 +2091,7 @@ pub mod peg {
                                     )
                                 }
                                 ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
-                                ::peg::RuleResult::Error(..) => panic!()
+                                ::peg::RuleResult::Error(__e) => ::peg::RuleResult::Error(__e),
                             }
                         };
                         match __step_res {
@@ -1829,10 +2102,15 @@ pub mod peg {
                             ::peg::RuleResult::Failed => {
                                 break;
                             }
-                            ::peg::RuleResult::Error(..) => panic!()
+                            ::peg::RuleResult::Error(__e) => {
+                                __maybe_err = Some(__e);
+                                break;
+                            }
                         }
                     }
-                    if __repeat_value.len() >= 1 {
+                    if let Some(__e) = __maybe_err {
+                        ::peg::RuleResult::Error(__e)
+                    } else if __repeat_value.len() >= 1 {
                         ::peg::RuleResult::Matched(__repeat_pos, __repeat_value)
                     } else {
                         ::peg::RuleResult::Failed
@@ -1844,22 +2122,28 @@ pub mod peg {
                             ::peg::RuleResult::Matched(__pos, __val) => {
                                 ::peg::RuleResult::Matched(__pos, (|| p)())
                             }
+                            ::peg::RuleResult::Error(__e) => {
+                                __err_state.mark_error(__e);
+                                ::peg::RuleResult::Error(__e)
+                            }
                             ::peg::RuleResult::Failed => {
                                 __err_state.mark_failure(__pos, "\">\"");
                                 ::peg::RuleResult::Failed
                             }
-                            ::peg::RuleResult::Error(..) => panic!()
                         }
                     }
+                    ::peg::RuleResult::Error(__e) => ::peg::RuleResult::Error(__e),
                     ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
-                    ::peg::RuleResult::Error(..) => panic!()
                 }
+            }
+            ::peg::RuleResult::Error(__e) => {
+                __err_state.mark_error(__e);
+                ::peg::RuleResult::Error(__e)
             }
             ::peg::RuleResult::Failed => {
                 __err_state.mark_failure(__pos, "\"<\"");
                 ::peg::RuleResult::Failed
             }
-            ::peg::RuleResult::Error(..) => panic!()
         }
     }
     fn __parse_rust_generic_param<'input>(
@@ -1873,8 +2157,8 @@ pub mod peg {
             let __choice_res = {
                 let __seq_res = match __parse_LIFETIME(__input, __state, __err_state, __pos) {
                     ::peg::RuleResult::Matched(pos, _) => ::peg::RuleResult::Matched(pos, ()),
+                    ::peg::RuleResult::Error(e) => ::peg::RuleResult::Error(e),
                     ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
-                    ::peg::RuleResult::Error(..) => panic!()
                 };
                 match __seq_res {
                     ::peg::RuleResult::Matched(__pos, _) => {
@@ -1884,6 +2168,7 @@ pub mod peg {
                             ::peg::RuleResult::Matched(__pos, __val) => {
                                 let __seq_res = {
                                     let mut __repeat_pos = __pos;
+                                    let mut __maybe_err = None;
                                     let mut __repeat_value = vec![];
                                     loop {
                                         let __pos = __repeat_pos;
@@ -1897,16 +2182,22 @@ pub mod peg {
                                                     ::peg::RuleResult::Matched(__pos, __val) => {
                                                         ::peg::RuleResult::Matched(__pos, __val)
                                                     }
+                                                    ::peg::RuleResult::Error(__e) => {
+                                                        __err_state.mark_error(__e);
+                                                        ::peg::RuleResult::Error(__e)
+                                                    }
                                                     ::peg::RuleResult::Failed => {
                                                         __err_state.mark_failure(__pos, "\"+\"");
                                                         ::peg::RuleResult::Failed
                                                     }
-                                                    ::peg::RuleResult::Error(..) => panic!()
                                                 };
                                             match __sep_res {
                                                 ::peg::RuleResult::Matched(__newpos, _) => __newpos,
                                                 ::peg::RuleResult::Failed => break,
-                                                ::peg::RuleResult::Error(..) => panic!()
+                                                ::peg::RuleResult::Error(__e) => {
+                                                    __maybe_err = Some(__e);
+                                                    break;
+                                                }
                                             }
                                         };
                                         let __step_res = match __parse_LIFETIME(
@@ -1918,8 +2209,10 @@ pub mod peg {
                                             ::peg::RuleResult::Matched(pos, _) => {
                                                 ::peg::RuleResult::Matched(pos, ())
                                             }
+                                            ::peg::RuleResult::Error(e) => {
+                                                ::peg::RuleResult::Error(e)
+                                            }
                                             ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
-                                            ::peg::RuleResult::Error(..) => panic!()
                                         };
                                         match __step_res {
                                             ::peg::RuleResult::Matched(__newpos, __value) => {
@@ -1929,10 +2222,15 @@ pub mod peg {
                                             ::peg::RuleResult::Failed => {
                                                 break;
                                             }
-                                            ::peg::RuleResult::Error(..) => panic!()
+                                            ::peg::RuleResult::Error(__e) => {
+                                                __maybe_err = Some(__e);
+                                                break;
+                                            }
                                         }
                                     }
-                                    if __repeat_value.len() >= 1 {
+                                    if let Some(__e) = __maybe_err {
+                                        ::peg::RuleResult::Error(__e)
+                                    } else if __repeat_value.len() >= 1 {
                                         ::peg::RuleResult::Matched(__repeat_pos, ())
                                     } else {
                                         ::peg::RuleResult::Failed
@@ -1942,43 +2240,47 @@ pub mod peg {
                                     ::peg::RuleResult::Matched(__pos, _) => {
                                         ::peg::RuleResult::Matched(__pos, ())
                                     }
+                                    ::peg::RuleResult::Error(__e) => ::peg::RuleResult::Error(__e),
                                     ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
-                                    ::peg::RuleResult::Error(..) => panic!()
                                 }
+                            }
+                            ::peg::RuleResult::Error(__e) => {
+                                __err_state.mark_error(__e);
+                                ::peg::RuleResult::Error(__e)
                             }
                             ::peg::RuleResult::Failed => {
                                 __err_state.mark_failure(__pos, "\":\"");
                                 ::peg::RuleResult::Failed
                             }
-                            ::peg::RuleResult::Error(..) => panic!()
                         } {
                             ::peg::RuleResult::Matched(__newpos, _) => {
                                 ::peg::RuleResult::Matched(__newpos, ())
                             }
                             ::peg::RuleResult::Failed => ::peg::RuleResult::Matched(__pos, ()),
-                            ::peg::RuleResult::Error(..) => panic!()
+                            ::peg::RuleResult::Error(__e) => ::peg::RuleResult::Error(__e),
                         };
                         match __seq_res {
                             ::peg::RuleResult::Matched(__pos, _) => {
                                 ::peg::RuleResult::Matched(__pos, ())
                             }
+                            ::peg::RuleResult::Error(__e) => ::peg::RuleResult::Error(__e),
                             ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
-                            ::peg::RuleResult::Error(..) => panic!()
                         }
                     }
+                    ::peg::RuleResult::Error(__e) => ::peg::RuleResult::Error(__e),
                     ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
-                    ::peg::RuleResult::Error(..) => panic!()
                 }
             };
             match __choice_res {
                 ::peg::RuleResult::Matched(__pos, __value) => {
                     ::peg::RuleResult::Matched(__pos, __value)
                 }
+                ::peg::RuleResult::Error(__e) => ::peg::RuleResult::Error(__e),
                 ::peg::RuleResult::Failed => {
                     let __seq_res = match __parse_IDENT(__input, __state, __err_state, __pos) {
                         ::peg::RuleResult::Matched(pos, _) => ::peg::RuleResult::Matched(pos, ()),
+                        ::peg::RuleResult::Error(e) => ::peg::RuleResult::Error(e),
                         ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
-                        ::peg::RuleResult::Error(..) => panic!()
                     };
                     match __seq_res {
                         ::peg::RuleResult::Matched(__pos, _) => {
@@ -1988,6 +2290,7 @@ pub mod peg {
                                 ::peg::RuleResult::Matched(__pos, __val) => {
                                     let __seq_res = {
                                         let mut __repeat_pos = __pos;
+                                        let mut __maybe_err = None;
                                         let mut __repeat_value = vec![];
                                         loop {
                                             let __pos = __repeat_pos;
@@ -2004,19 +2307,25 @@ pub mod peg {
                                                         ) => {
                                                             ::peg::RuleResult::Matched(__pos, __val)
                                                         }
+                                                        ::peg::RuleResult::Error(__e) => {
+                                                            __err_state.mark_error(__e);
+                                                            ::peg::RuleResult::Error(__e)
+                                                        }
                                                         ::peg::RuleResult::Failed => {
                                                             __err_state
                                                                 .mark_failure(__pos, "\"+\"");
                                                             ::peg::RuleResult::Failed
                                                         }
-                                                        ::peg::RuleResult::Error(..) => panic!()
                                                     };
                                                 match __sep_res {
                                                     ::peg::RuleResult::Matched(__newpos, _) => {
                                                         __newpos
                                                     }
                                                     ::peg::RuleResult::Failed => break,
-                                                    ::peg::RuleResult::Error(..) => panic!()
+                                                    ::peg::RuleResult::Error(__e) => {
+                                                        __maybe_err = Some(__e);
+                                                        break;
+                                                    }
                                                 }
                                             };
                                             let __step_res = {
@@ -2029,23 +2338,28 @@ pub mod peg {
                                                     ::peg::RuleResult::Matched(pos, _) => {
                                                         ::peg::RuleResult::Matched(pos, ())
                                                     }
+                                                    ::peg::RuleResult::Error(e) => {
+                                                        ::peg::RuleResult::Error(e)
+                                                    }
                                                     ::peg::RuleResult::Failed => {
                                                         ::peg::RuleResult::Failed
                                                     }
-                                                    ::peg::RuleResult::Error(..) => panic!()
                                                 };
                                                 match __choice_res {
                                                     ::peg::RuleResult::Matched(__pos, __value) => {
                                                         ::peg::RuleResult::Matched(__pos, __value)
                                                     }
+                                                    ::peg::RuleResult::Error(__e) => {
+                                                        ::peg::RuleResult::Error(__e)
+                                                    }
                                                     ::peg::RuleResult::Failed => {
-                                                        let __seq_res = match match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "?") { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , __val) => { :: peg :: RuleResult :: Matched (__pos , __val) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"?\"") ; :: peg :: RuleResult :: Failed } } { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__newpos , _) => { :: peg :: RuleResult :: Matched (__newpos , ()) } , :: peg :: RuleResult :: Failed => { :: peg :: RuleResult :: Matched (__pos , ()) } , } ;
+                                                        let __seq_res = match match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "?") { :: peg :: RuleResult :: Matched (__pos , __val) => { :: peg :: RuleResult :: Matched (__pos , __val) } :: peg :: RuleResult :: Error (__e) => { __err_state . mark_error (__e) ; :: peg :: RuleResult :: Error (__e) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"?\"") ; :: peg :: RuleResult :: Failed } } { :: peg :: RuleResult :: Matched (__newpos , _) => { :: peg :: RuleResult :: Matched (__newpos , ()) } , :: peg :: RuleResult :: Failed => { :: peg :: RuleResult :: Matched (__pos , ()) } , :: peg :: RuleResult :: Error (__e) => { :: peg :: RuleResult :: Error (__e) } , } ;
                                                         match __seq_res {
                                                             ::peg::RuleResult::Matched(
                                                                 __pos,
                                                                 _,
                                                             ) => {
-                                                                let __seq_res = match __parse_rust_ty_path (__input , __state , __err_state , __pos) { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (pos , _) => :: peg :: RuleResult :: Matched (pos , ()) , :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } ;
+                                                                let __seq_res = match __parse_rust_ty_path (__input , __state , __err_state , __pos) { :: peg :: RuleResult :: Matched (pos , _) => :: peg :: RuleResult :: Matched (pos , ()) , :: peg :: RuleResult :: Error (e) => :: peg :: RuleResult :: Error (e) , :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } ;
                                                                 match __seq_res {
                                                                     ::peg::RuleResult::Matched(
                                                                         __pos,
@@ -2056,19 +2370,24 @@ pub mod peg {
                                                                             (),
                                                                         )
                                                                     }
+                                                                    ::peg::RuleResult::Error(
+                                                                        __e,
+                                                                    ) => ::peg::RuleResult::Error(
+                                                                        __e,
+                                                                    ),
                                                                     ::peg::RuleResult::Failed => {
                                                                         ::peg::RuleResult::Failed
                                                                     }
-                                                                    ::peg::RuleResult::Error(..) => panic!()
                                                                 }
+                                                            }
+                                                            ::peg::RuleResult::Error(__e) => {
+                                                                ::peg::RuleResult::Error(__e)
                                                             }
                                                             ::peg::RuleResult::Failed => {
                                                                 ::peg::RuleResult::Failed
                                                             }
-                                                            ::peg::RuleResult::Error(..) => panic!()
                                                         }
                                                     }
-                                                    ::peg::RuleResult::Error(..) => panic!()
                                                 }
                                             };
                                             match __step_res {
@@ -2079,10 +2398,15 @@ pub mod peg {
                                                 ::peg::RuleResult::Failed => {
                                                     break;
                                                 }
-                                                ::peg::RuleResult::Error(..) => panic!()
+                                                ::peg::RuleResult::Error(__e) => {
+                                                    __maybe_err = Some(__e);
+                                                    break;
+                                                }
                                             }
                                         }
-                                        if __repeat_value.len() >= 1 {
+                                        if let Some(__e) = __maybe_err {
+                                            ::peg::RuleResult::Error(__e)
+                                        } else if __repeat_value.len() >= 1 {
                                             ::peg::RuleResult::Matched(__repeat_pos, ())
                                         } else {
                                             ::peg::RuleResult::Failed
@@ -2092,35 +2416,39 @@ pub mod peg {
                                         ::peg::RuleResult::Matched(__pos, _) => {
                                             ::peg::RuleResult::Matched(__pos, ())
                                         }
+                                        ::peg::RuleResult::Error(__e) => {
+                                            ::peg::RuleResult::Error(__e)
+                                        }
                                         ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
-                                        ::peg::RuleResult::Error(..) => panic!()
                                     }
+                                }
+                                ::peg::RuleResult::Error(__e) => {
+                                    __err_state.mark_error(__e);
+                                    ::peg::RuleResult::Error(__e)
                                 }
                                 ::peg::RuleResult::Failed => {
                                     __err_state.mark_failure(__pos, "\":\"");
                                     ::peg::RuleResult::Failed
                                 }
-                                ::peg::RuleResult::Error(..) => panic!()
                             } {
                                 ::peg::RuleResult::Matched(__newpos, _) => {
                                     ::peg::RuleResult::Matched(__newpos, ())
                                 }
                                 ::peg::RuleResult::Failed => ::peg::RuleResult::Matched(__pos, ()),
-                                ::peg::RuleResult::Error(..) => panic!()
+                                ::peg::RuleResult::Error(__e) => ::peg::RuleResult::Error(__e),
                             };
                             match __seq_res {
                                 ::peg::RuleResult::Matched(__pos, _) => {
                                     ::peg::RuleResult::Matched(__pos, ())
                                 }
+                                ::peg::RuleResult::Error(__e) => ::peg::RuleResult::Error(__e),
                                 ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
-                                ::peg::RuleResult::Error(..) => panic!()
                             }
                         }
+                        ::peg::RuleResult::Error(__e) => ::peg::RuleResult::Error(__e),
                         ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
-                        ::peg::RuleResult::Error(..) => panic!()
                     }
                 }
-                ::peg::RuleResult::Error(..) => panic!()
             }
         }
     }
@@ -2146,6 +2474,7 @@ pub mod peg {
                 ::peg::RuleResult::Matched(__pos, sp) => {
                     let __seq_res = {
                         let mut __repeat_pos = __pos;
+                        let mut __maybe_err = None;
                         let mut __repeat_value = vec![];
                         loop {
                             let __pos = __repeat_pos;
@@ -2158,16 +2487,22 @@ pub mod peg {
                                     ::peg::RuleResult::Matched(__pos, __val) => {
                                         ::peg::RuleResult::Matched(__pos, __val)
                                     }
+                                    ::peg::RuleResult::Error(__e) => {
+                                        __err_state.mark_error(__e);
+                                        ::peg::RuleResult::Error(__e)
+                                    }
                                     ::peg::RuleResult::Failed => {
                                         __err_state.mark_failure(__pos, "\"/\"");
                                         ::peg::RuleResult::Failed
                                     }
-                                    ::peg::RuleResult::Error(..) => panic!()
                                 };
                                 match __sep_res {
                                     ::peg::RuleResult::Matched(__newpos, _) => __newpos,
                                     ::peg::RuleResult::Failed => break,
-                                    ::peg::RuleResult::Error(..) => panic!()
+                                    ::peg::RuleResult::Error(__e) => {
+                                        __maybe_err = Some(__e);
+                                        break;
+                                    }
                                 }
                             };
                             let __step_res = __parse_sequence(__input, __state, __err_state, __pos);
@@ -2179,10 +2514,15 @@ pub mod peg {
                                 ::peg::RuleResult::Failed => {
                                     break;
                                 }
-                                ::peg::RuleResult::Error(..) => panic!()
+                                ::peg::RuleResult::Error(__e) => {
+                                    __maybe_err = Some(__e);
+                                    break;
+                                }
                             }
                         }
-                        if __repeat_value.len() >= 1 {
+                        if let Some(__e) = __maybe_err {
+                            ::peg::RuleResult::Error(__e)
+                        } else if __repeat_value.len() >= 1 {
                             ::peg::RuleResult::Matched(__repeat_pos, __repeat_value)
                         } else {
                             ::peg::RuleResult::Failed
@@ -2199,12 +2539,12 @@ pub mod peg {
                                 }
                             })(),
                         ),
+                        ::peg::RuleResult::Error(__e) => ::peg::RuleResult::Error(__e),
                         ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
-                        ::peg::RuleResult::Error(..) => panic!()
                     }
                 }
+                ::peg::RuleResult::Error(__e) => ::peg::RuleResult::Error(__e),
                 ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
-                ::peg::RuleResult::Error(..) => panic!()
             }
         }
     }
@@ -2221,6 +2561,7 @@ pub mod peg {
                 ::peg::RuleResult::Matched(__pos, sp) => {
                     let __seq_res = {
                         let mut __repeat_pos = __pos;
+                        let mut __maybe_err = None;
                         let mut __repeat_value = vec![];
                         loop {
                             let __pos = __repeat_pos;
@@ -2233,7 +2574,10 @@ pub mod peg {
                                 ::peg::RuleResult::Failed => {
                                     break;
                                 }
-                                ::peg::RuleResult::Error(..) => panic!()
+                                ::peg::RuleResult::Error(__e) => {
+                                    __maybe_err = Some(__e);
+                                    break;
+                                }
                             }
                         }
                         ::peg::RuleResult::Matched(__repeat_pos, __repeat_value)
@@ -2248,7 +2592,7 @@ pub mod peg {
                                     ::peg::RuleResult::Failed => {
                                         ::peg::RuleResult::Matched(__pos, None)
                                     }
-                                    ::peg::RuleResult::Error(..) => panic!()
+                                    ::peg::RuleResult::Error(__e) => ::peg::RuleResult::Error(__e),
                                 };
                             match __seq_res {
                                 ::peg::RuleResult::Matched(__pos, code) => {
@@ -2265,16 +2609,16 @@ pub mod peg {
                                         })(),
                                     )
                                 }
+                                ::peg::RuleResult::Error(__e) => ::peg::RuleResult::Error(__e),
                                 ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
-                                ::peg::RuleResult::Error(..) => panic!()
                             }
                         }
+                        ::peg::RuleResult::Error(__e) => ::peg::RuleResult::Error(__e),
                         ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
-                        ::peg::RuleResult::Error(..) => panic!()
                     }
                 }
+                ::peg::RuleResult::Error(__e) => ::peg::RuleResult::Error(__e),
                 ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
-                ::peg::RuleResult::Error(..) => panic!()
             }
         }
     }
@@ -2294,22 +2638,25 @@ pub mod peg {
                             ::peg::RuleResult::Matched(__pos, __val) => {
                                 ::peg::RuleResult::Matched(__pos, (|| l)())
                             }
+                            ::peg::RuleResult::Error(__e) => {
+                                __err_state.mark_error(__e);
+                                ::peg::RuleResult::Error(__e)
+                            }
                             ::peg::RuleResult::Failed => {
                                 __err_state.mark_failure(__pos, "\":\"");
                                 ::peg::RuleResult::Failed
                             }
-                            ::peg::RuleResult::Error(..) => panic!()
                         }
                     }
+                    ::peg::RuleResult::Error(__e) => ::peg::RuleResult::Error(__e),
                     ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
-                    ::peg::RuleResult::Error(..) => panic!()
                 }
             } {
                 ::peg::RuleResult::Matched(__newpos, __value) => {
                     ::peg::RuleResult::Matched(__newpos, Some(__value))
                 }
                 ::peg::RuleResult::Failed => ::peg::RuleResult::Matched(__pos, None),
-                ::peg::RuleResult::Error(..) => panic!()
+                ::peg::RuleResult::Error(__e) => ::peg::RuleResult::Error(__e),
             };
             match __seq_res {
                 ::peg::RuleResult::Matched(__pos, label) => {
@@ -2324,12 +2671,12 @@ pub mod peg {
                                 })(),
                             )
                         }
+                        ::peg::RuleResult::Error(__e) => ::peg::RuleResult::Error(__e),
                         ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
-                        ::peg::RuleResult::Error(..) => panic!()
                     }
                 }
+                ::peg::RuleResult::Error(__e) => ::peg::RuleResult::Error(__e),
                 ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
-                ::peg::RuleResult::Error(..) => panic!()
             }
         }
     }
@@ -2356,25 +2703,29 @@ pub mod peg {
                                             (|| OptionalExpr(Box::new(e)).at(sp))(),
                                         )
                                     }
+                                    ::peg::RuleResult::Error(__e) => {
+                                        __err_state.mark_error(__e);
+                                        ::peg::RuleResult::Error(__e)
+                                    }
                                     ::peg::RuleResult::Failed => {
                                         __err_state.mark_failure(__pos, "\"?\"");
                                         ::peg::RuleResult::Failed
                                     }
-                                    ::peg::RuleResult::Error(..) => panic!()
                                 }
                             }
+                            ::peg::RuleResult::Error(__e) => ::peg::RuleResult::Error(__e),
                             ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
-                            ::peg::RuleResult::Error(..) => panic!()
                         }
                     }
+                    ::peg::RuleResult::Error(__e) => ::peg::RuleResult::Error(__e),
                     ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
-                    ::peg::RuleResult::Error(..) => panic!()
                 }
             };
             match __choice_res {
                 ::peg::RuleResult::Matched(__pos, __value) => {
                     ::peg::RuleResult::Matched(__pos, __value)
                 }
+                ::peg::RuleResult::Error(__e) => ::peg::RuleResult::Error(__e),
                 ::peg::RuleResult::Failed => {
                     let __choice_res = {
                         let __seq_res = __parse_prefixed(__input, __state, __err_state, __pos);
@@ -2417,37 +2768,45 @@ pub mod peg {
                                                                 })(
                                                                 ),
                                                             ),
+                                                            ::peg::RuleResult::Error(__e) => {
+                                                                ::peg::RuleResult::Error(__e)
+                                                            }
                                                             ::peg::RuleResult::Failed => {
                                                                 ::peg::RuleResult::Failed
                                                             }
-                                                            ::peg::RuleResult::Error(..) => panic!()
                                                         }
+                                                    }
+                                                    ::peg::RuleResult::Error(__e) => {
+                                                        ::peg::RuleResult::Error(__e)
                                                     }
                                                     ::peg::RuleResult::Failed => {
                                                         ::peg::RuleResult::Failed
                                                     }
-                                                    ::peg::RuleResult::Error(..) => panic!()
                                                 }
+                                            }
+                                            ::peg::RuleResult::Error(__e) => {
+                                                __err_state.mark_error(__e);
+                                                ::peg::RuleResult::Error(__e)
                                             }
                                             ::peg::RuleResult::Failed => {
                                                 __err_state.mark_failure(__pos, "\"**\"");
                                                 ::peg::RuleResult::Failed
                                             }
-                                            ::peg::RuleResult::Error(..) => panic!()
                                         }
                                     }
+                                    ::peg::RuleResult::Error(__e) => ::peg::RuleResult::Error(__e),
                                     ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
-                                    ::peg::RuleResult::Error(..) => panic!()
                                 }
                             }
+                            ::peg::RuleResult::Error(__e) => ::peg::RuleResult::Error(__e),
                             ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
-                            ::peg::RuleResult::Error(..) => panic!()
                         }
                     };
                     match __choice_res {
                         ::peg::RuleResult::Matched(__pos, __value) => {
                             ::peg::RuleResult::Matched(__pos, __value)
                         }
+                        ::peg::RuleResult::Error(__e) => ::peg::RuleResult::Error(__e),
                         ::peg::RuleResult::Failed => {
                             let __choice_res = {
                                 let __seq_res =
@@ -2484,31 +2843,39 @@ pub mod peg {
                                                                 })(
                                                                 ),
                                                             ),
+                                                            ::peg::RuleResult::Error(__e) => {
+                                                                ::peg::RuleResult::Error(__e)
+                                                            }
                                                             ::peg::RuleResult::Failed => {
                                                                 ::peg::RuleResult::Failed
                                                             }
-                                                            ::peg::RuleResult::Error(..) => panic!()
                                                         }
+                                                    }
+                                                    ::peg::RuleResult::Error(__e) => {
+                                                        __err_state.mark_error(__e);
+                                                        ::peg::RuleResult::Error(__e)
                                                     }
                                                     ::peg::RuleResult::Failed => {
                                                         __err_state.mark_failure(__pos, "\"++\"");
                                                         ::peg::RuleResult::Failed
                                                     }
-                                                    ::peg::RuleResult::Error(..) => panic!()
                                                 }
                                             }
+                                            ::peg::RuleResult::Error(__e) => {
+                                                ::peg::RuleResult::Error(__e)
+                                            }
                                             ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
-                                            ::peg::RuleResult::Error(..) => panic!()
                                         }
                                     }
+                                    ::peg::RuleResult::Error(__e) => ::peg::RuleResult::Error(__e),
                                     ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
-                                    ::peg::RuleResult::Error(..) => panic!()
                                 }
                             };
                             match __choice_res {
                                 ::peg::RuleResult::Matched(__pos, __value) => {
                                     ::peg::RuleResult::Matched(__pos, __value)
                                 }
+                                ::peg::RuleResult::Error(__e) => ::peg::RuleResult::Error(__e),
                                 ::peg::RuleResult::Failed => {
                                     let __choice_res = {
                                         let __seq_res =
@@ -2521,15 +2888,20 @@ pub mod peg {
                                                     __err_state,
                                                     __pos,
                                                 );
-                                                match __seq_res { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , sp) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "*") { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , __val) => { { let __seq_res = __parse_repeatcount (__input , __state , __err_state , __pos) ; match __seq_res { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , count) => { :: peg :: RuleResult :: Matched (__pos , (|| { Repeat { inner : Box :: new (e) , bound : count , sep : None } . at (sp) }) ()) } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"*\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , }
+                                                match __seq_res { :: peg :: RuleResult :: Matched (__pos , sp) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "*") { :: peg :: RuleResult :: Matched (__pos , __val) => { { let __seq_res = __parse_repeatcount (__input , __state , __err_state , __pos) ; match __seq_res { :: peg :: RuleResult :: Matched (__pos , count) => { :: peg :: RuleResult :: Matched (__pos , (|| { Repeat { inner : Box :: new (e) , bound : count , sep : None } . at (sp) }) ()) } :: peg :: RuleResult :: Error (__e) => :: peg :: RuleResult :: Error (__e) , :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } } :: peg :: RuleResult :: Error (__e) => { __err_state . mark_error (__e) ; :: peg :: RuleResult :: Error (__e) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"*\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Error (__e) => :: peg :: RuleResult :: Error (__e) , :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , }
+                                            }
+                                            ::peg::RuleResult::Error(__e) => {
+                                                ::peg::RuleResult::Error(__e)
                                             }
                                             ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
-                                            ::peg::RuleResult::Error(..) => panic!()
                                         }
                                     };
                                     match __choice_res {
                                         ::peg::RuleResult::Matched(__pos, __value) => {
                                             ::peg::RuleResult::Matched(__pos, __value)
+                                        }
+                                        ::peg::RuleResult::Error(__e) => {
+                                            ::peg::RuleResult::Error(__e)
                                         }
                                         ::peg::RuleResult::Failed => {
                                             let __choice_res = {
@@ -2547,17 +2919,22 @@ pub mod peg {
                                                             __err_state,
                                                             __pos,
                                                         );
-                                                        match __seq_res { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , sp) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "+") { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , __val) => { :: peg :: RuleResult :: Matched (__pos , (|| { Repeat { inner : Box :: new (e) , bound : BoundedRepeat :: Plus , sep : None } . at (sp) }) ()) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"+\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , }
+                                                        match __seq_res { :: peg :: RuleResult :: Matched (__pos , sp) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "+") { :: peg :: RuleResult :: Matched (__pos , __val) => { :: peg :: RuleResult :: Matched (__pos , (|| { Repeat { inner : Box :: new (e) , bound : BoundedRepeat :: Plus , sep : None } . at (sp) }) ()) } :: peg :: RuleResult :: Error (__e) => { __err_state . mark_error (__e) ; :: peg :: RuleResult :: Error (__e) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"+\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Error (__e) => :: peg :: RuleResult :: Error (__e) , :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , }
+                                                    }
+                                                    ::peg::RuleResult::Error(__e) => {
+                                                        ::peg::RuleResult::Error(__e)
                                                     }
                                                     ::peg::RuleResult::Failed => {
                                                         ::peg::RuleResult::Failed
                                                     }
-                                                    ::peg::RuleResult::Error(..) => panic!()
                                                 }
                                             };
                                             match __choice_res {
                                                 ::peg::RuleResult::Matched(__pos, __value) => {
                                                     ::peg::RuleResult::Matched(__pos, __value)
+                                                }
+                                                ::peg::RuleResult::Error(__e) => {
+                                                    ::peg::RuleResult::Error(__e)
                                                 }
                                                 ::peg::RuleResult::Failed => __parse_prefixed(
                                                     __input,
@@ -2565,19 +2942,14 @@ pub mod peg {
                                                     __err_state,
                                                     __pos,
                                                 ),
-                                                ::peg::RuleResult::Error(..) => panic!()
                                             }
                                         }
-                                        ::peg::RuleResult::Error(..) => panic!()
                                     }
                                 }
-                                ::peg::RuleResult::Error(..) => panic!()
                             }
                         }
-                        ::peg::RuleResult::Error(..) => panic!()
                     }
                 }
-                ::peg::RuleResult::Error(..) => panic!()
             }
         }
     }
@@ -2602,27 +2974,34 @@ pub mod peg {
                                         (|| BoundedRepeat::Exact(n))(),
                                     )
                                 }
+                                ::peg::RuleResult::Error(__e) => {
+                                    __err_state.mark_error(__e);
+                                    ::peg::RuleResult::Error(__e)
+                                }
                                 ::peg::RuleResult::Failed => {
                                     __err_state.mark_failure(__pos, "\">\"");
                                     ::peg::RuleResult::Failed
                                 }
-                                ::peg::RuleResult::Error(..) => panic!()
                             }
                         }
+                        ::peg::RuleResult::Error(__e) => ::peg::RuleResult::Error(__e),
                         ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
-                        ::peg::RuleResult::Error(..) => panic!()
                     }
+                }
+                ::peg::RuleResult::Error(__e) => {
+                    __err_state.mark_error(__e);
+                    ::peg::RuleResult::Error(__e)
                 }
                 ::peg::RuleResult::Failed => {
                     __err_state.mark_failure(__pos, "\"<\"");
                     ::peg::RuleResult::Failed
                 }
-                ::peg::RuleResult::Error(..) => panic!()
             };
             match __choice_res {
                 ::peg::RuleResult::Matched(__pos, __value) => {
                     ::peg::RuleResult::Matched(__pos, __value)
                 }
+                ::peg::RuleResult::Error(__e) => ::peg::RuleResult::Error(__e),
                 ::peg::RuleResult::Failed => {
                     let __choice_res = match ::peg::ParseLiteral::parse_string_literal(
                         __input, __pos, "<",
@@ -2636,7 +3015,7 @@ pub mod peg {
                                     ::peg::RuleResult::Failed => {
                                         ::peg::RuleResult::Matched(__pos, None)
                                     }
-                                    ::peg::RuleResult::Error(..) => panic!()
+                                    ::peg::RuleResult::Error(__e) => ::peg::RuleResult::Error(__e),
                                 };
                             match __seq_res {
                                 ::peg::RuleResult::Matched(__pos, min) => {
@@ -2659,7 +3038,9 @@ pub mod peg {
                                                 ::peg::RuleResult::Failed => {
                                                     ::peg::RuleResult::Matched(__pos, None)
                                                 }
-                                                ::peg::RuleResult::Error(..) => panic!()
+                                                ::peg::RuleResult::Error(__e) => {
+                                                    ::peg::RuleResult::Error(__e)
+                                                }
                                             };
                                             match __seq_res {
                                                 ::peg::RuleResult::Matched(__pos, max) => {
@@ -2673,48 +3054,58 @@ pub mod peg {
                                                             __pos,
                                                             (|| BoundedRepeat::Both(min, max))(),
                                                         ),
+                                                        ::peg::RuleResult::Error(__e) => {
+                                                            __err_state.mark_error(__e);
+                                                            ::peg::RuleResult::Error(__e)
+                                                        }
                                                         ::peg::RuleResult::Failed => {
                                                             __err_state
                                                                 .mark_failure(__pos, "\">\"");
                                                             ::peg::RuleResult::Failed
                                                         }
-                                                        ::peg::RuleResult::Error(..) => panic!()
                                                     }
+                                                }
+                                                ::peg::RuleResult::Error(__e) => {
+                                                    ::peg::RuleResult::Error(__e)
                                                 }
                                                 ::peg::RuleResult::Failed => {
                                                     ::peg::RuleResult::Failed
                                                 }
-                                                ::peg::RuleResult::Error(..) => panic!()
                                             }
+                                        }
+                                        ::peg::RuleResult::Error(__e) => {
+                                            __err_state.mark_error(__e);
+                                            ::peg::RuleResult::Error(__e)
                                         }
                                         ::peg::RuleResult::Failed => {
                                             __err_state.mark_failure(__pos, "\",\"");
                                             ::peg::RuleResult::Failed
                                         }
-                                        ::peg::RuleResult::Error(..) => panic!()
                                     }
                                 }
+                                ::peg::RuleResult::Error(__e) => ::peg::RuleResult::Error(__e),
                                 ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
-                                ::peg::RuleResult::Error(..) => panic!()
                             }
+                        }
+                        ::peg::RuleResult::Error(__e) => {
+                            __err_state.mark_error(__e);
+                            ::peg::RuleResult::Error(__e)
                         }
                         ::peg::RuleResult::Failed => {
                             __err_state.mark_failure(__pos, "\"<\"");
                             ::peg::RuleResult::Failed
                         }
-                        ::peg::RuleResult::Error(..) => panic!()
                     };
                     match __choice_res {
                         ::peg::RuleResult::Matched(__pos, __value) => {
                             ::peg::RuleResult::Matched(__pos, __value)
                         }
+                        ::peg::RuleResult::Error(__e) => ::peg::RuleResult::Error(__e),
                         ::peg::RuleResult::Failed => {
                             ::peg::RuleResult::Matched(__pos, (|| BoundedRepeat::None)())
                         }
-                        ::peg::RuleResult::Error(..) => panic!()
                     }
                 }
-                ::peg::RuleResult::Error(..) => panic!()
             }
         }
     }
@@ -2730,23 +3121,23 @@ pub mod peg {
             match {
                 let __choice_res = match __parse_INTEGER(__input, __state, __err_state, __pos) {
                     ::peg::RuleResult::Matched(pos, _) => ::peg::RuleResult::Matched(pos, ()),
+                    ::peg::RuleResult::Error(e) => ::peg::RuleResult::Error(e),
                     ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
-                    ::peg::RuleResult::Error(..) => panic!()
                 };
                 match __choice_res {
                     ::peg::RuleResult::Matched(__pos, __value) => {
                         ::peg::RuleResult::Matched(__pos, __value)
                     }
+                    ::peg::RuleResult::Error(__e) => ::peg::RuleResult::Error(__e),
                     ::peg::RuleResult::Failed => {
                         match __parse_BRACE_GROUP(__input, __state, __err_state, __pos) {
                             ::peg::RuleResult::Matched(pos, _) => {
                                 ::peg::RuleResult::Matched(pos, ())
                             }
+                            ::peg::RuleResult::Error(e) => ::peg::RuleResult::Error(e),
                             ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
-                            ::peg::RuleResult::Error(..) => panic!()
                         }
                     }
-                    ::peg::RuleResult::Error(..) => panic!()
                 }
             } {
                 ::peg::RuleResult::Matched(__newpos, _) => ::peg::RuleResult::Matched(
@@ -2754,7 +3145,7 @@ pub mod peg {
                     ::peg::ParseSlice::parse_slice(__input, str_start, __newpos),
                 ),
                 ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
-                ::peg::RuleResult::Error(..) => panic!()
+                ::peg::RuleResult::Error(__e) => ::peg::RuleResult::Error(__e),
             }
         }
     }
@@ -2781,25 +3172,29 @@ pub mod peg {
                                             (|| MatchStrExpr(Box::new(expression)).at(sp))(),
                                         )
                                     }
+                                    ::peg::RuleResult::Error(__e) => ::peg::RuleResult::Error(__e),
                                     ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
-                                    ::peg::RuleResult::Error(..) => panic!()
                                 }
+                            }
+                            ::peg::RuleResult::Error(__e) => {
+                                __err_state.mark_error(__e);
+                                ::peg::RuleResult::Error(__e)
                             }
                             ::peg::RuleResult::Failed => {
                                 __err_state.mark_failure(__pos, "\"$\"");
                                 ::peg::RuleResult::Failed
                             }
-                            ::peg::RuleResult::Error(..) => panic!()
                         }
                     }
+                    ::peg::RuleResult::Error(__e) => ::peg::RuleResult::Error(__e),
                     ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
-                    ::peg::RuleResult::Error(..) => panic!()
                 }
             };
             match __choice_res {
                 ::peg::RuleResult::Matched(__pos, __value) => {
                     ::peg::RuleResult::Matched(__pos, __value)
                 }
+                ::peg::RuleResult::Error(__e) => ::peg::RuleResult::Error(__e),
                 ::peg::RuleResult::Failed => {
                     let __choice_res = {
                         let __seq_res = __parse_sp(__input, __state, __err_state, __pos);
@@ -2818,25 +3213,31 @@ pub mod peg {
                                                     ),
                                                 )
                                             }
+                                            ::peg::RuleResult::Error(__e) => {
+                                                ::peg::RuleResult::Error(__e)
+                                            }
                                             ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
-                                            ::peg::RuleResult::Error(..) => panic!()
                                         }
+                                    }
+                                    ::peg::RuleResult::Error(__e) => {
+                                        __err_state.mark_error(__e);
+                                        ::peg::RuleResult::Error(__e)
                                     }
                                     ::peg::RuleResult::Failed => {
                                         __err_state.mark_failure(__pos, "\"&\"");
                                         ::peg::RuleResult::Failed
                                     }
-                                    ::peg::RuleResult::Error(..) => panic!()
                                 }
                             }
+                            ::peg::RuleResult::Error(__e) => ::peg::RuleResult::Error(__e),
                             ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
-                            ::peg::RuleResult::Error(..) => panic!()
                         }
                     };
                     match __choice_res {
                         ::peg::RuleResult::Matched(__pos, __value) => {
                             ::peg::RuleResult::Matched(__pos, __value)
                         }
+                        ::peg::RuleResult::Error(__e) => ::peg::RuleResult::Error(__e),
                         ::peg::RuleResult::Failed => {
                             let __choice_res = {
                                 let __seq_res = __parse_sp(__input, __state, __err_state, __pos);
@@ -2864,37 +3265,40 @@ pub mod peg {
                                                         })(
                                                         ),
                                                     ),
+                                                    ::peg::RuleResult::Error(__e) => {
+                                                        ::peg::RuleResult::Error(__e)
+                                                    }
                                                     ::peg::RuleResult::Failed => {
                                                         ::peg::RuleResult::Failed
                                                     }
-                                                    ::peg::RuleResult::Error(..) => panic!()
                                                 }
+                                            }
+                                            ::peg::RuleResult::Error(__e) => {
+                                                __err_state.mark_error(__e);
+                                                ::peg::RuleResult::Error(__e)
                                             }
                                             ::peg::RuleResult::Failed => {
                                                 __err_state.mark_failure(__pos, "\"!\"");
                                                 ::peg::RuleResult::Failed
                                             }
-                                            ::peg::RuleResult::Error(..) => panic!()
                                         }
                                     }
+                                    ::peg::RuleResult::Error(__e) => ::peg::RuleResult::Error(__e),
                                     ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
-                                    ::peg::RuleResult::Error(..) => panic!()
                                 }
                             };
                             match __choice_res {
                                 ::peg::RuleResult::Matched(__pos, __value) => {
                                     ::peg::RuleResult::Matched(__pos, __value)
                                 }
+                                ::peg::RuleResult::Error(__e) => ::peg::RuleResult::Error(__e),
                                 ::peg::RuleResult::Failed => {
                                     __parse_primary(__input, __state, __err_state, __pos)
                                 }
-                                ::peg::RuleResult::Error(..) => panic!()
                             }
                         }
-                        ::peg::RuleResult::Error(..) => panic!()
                     }
                 }
-                ::peg::RuleResult::Error(..) => panic!()
             }
         }
     }
@@ -2928,20 +3332,24 @@ pub mod peg {
                                             ::peg::RuleResult::Matched(__pos, __val) => {
                                                 let __seq_res = {
                                                     let mut __repeat_pos = __pos;
+                                                    let mut __maybe_err = None;
                                                     let mut __repeat_value = vec![];
                                                     loop {
                                                         let __pos = __repeat_pos;
                                                         let __pos = if __repeat_value.is_empty() {
                                                             __pos
                                                         } else {
-                                                            let __sep_res = match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "--") { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , __val) => { :: peg :: RuleResult :: Matched (__pos , __val) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"--\"") ; :: peg :: RuleResult :: Failed } } ;
+                                                            let __sep_res = match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "--") { :: peg :: RuleResult :: Matched (__pos , __val) => { :: peg :: RuleResult :: Matched (__pos , __val) } :: peg :: RuleResult :: Error (__e) => { __err_state . mark_error (__e) ; :: peg :: RuleResult :: Error (__e) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"--\"") ; :: peg :: RuleResult :: Failed } } ;
                                                             match __sep_res {
                                                                 ::peg::RuleResult::Matched(
                                                                     __newpos,
                                                                     _,
                                                                 ) => __newpos,
                                                                 ::peg::RuleResult::Failed => break,
-                                                                ::peg::RuleResult::Error(..) => panic!()
+                                                                ::peg::RuleResult::Error(__e) => {
+                                                                    __maybe_err = Some(__e);
+                                                                    break;
+                                                                }
                                                             }
                                                         };
                                                         let __step_res = __parse_precedence_level(
@@ -2961,7 +3369,10 @@ pub mod peg {
                                                             ::peg::RuleResult::Failed => {
                                                                 break;
                                                             }
-                                                            ::peg::RuleResult::Error(..) => panic!()
+                                                            ::peg::RuleResult::Error(__e) => {
+                                                                __maybe_err = Some(__e);
+                                                                break;
+                                                            }
                                                         }
                                                     }
                                                     ::peg::RuleResult::Matched(
@@ -2969,155 +3380,96 @@ pub mod peg {
                                                         __repeat_value,
                                                     )
                                                 };
-                                                match __seq_res { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , levels) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "}") { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , __val) => { :: peg :: RuleResult :: Matched (__pos , (|| { PrecedenceExpr { levels : levels } . at (sp) }) ()) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"}\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , }
+                                                match __seq_res { :: peg :: RuleResult :: Matched (__pos , levels) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "}") { :: peg :: RuleResult :: Matched (__pos , __val) => { :: peg :: RuleResult :: Matched (__pos , (|| { PrecedenceExpr { levels : levels } . at (sp) }) ()) } :: peg :: RuleResult :: Error (__e) => { __err_state . mark_error (__e) ; :: peg :: RuleResult :: Error (__e) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"}\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Error (__e) => :: peg :: RuleResult :: Error (__e) , :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , }
+                                            }
+                                            ::peg::RuleResult::Error(__e) => {
+                                                __err_state.mark_error(__e);
+                                                ::peg::RuleResult::Error(__e)
                                             }
                                             ::peg::RuleResult::Failed => {
                                                 __err_state.mark_failure(__pos, "\"{\"");
                                                 ::peg::RuleResult::Failed
                                             }
-                                            ::peg::RuleResult::Error(..) => panic!()
                                         }
+                                    }
+                                    ::peg::RuleResult::Error(__e) => {
+                                        __err_state.mark_error(__e);
+                                        ::peg::RuleResult::Error(__e)
                                     }
                                     ::peg::RuleResult::Failed => {
                                         __err_state.mark_failure(__pos, "\"!\"");
                                         ::peg::RuleResult::Failed
                                     }
-                                    ::peg::RuleResult::Error(..) => panic!()
                                 }
+                            }
+                            ::peg::RuleResult::Error(__e) => {
+                                __err_state.mark_error(__e);
+                                ::peg::RuleResult::Error(__e)
                             }
                             ::peg::RuleResult::Failed => {
                                 __err_state.mark_failure(__pos, "\"precedence\"");
                                 ::peg::RuleResult::Failed
                             }
-                            ::peg::RuleResult::Error(..) => panic!()
                         }
                     }
+                    ::peg::RuleResult::Error(__e) => ::peg::RuleResult::Error(__e),
                     ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
-                    ::peg::RuleResult::Error(..) => panic!()
                 }
             };
             match __choice_res {
                 ::peg::RuleResult::Matched(__pos, __value) => {
                     ::peg::RuleResult::Matched(__pos, __value)
                 }
+                ::peg::RuleResult::Error(__e) => ::peg::RuleResult::Error(__e),
                 ::peg::RuleResult::Failed => {
                     let __choice_res = {
                         let __seq_res = __parse_sp(__input, __state, __err_state, __pos);
-                        match __seq_res { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , sp) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "position") { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , __val) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "!") { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , __val) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "(") { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , __val) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , ")") { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , __val) => { :: peg :: RuleResult :: Matched (__pos , (|| { PositionExpr . at (sp) }) ()) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\")\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"(\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"!\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"position\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , }
+                        match __seq_res { :: peg :: RuleResult :: Matched (__pos , sp) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "position") { :: peg :: RuleResult :: Matched (__pos , __val) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "!") { :: peg :: RuleResult :: Matched (__pos , __val) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "(") { :: peg :: RuleResult :: Matched (__pos , __val) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , ")") { :: peg :: RuleResult :: Matched (__pos , __val) => { :: peg :: RuleResult :: Matched (__pos , (|| { PositionExpr . at (sp) }) ()) } :: peg :: RuleResult :: Error (__e) => { __err_state . mark_error (__e) ; :: peg :: RuleResult :: Error (__e) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\")\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Error (__e) => { __err_state . mark_error (__e) ; :: peg :: RuleResult :: Error (__e) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"(\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Error (__e) => { __err_state . mark_error (__e) ; :: peg :: RuleResult :: Error (__e) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"!\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Error (__e) => { __err_state . mark_error (__e) ; :: peg :: RuleResult :: Error (__e) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"position\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Error (__e) => :: peg :: RuleResult :: Error (__e) , :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , }
                     };
                     match __choice_res {
                         ::peg::RuleResult::Matched(__pos, __value) => {
                             ::peg::RuleResult::Matched(__pos, __value)
                         }
+                        ::peg::RuleResult::Error(__e) => ::peg::RuleResult::Error(__e),
                         ::peg::RuleResult::Failed => {
                             let __choice_res = {
                                 let __seq_res = __parse_sp(__input, __state, __err_state, __pos);
-                                match __seq_res { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , sp) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "quiet") { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , __val) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "!") { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , __val) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "{") { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , __val) => { { let __seq_res = __parse_expression (__input , __state , __err_state , __pos) ; match __seq_res { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , e) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "}") { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , __val) => { :: peg :: RuleResult :: Matched (__pos , (|| { QuietExpr (Box :: new (e)) . at (sp) }) ()) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"}\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"{\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"!\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"quiet\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , }
+                                match __seq_res { :: peg :: RuleResult :: Matched (__pos , sp) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "quiet") { :: peg :: RuleResult :: Matched (__pos , __val) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "!") { :: peg :: RuleResult :: Matched (__pos , __val) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "{") { :: peg :: RuleResult :: Matched (__pos , __val) => { { let __seq_res = __parse_expression (__input , __state , __err_state , __pos) ; match __seq_res { :: peg :: RuleResult :: Matched (__pos , e) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "}") { :: peg :: RuleResult :: Matched (__pos , __val) => { :: peg :: RuleResult :: Matched (__pos , (|| { QuietExpr (Box :: new (e)) . at (sp) }) ()) } :: peg :: RuleResult :: Error (__e) => { __err_state . mark_error (__e) ; :: peg :: RuleResult :: Error (__e) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"}\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Error (__e) => :: peg :: RuleResult :: Error (__e) , :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } } :: peg :: RuleResult :: Error (__e) => { __err_state . mark_error (__e) ; :: peg :: RuleResult :: Error (__e) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"{\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Error (__e) => { __err_state . mark_error (__e) ; :: peg :: RuleResult :: Error (__e) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"!\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Error (__e) => { __err_state . mark_error (__e) ; :: peg :: RuleResult :: Error (__e) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"quiet\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Error (__e) => :: peg :: RuleResult :: Error (__e) , :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , }
                             };
                             match __choice_res {
                                 ::peg::RuleResult::Matched(__pos, __value) => {
                                     ::peg::RuleResult::Matched(__pos, __value)
                                 }
+                                ::peg::RuleResult::Error(__e) => ::peg::RuleResult::Error(__e),
                                 ::peg::RuleResult::Failed => {
                                     let __choice_res = {
                                         let __seq_res =
                                             __parse_sp(__input, __state, __err_state, __pos);
-                                        match __seq_res { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , sp) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "expected") { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , __val) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "!") { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , __val) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "(") { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , __val) => { { let __seq_res = __parse_LITERAL (__input , __state , __err_state , __pos) ; match __seq_res { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , s) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , ")") { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , __val) => { :: peg :: RuleResult :: Matched (__pos , (|| { FailExpr (s) . at (sp) }) ()) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\")\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"(\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"!\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"expected\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , }
+                                        match __seq_res { :: peg :: RuleResult :: Matched (__pos , sp) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "expected") { :: peg :: RuleResult :: Matched (__pos , __val) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "!") { :: peg :: RuleResult :: Matched (__pos , __val) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "(") { :: peg :: RuleResult :: Matched (__pos , __val) => { { let __seq_res = __parse_LITERAL (__input , __state , __err_state , __pos) ; match __seq_res { :: peg :: RuleResult :: Matched (__pos , s) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , ")") { :: peg :: RuleResult :: Matched (__pos , __val) => { :: peg :: RuleResult :: Matched (__pos , (|| { FailExpr (s) . at (sp) }) ()) } :: peg :: RuleResult :: Error (__e) => { __err_state . mark_error (__e) ; :: peg :: RuleResult :: Error (__e) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\")\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Error (__e) => :: peg :: RuleResult :: Error (__e) , :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } } :: peg :: RuleResult :: Error (__e) => { __err_state . mark_error (__e) ; :: peg :: RuleResult :: Error (__e) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"(\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Error (__e) => { __err_state . mark_error (__e) ; :: peg :: RuleResult :: Error (__e) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"!\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Error (__e) => { __err_state . mark_error (__e) ; :: peg :: RuleResult :: Error (__e) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"expected\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Error (__e) => :: peg :: RuleResult :: Error (__e) , :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , }
                                     };
                                     match __choice_res {
                                         ::peg::RuleResult::Matched(__pos, __value) => {
                                             ::peg::RuleResult::Matched(__pos, __value)
                                         }
+                                        ::peg::RuleResult::Error(__e) => {
+                                            ::peg::RuleResult::Error(__e)
+                                        }
                                         ::peg::RuleResult::Failed => {
                                             let __choice_res = {
-                                                let __seq_res = {
-                                                    __err_state.suppress_fail += 1;
-                                                    let __assert_res = {
-                                                        let __choice_res = match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "_") { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , __val) => { :: peg :: RuleResult :: Matched (__pos , __val) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"_\"") ; :: peg :: RuleResult :: Failed } } ;
-                                                        match __choice_res {
-                                                            ::peg::RuleResult::Matched(
-                                                                __pos,
-                                                                __value,
-                                                            ) => ::peg::RuleResult::Matched(
-                                                                __pos, __value,
-                                                            ),
-                                                            ::peg::RuleResult::Failed => {
-                                                                let __choice_res = match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "__") { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , __val) => { :: peg :: RuleResult :: Matched (__pos , __val) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"__\"") ; :: peg :: RuleResult :: Failed } } ;
-                                                                match __choice_res { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , __value) => :: peg :: RuleResult :: Matched (__pos , __value) , :: peg :: RuleResult :: Failed => match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "___") { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , __val) => { :: peg :: RuleResult :: Matched (__pos , __val) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"___\"") ; :: peg :: RuleResult :: Failed } } }
-                                                            }
-                                                            ::peg::RuleResult::Error(..) => panic!()
-                                                        }
-                                                    };
-                                                    __err_state.suppress_fail -= 1;
-                                                    match __assert_res {
-                                                        ::peg::RuleResult::Matched(_, __value) => {
-                                                            ::peg::RuleResult::Matched(
-                                                                __pos, __value,
-                                                            )
-                                                        }
-                                                        ::peg::RuleResult::Failed => {
-                                                            ::peg::RuleResult::Failed
-                                                        }
-                                                        ::peg::RuleResult::Error(..) => panic!()
-                                                    }
-                                                };
-                                                match __seq_res {
-                                                    ::peg::RuleResult::Matched(__pos, _) => {
-                                                        let __seq_res = __parse_sp(
-                                                            __input,
-                                                            __state,
-                                                            __err_state,
-                                                            __pos,
-                                                        );
-                                                        match __seq_res {
-                                                            ::peg::RuleResult::Matched(
-                                                                __pos,
-                                                                sp,
-                                                            ) => {
-                                                                let __seq_res = __parse_IDENT(
-                                                                    __input,
-                                                                    __state,
-                                                                    __err_state,
-                                                                    __pos,
-                                                                );
-                                                                match __seq_res {
-                                                                    ::peg::RuleResult::Matched(
-                                                                        __pos,
-                                                                        name,
-                                                                    ) => {
-                                                                        ::peg::RuleResult::Matched(
-                                                                            __pos,
-                                                                            (|| {
-                                                                                RuleExpr(
-                                                                                    name,
-                                                                                    Vec::new(),
-                                                                                )
-                                                                                .at(sp)
-                                                                            })(
-                                                                            ),
-                                                                        )
-                                                                    }
-                                                                    ::peg::RuleResult::Failed => {
-                                                                        ::peg::RuleResult::Failed
-                                                                    }
-                                                                    ::peg::RuleResult::Error(..) => panic!()
-                                                                }
-                                                            }
-                                                            ::peg::RuleResult::Failed => {
-                                                                ::peg::RuleResult::Failed
-                                                            }
-                                                            ::peg::RuleResult::Error(..) => panic!()
-                                                        }
-                                                    }
-                                                    ::peg::RuleResult::Failed => {
-                                                        ::peg::RuleResult::Failed
-                                                    }
-                                                    ::peg::RuleResult::Error(..) => panic!()
-                                                }
+                                                let __seq_res = __parse_sp(
+                                                    __input,
+                                                    __state,
+                                                    __err_state,
+                                                    __pos,
+                                                );
+                                                match __seq_res { :: peg :: RuleResult :: Matched (__pos , sp) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "error") { :: peg :: RuleResult :: Matched (__pos , __val) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "!") { :: peg :: RuleResult :: Matched (__pos , __val) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "{") { :: peg :: RuleResult :: Matched (__pos , __val) => { { let __seq_res = __parse_LITERAL (__input , __state , __err_state , __pos) ; match __seq_res { :: peg :: RuleResult :: Matched (__pos , s) => { { let __seq_res = __parse_sequence (__input , __state , __err_state , __pos) ; match __seq_res { :: peg :: RuleResult :: Matched (__pos , seq) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "}") { :: peg :: RuleResult :: Matched (__pos , __val) => { :: peg :: RuleResult :: Matched (__pos , (|| { ErrorIfExpr (Box :: new (ActionExpr (vec ! [] , None) . at (sp)) , s , Box :: new (seq)) . at (sp) }) ()) } :: peg :: RuleResult :: Error (__e) => { __err_state . mark_error (__e) ; :: peg :: RuleResult :: Error (__e) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"}\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Error (__e) => :: peg :: RuleResult :: Error (__e) , :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } } :: peg :: RuleResult :: Error (__e) => :: peg :: RuleResult :: Error (__e) , :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } } :: peg :: RuleResult :: Error (__e) => { __err_state . mark_error (__e) ; :: peg :: RuleResult :: Error (__e) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"{\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Error (__e) => { __err_state . mark_error (__e) ; :: peg :: RuleResult :: Error (__e) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"!\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Error (__e) => { __err_state . mark_error (__e) ; :: peg :: RuleResult :: Error (__e) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"error\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Error (__e) => :: peg :: RuleResult :: Error (__e) , :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , }
                                             };
                                             match __choice_res {
                                                 ::peg::RuleResult::Matched(__pos, __value) => {
                                                     ::peg::RuleResult::Matched(__pos, __value)
+                                                }
+                                                ::peg::RuleResult::Error(__e) => {
+                                                    ::peg::RuleResult::Error(__e)
                                                 }
                                                 ::peg::RuleResult::Failed => {
                                                     let __choice_res = {
@@ -3127,24 +3479,7 @@ pub mod peg {
                                                             __err_state,
                                                             __pos,
                                                         );
-                                                        match __seq_res {
-                                                            ::peg::RuleResult::Matched(
-                                                                __pos,
-                                                                sp,
-                                                            ) => {
-                                                                let __seq_res = __parse_IDENT(
-                                                                    __input,
-                                                                    __state,
-                                                                    __err_state,
-                                                                    __pos,
-                                                                );
-                                                                match __seq_res { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , name) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "(") { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , __val) => { { let __seq_res = { let mut __repeat_pos = __pos ; let mut __repeat_value = vec ! () ; loop { let __pos = __repeat_pos ; let __pos = if __repeat_value . is_empty () { __pos } else { let __sep_res = match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , ",") { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , __val) => { :: peg :: RuleResult :: Matched (__pos , __val) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\",\"") ; :: peg :: RuleResult :: Failed } } ; match __sep_res { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__newpos , _) => { __newpos } , :: peg :: RuleResult :: Failed => break , } } ; let __step_res = __parse_rule_arg (__input , __state , __err_state , __pos) ; match __step_res { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__newpos , __value) => { __repeat_pos = __newpos ; __repeat_value . push (__value) ; } , :: peg :: RuleResult :: Failed => { break ; } } } :: peg :: RuleResult :: Matched (__repeat_pos , __repeat_value) } ; match __seq_res { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , args) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , ")") { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , __val) => { :: peg :: RuleResult :: Matched (__pos , (|| { RuleExpr (name , args) . at (sp) }) ()) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\")\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"(\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , }
-                                                            }
-                                                            ::peg::RuleResult::Failed => {
-                                                                ::peg::RuleResult::Failed
-                                                            }
-                                                            ::peg::RuleResult::Error(..) => panic!()
-                                                        }
+                                                        match __seq_res { :: peg :: RuleResult :: Matched (__pos , sp) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "error_if") { :: peg :: RuleResult :: Matched (__pos , __val) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "!") { :: peg :: RuleResult :: Matched (__pos , __val) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "{") { :: peg :: RuleResult :: Matched (__pos , __val) => { { let __seq_res = __parse_sequence (__input , __state , __err_state , __pos) ; match __seq_res { :: peg :: RuleResult :: Matched (__pos , seq1) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "|") { :: peg :: RuleResult :: Matched (__pos , __val) => { { let __seq_res = __parse_LITERAL (__input , __state , __err_state , __pos) ; match __seq_res { :: peg :: RuleResult :: Matched (__pos , s) => { { let __seq_res = __parse_sequence (__input , __state , __err_state , __pos) ; match __seq_res { :: peg :: RuleResult :: Matched (__pos , seq2) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "}") { :: peg :: RuleResult :: Matched (__pos , __val) => { :: peg :: RuleResult :: Matched (__pos , (|| { ErrorIfExpr (Box :: new (seq1) , s , Box :: new (seq2)) . at (sp) }) ()) } :: peg :: RuleResult :: Error (__e) => { __err_state . mark_error (__e) ; :: peg :: RuleResult :: Error (__e) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"}\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Error (__e) => :: peg :: RuleResult :: Error (__e) , :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } } :: peg :: RuleResult :: Error (__e) => :: peg :: RuleResult :: Error (__e) , :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } } :: peg :: RuleResult :: Error (__e) => { __err_state . mark_error (__e) ; :: peg :: RuleResult :: Error (__e) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"|\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Error (__e) => :: peg :: RuleResult :: Error (__e) , :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } } :: peg :: RuleResult :: Error (__e) => { __err_state . mark_error (__e) ; :: peg :: RuleResult :: Error (__e) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"{\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Error (__e) => { __err_state . mark_error (__e) ; :: peg :: RuleResult :: Error (__e) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"!\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Error (__e) => { __err_state . mark_error (__e) ; :: peg :: RuleResult :: Error (__e) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"error_if\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Error (__e) => :: peg :: RuleResult :: Error (__e) , :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , }
                                                     };
                                                     match __choice_res {
                                                         ::peg::RuleResult::Matched(
@@ -3153,6 +3488,9 @@ pub mod peg {
                                                         ) => ::peg::RuleResult::Matched(
                                                             __pos, __value,
                                                         ),
+                                                        ::peg::RuleResult::Error(__e) => {
+                                                            ::peg::RuleResult::Error(__e)
+                                                        }
                                                         ::peg::RuleResult::Failed => {
                                                             let __choice_res = {
                                                                 let __seq_res = __parse_sp(
@@ -3161,25 +3499,7 @@ pub mod peg {
                                                                     __err_state,
                                                                     __pos,
                                                                 );
-                                                                match __seq_res {
-                                                                    ::peg::RuleResult::Matched(
-                                                                        __pos,
-                                                                        sp,
-                                                                    ) => {
-                                                                        let __seq_res =
-                                                                            __parse_LITERAL(
-                                                                                __input,
-                                                                                __state,
-                                                                                __err_state,
-                                                                                __pos,
-                                                                            );
-                                                                        match __seq_res { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , l) => { :: peg :: RuleResult :: Matched (__pos , (|| { LiteralExpr (l) . at (sp) }) ()) } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , }
-                                                                    }
-                                                                    ::peg::RuleResult::Failed => {
-                                                                        ::peg::RuleResult::Failed
-                                                                    }
-                                                                    ::peg::RuleResult::Error(..) => panic!()
-                                                                }
+                                                                match __seq_res { :: peg :: RuleResult :: Matched (__pos , sp) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "error_unless") { :: peg :: RuleResult :: Matched (__pos , __val) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "!") { :: peg :: RuleResult :: Matched (__pos , __val) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "{") { :: peg :: RuleResult :: Matched (__pos , __val) => { { let __seq_res = __parse_sequence (__input , __state , __err_state , __pos) ; match __seq_res { :: peg :: RuleResult :: Matched (__pos , seq1) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "|") { :: peg :: RuleResult :: Matched (__pos , __val) => { { let __seq_res = __parse_LITERAL (__input , __state , __err_state , __pos) ; match __seq_res { :: peg :: RuleResult :: Matched (__pos , s) => { { let __seq_res = __parse_sequence (__input , __state , __err_state , __pos) ; match __seq_res { :: peg :: RuleResult :: Matched (__pos , seq2) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "}") { :: peg :: RuleResult :: Matched (__pos , __val) => { :: peg :: RuleResult :: Matched (__pos , (|| { ErrorUnlessExpr (Box :: new (seq1) , s , Box :: new (seq2)) . at (sp) }) ()) } :: peg :: RuleResult :: Error (__e) => { __err_state . mark_error (__e) ; :: peg :: RuleResult :: Error (__e) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"}\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Error (__e) => :: peg :: RuleResult :: Error (__e) , :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } } :: peg :: RuleResult :: Error (__e) => :: peg :: RuleResult :: Error (__e) , :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } } :: peg :: RuleResult :: Error (__e) => { __err_state . mark_error (__e) ; :: peg :: RuleResult :: Error (__e) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"|\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Error (__e) => :: peg :: RuleResult :: Error (__e) , :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } } :: peg :: RuleResult :: Error (__e) => { __err_state . mark_error (__e) ; :: peg :: RuleResult :: Error (__e) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"{\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Error (__e) => { __err_state . mark_error (__e) ; :: peg :: RuleResult :: Error (__e) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"!\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Error (__e) => { __err_state . mark_error (__e) ; :: peg :: RuleResult :: Error (__e) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"error_unless\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Error (__e) => :: peg :: RuleResult :: Error (__e) , :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , }
                                                             };
                                                             match __choice_res {
                                                                 ::peg::RuleResult::Matched(
@@ -3188,37 +3508,38 @@ pub mod peg {
                                                                 ) => ::peg::RuleResult::Matched(
                                                                     __pos, __value,
                                                                 ),
+                                                                ::peg::RuleResult::Error(__e) => {
+                                                                    ::peg::RuleResult::Error(__e)
+                                                                }
                                                                 ::peg::RuleResult::Failed => {
                                                                     let __choice_res = {
-                                                                        let __seq_res = __parse_sp(
-                                                                            __input,
-                                                                            __state,
-                                                                            __err_state,
-                                                                            __pos,
-                                                                        );
-                                                                        match __seq_res { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , sp) => { { let __seq_res = __parse_BRACKET_GROUP (__input , __state , __err_state , __pos) ; match __seq_res { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , p) => { :: peg :: RuleResult :: Matched (__pos , (|| { PatternExpr (p) . at (sp) }) ()) } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , }
+                                                                        let __seq_res = {
+                                                                            __err_state
+                                                                                .suppress_fail += 1;
+                                                                            let __assert_res = {
+                                                                                let __choice_res = match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "_") { :: peg :: RuleResult :: Matched (__pos , __val) => { :: peg :: RuleResult :: Matched (__pos , __val) } :: peg :: RuleResult :: Error (__e) => { __err_state . mark_error (__e) ; :: peg :: RuleResult :: Error (__e) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"_\"") ; :: peg :: RuleResult :: Failed } } ;
+                                                                                match __choice_res { :: peg :: RuleResult :: Matched (__pos , __value) => :: peg :: RuleResult :: Matched (__pos , __value) , :: peg :: RuleResult :: Error (__e) => :: peg :: RuleResult :: Error (__e) , :: peg :: RuleResult :: Failed => { let __choice_res = match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "__") { :: peg :: RuleResult :: Matched (__pos , __val) => { :: peg :: RuleResult :: Matched (__pos , __val) } :: peg :: RuleResult :: Error (__e) => { __err_state . mark_error (__e) ; :: peg :: RuleResult :: Error (__e) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"__\"") ; :: peg :: RuleResult :: Failed } } ; match __choice_res { :: peg :: RuleResult :: Matched (__pos , __value) => :: peg :: RuleResult :: Matched (__pos , __value) , :: peg :: RuleResult :: Error (__e) => :: peg :: RuleResult :: Error (__e) , :: peg :: RuleResult :: Failed => match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "___") { :: peg :: RuleResult :: Matched (__pos , __val) => { :: peg :: RuleResult :: Matched (__pos , __val) } :: peg :: RuleResult :: Error (__e) => { __err_state . mark_error (__e) ; :: peg :: RuleResult :: Error (__e) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"___\"") ; :: peg :: RuleResult :: Failed } } } } }
+                                                                            };
+                                                                            __err_state
+                                                                                .suppress_fail -= 1;
+                                                                            match __assert_res { :: peg :: RuleResult :: Matched (_ , __value) => :: peg :: RuleResult :: Matched (__pos , __value) , :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , :: peg :: RuleResult :: Error (..) => :: peg :: RuleResult :: Failed , }
+                                                                        };
+                                                                        match __seq_res { :: peg :: RuleResult :: Matched (__pos , _) => { { let __seq_res = __parse_sp (__input , __state , __err_state , __pos) ; match __seq_res { :: peg :: RuleResult :: Matched (__pos , sp) => { { let __seq_res = __parse_IDENT (__input , __state , __err_state , __pos) ; match __seq_res { :: peg :: RuleResult :: Matched (__pos , name) => { :: peg :: RuleResult :: Matched (__pos , (|| { RuleExpr (name , Vec :: new ()) . at (sp) }) ()) } :: peg :: RuleResult :: Error (__e) => :: peg :: RuleResult :: Error (__e) , :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } } :: peg :: RuleResult :: Error (__e) => :: peg :: RuleResult :: Error (__e) , :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } } :: peg :: RuleResult :: Error (__e) => :: peg :: RuleResult :: Error (__e) , :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , }
                                                                     };
-                                                                    match __choice_res { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , __value) => :: peg :: RuleResult :: Matched (__pos , __value) , :: peg :: RuleResult :: Failed => { let __choice_res = match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "(") { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , __val) => { { let __seq_res = __parse_sp (__input , __state , __err_state , __pos) ; match __seq_res { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , sp) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "@") { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , __val) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , ")") { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , __val) => { :: peg :: RuleResult :: Matched (__pos , (|| { MarkerExpr (true) . at (sp) }) ()) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\")\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"@\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"(\"") ; :: peg :: RuleResult :: Failed } } ; match __choice_res { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , __value) => :: peg :: RuleResult :: Matched (__pos , __value) , :: peg :: RuleResult :: Failed => { let __choice_res = { let __seq_res = __parse_sp (__input , __state , __err_state , __pos) ; match __seq_res { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , sp) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "@") { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , __val) => { :: peg :: RuleResult :: Matched (__pos , (|| { MarkerExpr (false) . at (sp) }) ()) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"@\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } ; match __choice_res { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , __value) => :: peg :: RuleResult :: Matched (__pos , __value) , :: peg :: RuleResult :: Failed => { let __choice_res = { let __seq_res = __parse_sp (__input , __state , __err_state , __pos) ; match __seq_res { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , sp) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "##") { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , __val) => { { let __seq_res = __parse_IDENT (__input , __state , __err_state , __pos) ; match __seq_res { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , method) => { { let __seq_res = __parse_PAREN_GROUP (__input , __state , __err_state , __pos) ; match __seq_res { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , args) => { :: peg :: RuleResult :: Matched (__pos , (|| { MethodExpr (method , args . stream ()) . at (sp) }) ()) } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"##\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } ; match __choice_res { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , __value) => :: peg :: RuleResult :: Matched (__pos , __value) , :: peg :: RuleResult :: Failed => match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "(") { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , __val) => { { let __seq_res = __parse_expression (__input , __state , __err_state , __pos) ; match __seq_res { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , expression) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , ")") { ::peg::RuleResult::Error(..) => panic!(), :: peg :: RuleResult :: Matched (__pos , __val) => { :: peg :: RuleResult :: Matched (__pos , (|| { expression }) ()) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\")\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"(\"") ; :: peg :: RuleResult :: Failed } } } } } } } } }
+                                                                    match __choice_res { :: peg :: RuleResult :: Matched (__pos , __value) => :: peg :: RuleResult :: Matched (__pos , __value) , :: peg :: RuleResult :: Error (__e) => :: peg :: RuleResult :: Error (__e) , :: peg :: RuleResult :: Failed => { let __choice_res = { let __seq_res = __parse_sp (__input , __state , __err_state , __pos) ; match __seq_res { :: peg :: RuleResult :: Matched (__pos , sp) => { { let __seq_res = __parse_IDENT (__input , __state , __err_state , __pos) ; match __seq_res { :: peg :: RuleResult :: Matched (__pos , name) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "(") { :: peg :: RuleResult :: Matched (__pos , __val) => { { let __seq_res = { let mut __repeat_pos = __pos ; let mut __maybe_err = None ; let mut __repeat_value = vec ! () ; loop { let __pos = __repeat_pos ; let __pos = if __repeat_value . is_empty () { __pos } else { let __sep_res = match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , ",") { :: peg :: RuleResult :: Matched (__pos , __val) => { :: peg :: RuleResult :: Matched (__pos , __val) } :: peg :: RuleResult :: Error (__e) => { __err_state . mark_error (__e) ; :: peg :: RuleResult :: Error (__e) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\",\"") ; :: peg :: RuleResult :: Failed } } ; match __sep_res { :: peg :: RuleResult :: Matched (__newpos , _) => { __newpos } , :: peg :: RuleResult :: Failed => break , :: peg :: RuleResult :: Error (__e) => { __maybe_err = Some (__e) ; break } } } ; let __step_res = __parse_rule_arg (__input , __state , __err_state , __pos) ; match __step_res { :: peg :: RuleResult :: Matched (__newpos , __value) => { __repeat_pos = __newpos ; __repeat_value . push (__value) ; } , :: peg :: RuleResult :: Failed => { break ; } :: peg :: RuleResult :: Error (__e) => { __maybe_err = Some (__e) ; break ; } } } :: peg :: RuleResult :: Matched (__repeat_pos , __repeat_value) } ; match __seq_res { :: peg :: RuleResult :: Matched (__pos , args) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , ")") { :: peg :: RuleResult :: Matched (__pos , __val) => { :: peg :: RuleResult :: Matched (__pos , (|| { RuleExpr (name , args) . at (sp) }) ()) } :: peg :: RuleResult :: Error (__e) => { __err_state . mark_error (__e) ; :: peg :: RuleResult :: Error (__e) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\")\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Error (__e) => :: peg :: RuleResult :: Error (__e) , :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } } :: peg :: RuleResult :: Error (__e) => { __err_state . mark_error (__e) ; :: peg :: RuleResult :: Error (__e) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"(\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Error (__e) => :: peg :: RuleResult :: Error (__e) , :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } } :: peg :: RuleResult :: Error (__e) => :: peg :: RuleResult :: Error (__e) , :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } ; match __choice_res { :: peg :: RuleResult :: Matched (__pos , __value) => :: peg :: RuleResult :: Matched (__pos , __value) , :: peg :: RuleResult :: Error (__e) => :: peg :: RuleResult :: Error (__e) , :: peg :: RuleResult :: Failed => { let __choice_res = { let __seq_res = __parse_sp (__input , __state , __err_state , __pos) ; match __seq_res { :: peg :: RuleResult :: Matched (__pos , sp) => { { let __seq_res = __parse_LITERAL (__input , __state , __err_state , __pos) ; match __seq_res { :: peg :: RuleResult :: Matched (__pos , l) => { :: peg :: RuleResult :: Matched (__pos , (|| { LiteralExpr (l) . at (sp) }) ()) } :: peg :: RuleResult :: Error (__e) => :: peg :: RuleResult :: Error (__e) , :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } } :: peg :: RuleResult :: Error (__e) => :: peg :: RuleResult :: Error (__e) , :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } ; match __choice_res { :: peg :: RuleResult :: Matched (__pos , __value) => :: peg :: RuleResult :: Matched (__pos , __value) , :: peg :: RuleResult :: Error (__e) => :: peg :: RuleResult :: Error (__e) , :: peg :: RuleResult :: Failed => { let __choice_res = { let __seq_res = __parse_sp (__input , __state , __err_state , __pos) ; match __seq_res { :: peg :: RuleResult :: Matched (__pos , sp) => { { let __seq_res = __parse_BRACKET_GROUP (__input , __state , __err_state , __pos) ; match __seq_res { :: peg :: RuleResult :: Matched (__pos , p) => { :: peg :: RuleResult :: Matched (__pos , (|| { PatternExpr (p) . at (sp) }) ()) } :: peg :: RuleResult :: Error (__e) => :: peg :: RuleResult :: Error (__e) , :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } } :: peg :: RuleResult :: Error (__e) => :: peg :: RuleResult :: Error (__e) , :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } ; match __choice_res { :: peg :: RuleResult :: Matched (__pos , __value) => :: peg :: RuleResult :: Matched (__pos , __value) , :: peg :: RuleResult :: Error (__e) => :: peg :: RuleResult :: Error (__e) , :: peg :: RuleResult :: Failed => { let __choice_res = match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "(") { :: peg :: RuleResult :: Matched (__pos , __val) => { { let __seq_res = __parse_sp (__input , __state , __err_state , __pos) ; match __seq_res { :: peg :: RuleResult :: Matched (__pos , sp) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "@") { :: peg :: RuleResult :: Matched (__pos , __val) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , ")") { :: peg :: RuleResult :: Matched (__pos , __val) => { :: peg :: RuleResult :: Matched (__pos , (|| { MarkerExpr (true) . at (sp) }) ()) } :: peg :: RuleResult :: Error (__e) => { __err_state . mark_error (__e) ; :: peg :: RuleResult :: Error (__e) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\")\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Error (__e) => { __err_state . mark_error (__e) ; :: peg :: RuleResult :: Error (__e) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"@\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Error (__e) => :: peg :: RuleResult :: Error (__e) , :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } } :: peg :: RuleResult :: Error (__e) => { __err_state . mark_error (__e) ; :: peg :: RuleResult :: Error (__e) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"(\"") ; :: peg :: RuleResult :: Failed } } ; match __choice_res { :: peg :: RuleResult :: Matched (__pos , __value) => :: peg :: RuleResult :: Matched (__pos , __value) , :: peg :: RuleResult :: Error (__e) => :: peg :: RuleResult :: Error (__e) , :: peg :: RuleResult :: Failed => { let __choice_res = { let __seq_res = __parse_sp (__input , __state , __err_state , __pos) ; match __seq_res { :: peg :: RuleResult :: Matched (__pos , sp) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "@") { :: peg :: RuleResult :: Matched (__pos , __val) => { :: peg :: RuleResult :: Matched (__pos , (|| { MarkerExpr (false) . at (sp) }) ()) } :: peg :: RuleResult :: Error (__e) => { __err_state . mark_error (__e) ; :: peg :: RuleResult :: Error (__e) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"@\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Error (__e) => :: peg :: RuleResult :: Error (__e) , :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } ; match __choice_res { :: peg :: RuleResult :: Matched (__pos , __value) => :: peg :: RuleResult :: Matched (__pos , __value) , :: peg :: RuleResult :: Error (__e) => :: peg :: RuleResult :: Error (__e) , :: peg :: RuleResult :: Failed => { let __choice_res = { let __seq_res = __parse_sp (__input , __state , __err_state , __pos) ; match __seq_res { :: peg :: RuleResult :: Matched (__pos , sp) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "##") { :: peg :: RuleResult :: Matched (__pos , __val) => { { let __seq_res = __parse_IDENT (__input , __state , __err_state , __pos) ; match __seq_res { :: peg :: RuleResult :: Matched (__pos , method) => { { let __seq_res = __parse_PAREN_GROUP (__input , __state , __err_state , __pos) ; match __seq_res { :: peg :: RuleResult :: Matched (__pos , args) => { :: peg :: RuleResult :: Matched (__pos , (|| { MethodExpr (method , args . stream ()) . at (sp) }) ()) } :: peg :: RuleResult :: Error (__e) => :: peg :: RuleResult :: Error (__e) , :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } } :: peg :: RuleResult :: Error (__e) => :: peg :: RuleResult :: Error (__e) , :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } } :: peg :: RuleResult :: Error (__e) => { __err_state . mark_error (__e) ; :: peg :: RuleResult :: Error (__e) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"##\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Error (__e) => :: peg :: RuleResult :: Error (__e) , :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } ; match __choice_res { :: peg :: RuleResult :: Matched (__pos , __value) => :: peg :: RuleResult :: Matched (__pos , __value) , :: peg :: RuleResult :: Error (__e) => :: peg :: RuleResult :: Error (__e) , :: peg :: RuleResult :: Failed => match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , "(") { :: peg :: RuleResult :: Matched (__pos , __val) => { { let __seq_res = __parse_expression (__input , __state , __err_state , __pos) ; match __seq_res { :: peg :: RuleResult :: Matched (__pos , expression) => { match :: peg :: ParseLiteral :: parse_string_literal (__input , __pos , ")") { :: peg :: RuleResult :: Matched (__pos , __val) => { :: peg :: RuleResult :: Matched (__pos , (|| { expression }) ()) } :: peg :: RuleResult :: Error (__e) => { __err_state . mark_error (__e) ; :: peg :: RuleResult :: Error (__e) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\")\"") ; :: peg :: RuleResult :: Failed } } } :: peg :: RuleResult :: Error (__e) => :: peg :: RuleResult :: Error (__e) , :: peg :: RuleResult :: Failed => :: peg :: RuleResult :: Failed , } } } :: peg :: RuleResult :: Error (__e) => { __err_state . mark_error (__e) ; :: peg :: RuleResult :: Error (__e) } :: peg :: RuleResult :: Failed => { __err_state . mark_failure (__pos , "\"(\"") ; :: peg :: RuleResult :: Failed } } } } } } } } } } } } } } }
                                                                 }
-                                                                ::peg::RuleResult::Error(..) => panic!()
                                                             }
                                                         }
-                                                        ::peg::RuleResult::Error(..) => panic!()
                                                     }
                                                 }
-                                                ::peg::RuleResult::Error(..) => panic!()
                                             }
                                         }
-                                        ::peg::RuleResult::Error(..) => panic!()
                                     }
                                 }
-                                ::peg::RuleResult::Error(..) => panic!()
                             }
                         }
-                        ::peg::RuleResult::Error(..) => panic!()
                     }
                 }
-                ::peg::RuleResult::Error(..) => panic!()
             }
         };
         __state.primary_cache.insert(__pos, __rule_result.clone());
@@ -3242,32 +3563,40 @@ pub mod peg {
                                 ::peg::RuleResult::Matched(__pos, __val) => {
                                     ::peg::RuleResult::Matched(__pos, (|| RuleArg::Peg(e))())
                                 }
+                                ::peg::RuleResult::Error(__e) => {
+                                    __err_state.mark_error(__e);
+                                    ::peg::RuleResult::Error(__e)
+                                }
                                 ::peg::RuleResult::Failed => {
                                     __err_state.mark_failure(__pos, "\">\"");
                                     ::peg::RuleResult::Failed
                                 }
-                                ::peg::RuleResult::Error(..) => panic!()
                             }
                         }
+                        ::peg::RuleResult::Error(__e) => ::peg::RuleResult::Error(__e),
                         ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
-                        ::peg::RuleResult::Error(..) => panic!()
                     }
+                }
+                ::peg::RuleResult::Error(__e) => {
+                    __err_state.mark_error(__e);
+                    ::peg::RuleResult::Error(__e)
                 }
                 ::peg::RuleResult::Failed => {
                     __err_state.mark_failure(__pos, "\"<\"");
                     ::peg::RuleResult::Failed
                 }
-                ::peg::RuleResult::Error(..) => panic!()
             };
             match __choice_res {
                 ::peg::RuleResult::Matched(__pos, __value) => {
                     ::peg::RuleResult::Matched(__pos, __value)
                 }
+                ::peg::RuleResult::Error(__e) => ::peg::RuleResult::Error(__e),
                 ::peg::RuleResult::Failed => {
                     let __seq_res = {
                         let str_start = __pos;
                         match {
                             let mut __repeat_pos = __pos;
+                            let mut __maybe_err = None;
                             let mut __repeat_value = vec![];
                             loop {
                                 let __pos = __repeat_pos;
@@ -3280,10 +3609,15 @@ pub mod peg {
                                     ::peg::RuleResult::Failed => {
                                         break;
                                     }
-                                    ::peg::RuleResult::Error(..) => panic!()
+                                    ::peg::RuleResult::Error(__e) => {
+                                        __maybe_err = Some(__e);
+                                        break;
+                                    }
                                 }
                             }
-                            if __repeat_value.len() >= 1 {
+                            if let Some(__e) = __maybe_err {
+                                ::peg::RuleResult::Error(__e)
+                            } else if __repeat_value.len() >= 1 {
                                 ::peg::RuleResult::Matched(__repeat_pos, ())
                             } else {
                                 ::peg::RuleResult::Failed
@@ -3294,18 +3628,17 @@ pub mod peg {
                                 ::peg::ParseSlice::parse_slice(__input, str_start, __newpos),
                             ),
                             ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
-                            ::peg::RuleResult::Error(..) => panic!()
+                            ::peg::RuleResult::Error(__e) => ::peg::RuleResult::Error(__e),
                         }
                     };
                     match __seq_res {
                         ::peg::RuleResult::Matched(__pos, tt) => {
                             ::peg::RuleResult::Matched(__pos, (|| RuleArg::Rust(tt))())
                         }
+                        ::peg::RuleResult::Error(__e) => ::peg::RuleResult::Error(__e),
                         ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
-                        ::peg::RuleResult::Error(..) => panic!()
                     }
                 }
-                ::peg::RuleResult::Error(..) => panic!()
             }
         }
     }
@@ -3319,6 +3652,7 @@ pub mod peg {
         {
             let __seq_res = {
                 let mut __repeat_pos = __pos;
+                let mut __maybe_err = None;
                 let mut __repeat_value = vec![];
                 loop {
                     let __pos = __repeat_pos;
@@ -3331,10 +3665,15 @@ pub mod peg {
                         ::peg::RuleResult::Failed => {
                             break;
                         }
-                        ::peg::RuleResult::Error(..) => panic!()
+                        ::peg::RuleResult::Error(__e) => {
+                            __maybe_err = Some(__e);
+                            break;
+                        }
                     }
                 }
-                if __repeat_value.len() >= 1 {
+                if let Some(__e) = __maybe_err {
+                    ::peg::RuleResult::Error(__e)
+                } else if __repeat_value.len() >= 1 {
                     ::peg::RuleResult::Matched(__repeat_pos, __repeat_value)
                 } else {
                     ::peg::RuleResult::Failed
@@ -3347,8 +3686,8 @@ pub mod peg {
                         operators: operators,
                     })(),
                 ),
+                ::peg::RuleResult::Error(__e) => ::peg::RuleResult::Error(__e),
                 ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
-                ::peg::RuleResult::Error(..) => panic!()
             }
         }
     }
@@ -3365,6 +3704,7 @@ pub mod peg {
                 ::peg::RuleResult::Matched(__pos, span) => {
                     let __seq_res = {
                         let mut __repeat_pos = __pos;
+                        let mut __maybe_err = None;
                         let mut __repeat_value = vec![];
                         loop {
                             let __pos = __repeat_pos;
@@ -3377,7 +3717,10 @@ pub mod peg {
                                 ::peg::RuleResult::Failed => {
                                     break;
                                 }
-                                ::peg::RuleResult::Error(..) => panic!()
+                                ::peg::RuleResult::Error(__e) => {
+                                    __maybe_err = Some(__e);
+                                    break;
+                                }
                             }
                         }
                         ::peg::RuleResult::Matched(__repeat_pos, __repeat_value)
@@ -3397,16 +3740,16 @@ pub mod peg {
                                         })(),
                                     )
                                 }
+                                ::peg::RuleResult::Error(__e) => ::peg::RuleResult::Error(__e),
                                 ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
-                                ::peg::RuleResult::Error(..) => panic!()
                             }
                         }
+                        ::peg::RuleResult::Error(__e) => ::peg::RuleResult::Error(__e),
                         ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
-                        ::peg::RuleResult::Error(..) => panic!()
                     }
                 }
+                ::peg::RuleResult::Error(__e) => ::peg::RuleResult::Error(__e),
                 ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
-                ::peg::RuleResult::Error(..) => panic!()
             }
         }
     }
@@ -3432,32 +3775,40 @@ pub mod peg {
                     ::peg::RuleResult::Matched(__pos, __val) => {
                         ::peg::RuleResult::Matched(__pos, __val)
                     }
+                    ::peg::RuleResult::Error(__e) => {
+                        __err_state.mark_error(__e);
+                        ::peg::RuleResult::Error(__e)
+                    }
                     ::peg::RuleResult::Failed => {
                         __err_state.mark_failure(__pos, "\"pub\"");
                         ::peg::RuleResult::Failed
                     }
-                    ::peg::RuleResult::Error(..) => panic!()
                 };
             match __choice_res {
                 ::peg::RuleResult::Matched(__pos, __value) => {
                     ::peg::RuleResult::Matched(__pos, __value)
                 }
+                ::peg::RuleResult::Error(__e) => ::peg::RuleResult::Error(__e),
                 ::peg::RuleResult::Failed => {
                     let __choice_res =
                         match ::peg::ParseLiteral::parse_string_literal(__input, __pos, "crate") {
                             ::peg::RuleResult::Matched(__pos, __val) => {
                                 ::peg::RuleResult::Matched(__pos, __val)
                             }
+                            ::peg::RuleResult::Error(__e) => {
+                                __err_state.mark_error(__e);
+                                ::peg::RuleResult::Error(__e)
+                            }
                             ::peg::RuleResult::Failed => {
                                 __err_state.mark_failure(__pos, "\"crate\"");
                                 ::peg::RuleResult::Failed
                             }
-                            ::peg::RuleResult::Error(..) => panic!()
                         };
                     match __choice_res {
                         ::peg::RuleResult::Matched(__pos, __value) => {
                             ::peg::RuleResult::Matched(__pos, __value)
                         }
+                        ::peg::RuleResult::Error(__e) => ::peg::RuleResult::Error(__e),
                         ::peg::RuleResult::Failed => {
                             let __choice_res = match ::peg::ParseLiteral::parse_string_literal(
                                 __input, __pos, "rule",
@@ -3465,16 +3816,20 @@ pub mod peg {
                                 ::peg::RuleResult::Matched(__pos, __val) => {
                                     ::peg::RuleResult::Matched(__pos, __val)
                                 }
+                                ::peg::RuleResult::Error(__e) => {
+                                    __err_state.mark_error(__e);
+                                    ::peg::RuleResult::Error(__e)
+                                }
                                 ::peg::RuleResult::Failed => {
                                     __err_state.mark_failure(__pos, "\"rule\"");
                                     ::peg::RuleResult::Failed
                                 }
-                                ::peg::RuleResult::Error(..) => panic!()
                             };
                             match __choice_res {
                                 ::peg::RuleResult::Matched(__pos, __value) => {
                                     ::peg::RuleResult::Matched(__pos, __value)
                                 }
+                                ::peg::RuleResult::Error(__e) => ::peg::RuleResult::Error(__e),
                                 ::peg::RuleResult::Failed => {
                                     let __choice_res =
                                         match ::peg::ParseLiteral::parse_string_literal(
@@ -3483,15 +3838,21 @@ pub mod peg {
                                             ::peg::RuleResult::Matched(__pos, __val) => {
                                                 ::peg::RuleResult::Matched(__pos, __val)
                                             }
+                                            ::peg::RuleResult::Error(__e) => {
+                                                __err_state.mark_error(__e);
+                                                ::peg::RuleResult::Error(__e)
+                                            }
                                             ::peg::RuleResult::Failed => {
                                                 __err_state.mark_failure(__pos, "\"use\"");
                                                 ::peg::RuleResult::Failed
                                             }
-                                            ::peg::RuleResult::Error(..) => panic!()
                                         };
                                     match __choice_res {
                                         ::peg::RuleResult::Matched(__pos, __value) => {
                                             ::peg::RuleResult::Matched(__pos, __value)
+                                        }
+                                        ::peg::RuleResult::Error(__e) => {
+                                            ::peg::RuleResult::Error(__e)
                                         }
                                         ::peg::RuleResult::Failed => {
                                             match ::peg::ParseLiteral::parse_string_literal(
@@ -3500,23 +3861,22 @@ pub mod peg {
                                                 ::peg::RuleResult::Matched(__pos, __val) => {
                                                     ::peg::RuleResult::Matched(__pos, __val)
                                                 }
+                                                ::peg::RuleResult::Error(__e) => {
+                                                    __err_state.mark_error(__e);
+                                                    ::peg::RuleResult::Error(__e)
+                                                }
                                                 ::peg::RuleResult::Failed => {
                                                     __err_state.mark_failure(__pos, "\"type\"");
                                                     ::peg::RuleResult::Failed
                                                 }
-                                                ::peg::RuleResult::Error(..) => panic!()
                                             }
                                         }
-                                        ::peg::RuleResult::Error(..) => panic!()
                                     }
                                 }
-                                ::peg::RuleResult::Error(..) => panic!()
                             }
                         }
-                        ::peg::RuleResult::Error(..) => panic!()
                     }
                 }
-                ::peg::RuleResult::Error(..) => panic!()
             }
         }
     }
@@ -3532,14 +3892,14 @@ pub mod peg {
                 __err_state.suppress_fail += 1;
                 let __assert_res = match __parse_KEYWORD(__input, __state, __err_state, __pos) {
                     ::peg::RuleResult::Matched(pos, _) => ::peg::RuleResult::Matched(pos, ()),
+                    ::peg::RuleResult::Error(e) => ::peg::RuleResult::Error(e),
                     ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
-                    ::peg::RuleResult::Error(..) => panic!()
                 };
                 __err_state.suppress_fail -= 1;
                 match __assert_res {
                     ::peg::RuleResult::Failed => ::peg::RuleResult::Matched(__pos, ()),
+                    ::peg::RuleResult::Error(..) => ::peg::RuleResult::Matched(__pos, ()),
                     ::peg::RuleResult::Matched(..) => __err_state.mark_failure(__pos, "mismatch"),
-                    ::peg::RuleResult::Error(..) => panic!()
                 }
             };
             match __seq_res {
@@ -3549,12 +3909,12 @@ pub mod peg {
                         ::peg::RuleResult::Matched(__pos, i) => {
                             ::peg::RuleResult::Matched(__pos, (|| i)())
                         }
+                        ::peg::RuleResult::Error(__e) => ::peg::RuleResult::Error(__e),
                         ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
-                        ::peg::RuleResult::Error(..) => panic!()
                     }
                 }
+                ::peg::RuleResult::Error(__e) => ::peg::RuleResult::Error(__e),
                 ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
-                ::peg::RuleResult::Error(..) => panic!()
             }
         }
     }
@@ -3605,20 +3965,23 @@ pub mod peg {
             ::peg::RuleResult::Matched(__pos, __val) => {
                 let __seq_res = match __parse_IDENT(__input, __state, __err_state, __pos) {
                     ::peg::RuleResult::Matched(pos, _) => ::peg::RuleResult::Matched(pos, ()),
+                    ::peg::RuleResult::Error(e) => ::peg::RuleResult::Error(e),
                     ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
-                    ::peg::RuleResult::Error(..) => panic!()
                 };
                 match __seq_res {
                     ::peg::RuleResult::Matched(__pos, _) => ::peg::RuleResult::Matched(__pos, ()),
+                    ::peg::RuleResult::Error(__e) => ::peg::RuleResult::Error(__e),
                     ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
-                    ::peg::RuleResult::Error(..) => panic!()
                 }
+            }
+            ::peg::RuleResult::Error(__e) => {
+                __err_state.mark_error(__e);
+                ::peg::RuleResult::Error(__e)
             }
             ::peg::RuleResult::Failed => {
                 __err_state.mark_failure(__pos, "\"'\"");
                 ::peg::RuleResult::Failed
             }
-            ::peg::RuleResult::Error(..) => panic!()
         }
     }
     fn __parse_INTEGER<'input>(
@@ -3630,8 +3993,8 @@ pub mod peg {
         #![allow(non_snake_case, unused, clippy::redundant_closure_call)]
         match __parse_LITERAL(__input, __state, __err_state, __pos) {
             ::peg::RuleResult::Matched(pos, _) => ::peg::RuleResult::Matched(pos, ()),
+            ::peg::RuleResult::Error(e) => ::peg::RuleResult::Error(e),
             ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
-            ::peg::RuleResult::Error(..) => panic!()
-         }
+        }
     }
 }

--- a/peg-macros/grammar.rs
+++ b/peg-macros/grammar.rs
@@ -43,7 +43,7 @@ pub mod peg {
             _ => (),
         }
         __state = ParseState::new();
-        __err_state.reparse_for_error();
+        __err_state.reparse_for_failure();
         match __parse_peg_grammar(
             __input,
             &mut __state,

--- a/peg-macros/grammar.rustpeg
+++ b/peg-macros/grammar.rustpeg
@@ -125,6 +125,9 @@ rule primary() -> SpannedExpr
   / sp:sp() "position" "!" "(" ")" { PositionExpr.at(sp) }
   / sp:sp() "quiet" "!" "{" e:expression() "}" { QuietExpr(Box::new(e)).at(sp) }
   / sp:sp() "expected" "!" "(" s:LITERAL() ")" { FailExpr(s).at(sp) }
+  / sp:sp() "error" "!" "{" s:LITERAL() seq:sequence() "}" { ErrorIfExpr(Box::new(ActionExpr(vec![], None).at(sp)), s, Box::new(seq)).at(sp) }
+  / sp:sp() "error_if" "!" "{" seq1:sequence() "|" s:LITERAL() seq2:sequence() "}" { ErrorIfExpr(Box::new(seq1), s, Box::new(seq2)).at(sp) }
+  / sp:sp() "error_unless" "!" "{" seq1:sequence() "|" s:LITERAL() seq2:sequence() "}" { ErrorUnlessExpr(Box::new(seq1), s, Box::new(seq2)).at(sp) }
   / &("_" / "__" / "___") sp:sp() name:IDENT() { RuleExpr(name, Vec::new()).at(sp) }
   / sp:sp() name:IDENT() "(" args:(rule_arg() ** ",") ")" { RuleExpr(name, args).at(sp) }
   / sp:sp() l:LITERAL() { LiteralExpr(l).at(sp) }

--- a/peg-macros/lib.rs
+++ b/peg-macros/lib.rs
@@ -20,7 +20,7 @@ mod translate;
 #[proc_macro]
 pub fn parser(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let tokens = tokens::FlatTokenStream::new(input.into());
-    let grammar = match grammar::peg::peg_grammar(&tokens) {
+    let grammar = match grammar::peg::peg_grammar(&tokens).into_result() {
         Ok(g) => g,
         Err(err) => {
             let msg = format!("expected {}", err.expected);

--- a/peg-macros/translate.rs
+++ b/peg-macros/translate.rs
@@ -227,6 +227,10 @@ fn compile_rule(context: &Context, rule: &Rule) -> TokenStream {
                 ::peg::RuleResult::Failed => {
                     println!("[PEG_TRACE] Failed to match rule `{}` at {}", #str_rule_name, loc);
                 }
+                ::peg::RuleResult::Error(e) => {
+                    let eloc = ::peg::Parse::position_repr(__input, e.location);
+                    println!("[PEG_TRACE] Error matching rule `{}` at {}: {} at {}", #str_rule_name, loc, e.error, eloc);
+                }
             }
 
             __peg_result
@@ -249,6 +253,7 @@ fn compile_rule(context: &Context, rule: &Rule) -> TokenStream {
                     match &entry {
                         &::peg::RuleResult::Matched(..) => println!("[PEG_TRACE] Cached match of rule {} at {}", #str_rule_name, loc),
                         &Failed => println!("[PEG_TRACE] Cached fail of rule {} at {}", #str_rule_name, loc),
+                        &::peg::RuleResult::Error(..) => println!("[PEG_TRACE] Cached error of rule {} at {}", #str_rule_name, loc),
                     };
                 }
             } else {
@@ -282,10 +287,16 @@ fn compile_rule(context: &Context, rule: &Rule) -> TokenStream {
                             let __current_result = { #wrapped_body };
                             match __current_result {
                                 ::peg::RuleResult::Failed => break,
+                                ::peg::RuleResult::Error(..) => {
+                                        __state.#cache_field.insert(__pos, __current_result.clone());
+                                        __last_result = __current_result;
+                                        break
+                                },
                                 ::peg::RuleResult::Matched(__current_endpos, _) =>
                                     match __last_result {
                                         ::peg::RuleResult::Matched(__last_endpos, _) if __current_endpos <= __last_endpos => break,
-                                        _ => {
+                                        ::peg::RuleResult::Error(..) => panic!(),  // impossible; we would have broken on previous iteration
+                                        ::peg::RuleResult::Failed | ::peg::RuleResult::Matched(..) => {
                                             __state.#cache_field.insert(__pos, __current_result.clone());
                                             __last_result = __current_result;
                                         },
@@ -352,7 +363,10 @@ fn compile_rule_export(context: &Context, rule: &Rule) -> TokenStream {
                         __err_state.mark_failure(__pos, "EOF");
                     }
                 }
-                _ => ()
+                ::peg::RuleResult::Error(__e) => {
+                    return __err_state.into_error(__e, __input)
+                }
+                ::peg::RuleResult::Failed => ()
             }
 
             __state = ParseState::new();
@@ -387,6 +401,7 @@ fn ordered_choice(span: Span, mut rs: impl DoubleEndedIterator<Item = TokenStrea
             let __choice_res = #preferred;
             match __choice_res {
                 ::peg::RuleResult::Matched(__pos, __value) => ::peg::RuleResult::Matched(__pos, __value),
+                ::peg::RuleResult::Error(__e) => ::peg::RuleResult::Error(__e),
                 ::peg::RuleResult::Failed => #fallback
             }
         }}
@@ -421,6 +436,7 @@ fn compile_expr_continuation(context: &Context, e: &SpannedExpr, result_name: Op
                 let __seq_res = #seq_res;
                 match __seq_res {
                     ::peg::RuleResult::Matched(__pos, #result_pat) => { #continuation }
+                    ::peg::RuleResult::Error(__e) => ::peg::RuleResult::Error(__e),
                     ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
                 }
             }}
@@ -434,6 +450,7 @@ fn compile_literal_expr(s: &Literal, continuation: TokenStream) -> TokenStream {
     quote_spanned! { span =>
             match ::peg::ParseLiteral::parse_string_literal(__input, __pos, #s) {
             ::peg::RuleResult::Matched(__pos, __val) => { #continuation }
+            ::peg::RuleResult::Error(__e) => { __err_state.mark_error(__e); ::peg::RuleResult::Error(__e) }  // unexpected, but do something sensible
             ::peg::RuleResult::Failed => { __err_state.mark_failure(__pos, #escaped_str); ::peg::RuleResult::Failed }
         }
     }
@@ -457,6 +474,7 @@ fn compile_pattern_expr(pattern_group: &Group, result_name: Ident, success_res: 
                 _ => #not_in_set,
             }
             ::peg::RuleResult::Failed => { __err_state.mark_failure(__pos, #pat_str); ::peg::RuleResult::Failed },
+            ::peg::RuleResult::Error(__e) => { __err_state.mark_error(__e); ::peg::RuleResult::Error(__e) },  // unexpected, but do something sensible
         }
     }
 }
@@ -543,6 +561,7 @@ fn compile_expr(context: &Context, e: &SpannedExpr, result_used: bool) -> TokenS
                 quote_spanned!{ span=>
                     match #func(__input, __state, __err_state, __pos #extra_args_call #(, #rule_args_call)*){
                         ::peg::RuleResult::Matched(pos, _) => ::peg::RuleResult::Matched(pos, ()),
+                        ::peg::RuleResult::Error(e) => ::peg::RuleResult::Error(e),
                         ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
                     }
                 }
@@ -567,6 +586,7 @@ fn compile_expr(context: &Context, e: &SpannedExpr, result_used: bool) -> TokenS
                     match #optional_res {
                         ::peg::RuleResult::Matched(__newpos, __value) => { ::peg::RuleResult::Matched(__newpos, Some(__value)) },
                         ::peg::RuleResult::Failed => { ::peg::RuleResult::Matched(__pos, None) },
+                        ::peg::RuleResult::Error(__e) => { ::peg::RuleResult::Error(__e) },
                     }
                 }
             } else {
@@ -574,6 +594,7 @@ fn compile_expr(context: &Context, e: &SpannedExpr, result_used: bool) -> TokenS
                     match #optional_res {
                         ::peg::RuleResult::Matched(__newpos, _) => { ::peg::RuleResult::Matched(__newpos, ()) },
                         ::peg::RuleResult::Failed => { ::peg::RuleResult::Matched(__pos, ()) },
+                        ::peg::RuleResult::Error(__e) => { ::peg::RuleResult::Error(__e) },
                     }
                 }
             }
@@ -597,6 +618,7 @@ fn compile_expr(context: &Context, e: &SpannedExpr, result_used: bool) -> TokenS
                         match __sep_res {
                             ::peg::RuleResult::Matched(__newpos, _) => { __newpos },
                             ::peg::RuleResult::Failed => break,
+                            ::peg::RuleResult::Error(__e) => { __maybe_err = Some(__e); break }
                         }
                     };
                 }
@@ -626,7 +648,10 @@ fn compile_expr(context: &Context, e: &SpannedExpr, result_used: bool) -> TokenS
 
             let result_check = if let Some(min) = min {
                 quote_spanned!{ span=>
-                    if __repeat_value.len() >= #min {
+                    if let Some(__e) = __maybe_err {
+                        ::peg::RuleResult::Error(__e)
+                    }
+                    else if __repeat_value.len() >= #min {
                         ::peg::RuleResult::Matched(__repeat_pos, #result)
                     } else {
                         ::peg::RuleResult::Failed
@@ -638,6 +663,7 @@ fn compile_expr(context: &Context, e: &SpannedExpr, result_used: bool) -> TokenS
 
             quote_spanned!{ span=> {
                 let mut __repeat_pos = __pos;
+                let mut __maybe_err = None;
                 #repeat_vec
 
                 loop {
@@ -653,6 +679,10 @@ fn compile_expr(context: &Context, e: &SpannedExpr, result_used: bool) -> TokenS
                             #repeat_step
                         },
                         ::peg::RuleResult::Failed => {
+                            break;
+                        }
+                        ::peg::RuleResult::Error(__e) => {
+                            __maybe_err = Some(__e);
                             break;
                         }
                     }
@@ -671,6 +701,7 @@ fn compile_expr(context: &Context, e: &SpannedExpr, result_used: bool) -> TokenS
                 match __assert_res {
                     ::peg::RuleResult::Matched(_, __value) => ::peg::RuleResult::Matched(__pos, __value),
                     ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
+                    ::peg::RuleResult::Error(..) => ::peg::RuleResult::Failed,
                 }
             }}
         }
@@ -683,6 +714,7 @@ fn compile_expr(context: &Context, e: &SpannedExpr, result_used: bool) -> TokenS
                 __err_state.suppress_fail -= 1;
                 match __assert_res {
                     ::peg::RuleResult::Failed => ::peg::RuleResult::Matched(__pos, ()),
+                    ::peg::RuleResult::Error(..) => ::peg::RuleResult::Matched(__pos, ()),
                     ::peg::RuleResult::Matched(..) => __err_state.mark_failure(__pos, "mismatch"),
                 }
             }}
@@ -717,6 +749,7 @@ fn compile_expr(context: &Context, e: &SpannedExpr, result_used: bool) -> TokenS
                 match #inner {
                     ::peg::RuleResult::Matched(__newpos, _) => { ::peg::RuleResult::Matched(__newpos, ::peg::ParseSlice::parse_slice(__input, str_start, __newpos)) },
                     ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
+                    ::peg::RuleResult::Error(__e) => ::peg::RuleResult::Error(__e),
                 }
             }}
         }
@@ -735,7 +768,66 @@ fn compile_expr(context: &Context, e: &SpannedExpr, result_used: bool) -> TokenS
         FailExpr(ref expected) => {
             quote_spanned! { span => { __err_state.mark_failure(__pos, #expected); ::peg::RuleResult::Failed }}
         }
+        ErrorIfExpr(ref expr1, ref message, ref expr2) => {
+            let if_res = compile_expr(context, expr1, false);
+            let recover_res = compile_expr(context, expr2, result_used);
+            quote_spanned! { span => {
+                let __if_res = { #if_res };
+                match __if_res {
+                    ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
+                    ::peg::RuleResult::Error(__e) => ::peg::RuleResult::Error(__e),
+                    ::peg::RuleResult::Matched(__newpos, _) => {
+                        // Report error (if any) at start of `expr1`, then consume it by shadowing `__pos`.
+                        let __parse_err = ::peg::error::ParseErr { error: #message, location: __pos };
+                        let __pos = __newpos;
+                        if __err_state.suppress_fail == 0 {
+                            __err_state.suppress_fail += 1;
+                            let __recover_res = { #recover_res };
+                            __err_state.suppress_fail -= 1;
 
+                            match __recover_res {
+                                ::peg::RuleResult::Matched(__newpos, __value) => {
+                                    __err_state.mark_error(__parse_err);
+                                    ::peg::RuleResult::Matched(__newpos, __value)
+                                },
+                                ::peg::RuleResult::Failed | ::peg::RuleResult::Error(..) => ::peg::RuleResult::Error(__parse_err)
+                            }
+                        } else {
+                            ::peg::RuleResult::Error(__parse_err)
+                        }
+                    },
+                }
+            }}
+        }
+        ErrorUnlessExpr(ref expr1, ref message, ref expr2) => {
+            let unless_res = compile_expr(context, expr1, result_used);
+            let recover_res = compile_expr(context, expr2, result_used);
+            quote_spanned! { span => {
+                let __unless_res = { #unless_res };
+                match __unless_res {
+                    ::peg::RuleResult::Matched(__newpos, __value) => ::peg::RuleResult::Matched(__newpos, __value),
+                    ::peg::RuleResult::Error(__e) => ::peg::RuleResult::Error(__e),
+                    ::peg::RuleResult::Failed => {
+                        let __parse_err = ::peg::error::ParseErr { error: #message, location: __pos };
+                        if __err_state.suppress_fail == 0 {
+                            __err_state.suppress_fail += 1;
+                            let __recover_res = { #recover_res };
+                            __err_state.suppress_fail -= 1;
+
+                            match __recover_res {
+                                ::peg::RuleResult::Matched(__newpos, __value) => {
+                                    __err_state.mark_error(__parse_err);
+                                    ::peg::RuleResult::Matched(__newpos, __value)
+                                },
+                                ::peg::RuleResult::Failed | ::peg::RuleResult::Error(..) => ::peg::RuleResult::Error(__parse_err)
+                            }
+                        } else {
+                            ::peg::RuleResult::Error(__parse_err)
+                        }
+                    },
+                }
+            }}
+        }
         PrecedenceExpr { ref levels } => {
             let mut pre_rules = Vec::new();
             let mut level_code = Vec::new();

--- a/peg-runtime/error.rs
+++ b/peg-runtime/error.rs
@@ -1,7 +1,7 @@
 //! Parse error reporting
 
 use crate::{Parse, RuleResult, ParseResults, ParseResult};
-use std::collections::HashSet;
+use std::collections::{HashSet, BTreeSet};
 use std::fmt::{self, Debug, Display};
 
 /// A set of literals or names that failed to match
@@ -14,6 +14,13 @@ impl ExpectedSet {
     /// Iterator of expected literals
     pub fn tokens<'a>(&'a self) -> impl Iterator<Item = &'static str> + 'a {
         self.expected.iter().map(|x| *x)
+    }
+
+    /// Construct a new singleton set.
+    pub(crate) fn singleton(error: &'static str) -> Self {
+        let mut expected = HashSet::new();
+        expected.insert(error);
+        ExpectedSet { expected }
     }
 }
 
@@ -35,6 +42,37 @@ impl Display for ExpectedSet {
         }
 
         Ok(())
+    }
+}
+
+/// A parse error raised by an `error!` expression.
+#[derive(PartialEq, Eq, PartialOrd, Ord, Debug, Clone, Hash)]
+pub struct ParseErr<L> {
+    /// The location at which the error occurred.
+    pub location: L,
+
+    /// The error reported at that location.
+    pub error: &'static str,
+}
+
+impl Copy for ParseErr<usize> {}
+
+impl<L: Display> Display for ParseErr<L> {
+    fn fmt(&self, fmt: &mut ::std::fmt::Formatter) -> ::std::result::Result<(), ::std::fmt::Error> {
+        write!(
+            fmt,
+            "error at {}: {}",
+            self.location, self.error
+        )
+    }
+}
+
+impl<L> ParseErr<L> {
+    pub fn into_parseerror(self) -> ParseError<L> {
+        ParseError {
+            location: self.location,
+            expected: ExpectedSet::singleton(self.error)
+        }
     }
 }
 
@@ -67,19 +105,22 @@ impl<L: Display + Debug> ::std::error::Error for ParseError<L> {
 #[doc(hidden)]
 #[derive(Debug)]
 pub struct ErrorState {
-    /// Furthest failure we've hit so far.
+    /// Furthest failure we've hit so far. Not used for parse errors.
     pub max_err_pos: usize,
 
-    /// Are we inside a lookahead/quiet block? If so, failure is disabled.
+    /// Are we inside a lookahead/quiet block? If so, failure/error and recovery rules are disabled.
     /// Non-zero => yes, to support nested blocks.
     pub suppress_fail: usize,
 
     /// Are we reparsing after a failure? If so, compute and store expected set of all alternative expectations
-    /// when we are at offset `max_err_pos`.
+    /// when we are at offset `max_err_pos`. Not used for parse errors.
     pub reparsing_on_failure: bool,
 
     /// The set of tokens we expected to find when we hit the failure. Updated when `reparsing_on_failure`.
     pub expected: ExpectedSet,
+
+    /// The set of parse errors we have recovered from so far.
+    pub errors: BTreeSet<ParseErr<usize>>,
 }
 
 impl ErrorState {
@@ -91,6 +132,7 @@ impl ErrorState {
             expected: ExpectedSet {
                 expected: HashSet::new(),
             },
+            errors: BTreeSet::new(),
         }
     }
 
@@ -120,10 +162,19 @@ impl ErrorState {
         RuleResult::Failed
     }
 
+    /// Flag an error.
+    #[inline(always)]
+    pub fn mark_error(&mut self, error: ParseErr<usize>) {
+        if self.suppress_fail == 0 {
+            self.errors.insert(error);
+        }
+    }
+
     /// Build `Matched` parse result.
-    pub fn into_matched<T, I: Parse + ?Sized>(self, v: T, _input: &I) -> ParseResults<T, I::PositionRepr> {
+    pub fn into_matched<T, I: Parse + ?Sized>(self, v: T, input: &I) -> ParseResults<T, I::PositionRepr> {
         ParseResults {
             result: ParseResult::Matched(v),
+            errors: errors_positioned_in(self.errors, input),
         }
     }
 
@@ -134,14 +185,27 @@ impl ErrorState {
                 expected: self.expected,
                 location: input.position_repr(self.max_err_pos)
             }),
+            errors: errors_positioned_in(self.errors, input),
         }
     }
 
-    /// Build `ParseError`.
-    pub fn into_parse_error<I: Parse + ?Sized>(self, input: &I) -> ParseError<I::PositionRepr> {
-        ParseError {
-                expected: self.expected,
-                location: input.position_repr(self.max_err_pos)
+    /// Build `Error` parse result.
+    pub fn into_error<T, I: Parse + ?Sized>(self, error: ParseErr<usize>, input: &I) -> ParseResults<T, I::PositionRepr> {
+        ParseResults {
+            result: ParseResult::Error(ParseErr {
+                location: input.position_repr(error.location),
+                error: error.error,
+            }),
+            errors: errors_positioned_in(self.errors, input),
         }
     }
+}
+
+/// Calculate locations of set of parse errors.
+fn errors_positioned_in<I: Parse + ?Sized>(errors: impl IntoIterator<Item = ParseErr<usize>>, input: &I) -> Vec<ParseErr<I::PositionRepr>> {
+    let mut errors_ret = vec![];
+    for error in errors {
+        errors_ret.push(ParseErr { location: input.position_repr(error.location), error: error.error })
+    }
+    errors_ret
 }

--- a/peg-runtime/lib.rs
+++ b/peg-runtime/lib.rs
@@ -5,41 +5,71 @@ mod slice;
 pub mod str;
 
 
-/// The public API of a parser: the result of the parse.
+/// The public API of a parser: the result of the parse, and the set of errors
+/// that were recovered from.
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub struct ParseResults<T, L> {
     /// The result of the parse.
     pub result: ParseResult<T, L>,
+
+    /// The set of errors we recovered from during the parse.
+    pub errors: Vec<error::ParseErr<L>>,
 }
 
 impl<T: Display, L: Display> Display for ParseResults<T, L> {
     fn fmt(&self, fmt: &mut ::std::fmt::Formatter) -> Result<(), ::std::fmt::Error> {
-        write!(fmt, "{}", self.result)
+        if self.errors.is_empty() {
+            write!(fmt, "{} with no errors.", self.result)
+        } else {
+            write!(fmt, "{} after recovery from ", self.result)?;
+            let mut first = true;
+            for error in &self.errors {
+                if first {
+                    write!(fmt, "{}", error)?;
+                    first = false;
+                } else {
+                    write!(fmt, ", {}", error)?;
+                }
+            }
+            write!(fmt, ".")
+        }
     }
 }
 
 impl<T, L> ParseResults<T, L> {
-    /// Convert into a simple `Result`.
+    /// Convert into a simple `Result`, treating recovery as failure.
     pub fn into_result(self) -> Result<T, error::ParseError<L>> {
+        match (self.errors, self.result) {
+            (mut errors, _) if !errors.is_empty() => Err(errors.swap_remove(0).into_parseerror()),
+            (_, ParseResult::Matched(v)) => Ok(v),
+            (_, ParseResult::Failed(e)) => Err(e),
+            (_, ParseResult::Error(e)) => Err(e.into_parseerror()),
+        }
+    }
+
+    /// Convert into a simple `Result`, ignoring any recovered errors..
+    pub fn recover_result(self) -> Result<T, error::ParseError<L>> {
         match self.result {
             ParseResult::Matched(v) => Ok(v),
             ParseResult::Failed(e) => Err(e),
+            ParseResult::Error(e) => Err(e.into_parseerror()),
         }
     }
 }
 
 impl<T, L: Display> ParseResults<T, L> {
-    /// Return the contained match, or panic on failure.
+    /// Return the contained match, or panic on failure or error.
     pub fn unwrap(self) -> T {
         match self.result {
             ParseResult::Matched(v) => v,
             ParseResult::Failed(e) => panic!("parse failed: {}", e),
+            ParseResult::Error(e) => panic!("parse {}", e),
         }
     }
 }
 
 /// The public result of a parser.
-/// A parse may succeed or fail.
+/// A parse may succeed, fail, or raise a named error.
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub enum ParseResult<T, L> {
     /// Success
@@ -47,6 +77,9 @@ pub enum ParseResult<T, L> {
 
     /// Failure
     Failed(error::ParseError<L>),
+
+    /// Labelled error at location
+    Error(error::ParseErr<L>),
 }
 
 impl<T: Display, L: Display> Display for ParseResult<T, L> {
@@ -54,6 +87,7 @@ impl<T: Display, L: Display> Display for ParseResult<T, L> {
         match self {
             ParseResult::Matched(v) => write!(fmt, "{}", v),
             ParseResult::Failed(e) => write!(fmt, "{}", e),
+            ParseResult::Error(e) => write!(fmt, "{}", e),
         }
     }
 }
@@ -69,6 +103,9 @@ pub enum RuleResult<T> {
 
     /// Failure (furthest failure location is not yet known)
     Failed,
+
+    /// Labelled error at location
+    Error(error::ParseErr<usize>),
 }
 
 /// A type that can be used as input to a parser.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,9 +33,12 @@
 //!
 //! The macro expands to a Rust `mod` containing a function for each rule marked
 //! `pub` in the grammar. To parse an input sequence, call one of these
-//! functions. The call returns a `Result<T, ParseError>` carrying either the
-//! successfully parsed value returned by the rule, or a `ParseError` containing
-//! the failure position and the set of tokens expected there.
+//! functions. The call returns a `ParseResults<T,L>`, which carries either the
+//! successfully parsed value or the furthest failure.
+//!
+//! * Use `unwrap()` to obtain the successful `T` or panic.
+//! * Use `into_result()` to obtain a `Result<T, _>`.
+//! * For full details, match on the `result` field.
 //!
 //! ## Example
 //!
@@ -53,7 +56,7 @@
 //! }
 //!
 //! pub fn main() {
-//!     assert_eq!(list_parser::list("[1,1,2,3,5,8]"), Ok(vec![1, 1, 2, 3, 5, 8]));
+//!     assert_eq!(list_parser::list("[1,1,2,3,5,8]").into_result(), Ok(vec![1, 1, 2, 3, 5, 8]));
 //! }
 //! ```
 //!

--- a/tests/run-pass/arithmetic.rs
+++ b/tests/run-pass/arithmetic.rs
@@ -22,12 +22,12 @@ peg::parser!( grammar arithmetic() for str {
 });
 
 fn main() {
-    assert_eq!(expression("1+1"), Ok(2));
-    assert_eq!(expression("5*5"), Ok(25));
-    assert_eq!(expression("222+3333"), Ok(3555));
-    assert_eq!(expression("2+3*4"), Ok(14));
-    assert_eq!(expression("(2+2)*3"), Ok(12));
-    assert!(expression("(22+)+1").is_err());
-    assert!(expression("1++1").is_err());
-    assert!(expression("3)+1").is_err());
+    assert_eq!(expression("1+1").into_result(), Ok(2));
+    assert_eq!(expression("5*5").into_result(), Ok(25));
+    assert_eq!(expression("222+3333").into_result(), Ok(3555));
+    assert_eq!(expression("2+3*4").into_result(), Ok(14));
+    assert_eq!(expression("(2+2)*3").into_result(), Ok(12));
+    assert!(expression("(22+)+1").into_result().is_err());
+    assert!(expression("1++1").into_result().is_err());
+    assert!(expression("3)+1").into_result().is_err());
 }

--- a/tests/run-pass/arithmetic_ast.rs
+++ b/tests/run-pass/arithmetic_ast.rs
@@ -35,29 +35,29 @@ grammar arithmetic() for str {
 }}
 
 fn main() {
-    assert_eq!(arithmetic::expression("1+1"), Ok(Expression::Sum(
+    assert_eq!(arithmetic::expression("1+1").into_result(), Ok(Expression::Sum(
         Box::new(Expression::Number(1)),
         Box::new(Expression::Number(1)))
     ));
-    assert_eq!(arithmetic::expression("5*5"), Ok(Expression::Product(
+    assert_eq!(arithmetic::expression("5*5").into_result(), Ok(Expression::Product(
         Box::new(Expression::Number(5)),
         Box::new(Expression::Number(5)))
     ));
-    assert_eq!(arithmetic::expression("2+3*4"), Ok(Expression::Sum(
+    assert_eq!(arithmetic::expression("2+3*4").into_result(), Ok(Expression::Sum(
         Box::new(Expression::Number(2)),
         Box::new(Expression::Product(
             Box::new(Expression::Number(3)),
             Box::new(Expression::Number(4))
         )),
     )));
-    assert_eq!(arithmetic::expression("(2+3) * 4"), Ok(Expression::Product(
+    assert_eq!(arithmetic::expression("(2+3) * 4").into_result(), Ok(Expression::Product(
         Box::new(Expression::Sum(
             Box::new(Expression::Number(2)),
             Box::new(Expression::Number(3)),
         )),
         Box::new(Expression::Number(4))
     )));
-    assert!(arithmetic::expression("(22+)+1").is_err());
-    assert!(arithmetic::expression("1++1").is_err());
-    assert!(arithmetic::expression("3)+1").is_err());
+    assert!(arithmetic::expression("(22+)+1").into_result().is_err());
+    assert!(arithmetic::expression("1++1").into_result().is_err());
+    assert!(arithmetic::expression("3)+1").into_result().is_err());
 }

--- a/tests/run-pass/arithmetic_infix.rs
+++ b/tests/run-pass/arithmetic_infix.rs
@@ -22,10 +22,10 @@ peg::parser!( grammar arithmetic() for str {
 });
 
 fn main() {
-    assert_eq!(arithmetic::calculate("3+3*3+3"), Ok(15));
-    assert_eq!(arithmetic::calculate("2+2^2^2^2/2+2"), Ok(32772));
-    assert_eq!(arithmetic::calculate("1024/2/2/2+1"), Ok(129));
-    assert_eq!(arithmetic::calculate("1024/(1+1)/2/2+1"), Ok(129));
-    assert_eq!(arithmetic::calculate("-1-2*-2"), Ok(3));
-    assert_eq!(arithmetic::calculate("1+3!+1"), Ok(8));
+    assert_eq!(arithmetic::calculate("3+3*3+3").into_result(), Ok(15));
+    assert_eq!(arithmetic::calculate("2+2^2^2^2/2+2").into_result(), Ok(32772));
+    assert_eq!(arithmetic::calculate("1024/2/2/2+1").into_result(), Ok(129));
+    assert_eq!(arithmetic::calculate("1024/(1+1)/2/2+1").into_result(), Ok(129));
+    assert_eq!(arithmetic::calculate("-1-2*-2").into_result(), Ok(3));
+    assert_eq!(arithmetic::calculate("1+3!+1").into_result(), Ok(8));
 }

--- a/tests/run-pass/arithmetic_infix_ast.rs
+++ b/tests/run-pass/arithmetic_infix_ast.rs
@@ -22,7 +22,7 @@ pub enum InfixAst {
 }
 
 fn main(){
-    assert_eq!(arithmetic::expression("a + b `x` c").unwrap(),
+    assert_eq!(arithmetic::expression("a + b `x` c").into_result().unwrap(),
         InfixAst::Add(
             Box::new(InfixAst::Ident("a".to_owned())),
             Box::new(InfixAst::Op("x".to_owned(),

--- a/tests/run-pass/arithmetic_infix_ast_span.rs
+++ b/tests/run-pass/arithmetic_infix_ast_span.rs
@@ -29,7 +29,7 @@ pub enum Op {
 }
 
 fn main(){
-    assert_eq!(arithmetic::expression("a+b*c").unwrap(),
+    assert_eq!(arithmetic::expression("a+b*c").into_result().unwrap(),
         Node {
             start: 0,
             end: 5,

--- a/tests/run-pass/arithmetic_recovery.rs
+++ b/tests/run-pass/arithmetic_recovery.rs
@@ -1,0 +1,158 @@
+//! Example: How to use errors and parser recovery for a simple expression language.
+
+extern crate peg;
+use arithmetic::expression;
+use std::fmt::{Debug, Display};
+
+peg::parser!( grammar arithmetic() for str {
+    pub rule expression() -> i64
+        =
+          // The whole expression should just be a sum. If there's at least one
+          // character left over, report it and consume it.
+          _ v:sum() error_if!{ [_]+ | "unexpected content at end" }? { v }
+          // If we reach this alternative, we've not found anything at all
+          // (except possibly whitespace), so report that.
+        / error!{"empty expression" _} { 0 }
+
+    rule sum() -> i64
+        = l:product() "+" _ r:sum() { l+r }
+        / product()
+
+    rule product() -> i64
+        =
+          // If we see some common symbols, give a special error message explaining
+          // why they don't work. Then just treat them as if they were addition.
+          l:atom() ("*" / error_if!{ ['/' | '-' | '^'] | "unsupported operation" }) _ r:product() { l*r }
+        / atom()
+
+    rule atom() -> i64
+        = number()
+          // A parenthesised expression must end with `)`. If not, assume
+          // something has gone wrong with the expression and skip everything
+          // until we find that `)` (or EOF). This is likely to avoid a lot
+          // of spurious error messages - usually the `)` hasn't been forgotten,
+          // it's some error earlier.
+        / "(" _ v:sum() error_unless!{ ")" _ | "missing close paren" skip_to_rparen() } { v }
+          // Some other character that wasn't expected. Report it.
+        / error_if!{[_] | "expected atom" _} { 0 }
+
+    rule number() -> i64
+        = n:$(['0'..='9']+) _ { n.parse().unwrap() }
+
+    rule _ = quiet!{ [' ' | '\r' | '\n' | '\t']* }
+
+    /// Helper rule for recovery: skip to the next `)`, if any, skipping properly
+    /// over any balanced `(`...`)`.
+    rule skip_to_rparen()
+        = ("(" skip_to_rparen() / [^ '(' | ')'])* ")"? _
+
+});
+
+/// Check the errors and (recovered) value of the given parse result.
+fn assert_recovered<T: Eq + PartialEq + Display + Debug, L: Eq + PartialEq + Display + Debug>(
+    result: peg::ParseResults<T, L>,
+    errors: Vec<&str>,
+    value: T,
+) {
+    let pretty_result = result.to_string();
+    let actual_errors: Vec<String> = result.errors.iter().map(|e| e.to_string()).collect();
+    let expected_errors: Vec<String> = errors.iter().map(|e| e.to_string()).collect();
+    let recovered_result = result.recover_result();
+    assert_eq!(
+        recovered_result,
+        Ok(value),
+        "Should have recovered and got a result\nparsed: {}",
+        pretty_result
+    );
+    assert_eq!(
+        actual_errors, expected_errors,
+        "Unexpected list of recovered errors\nparsed: {}",
+        pretty_result
+    );
+}
+
+fn main() {
+    assert_eq!(expression("1 + 1").into_result(), Ok(2));
+    assert_eq!(expression("1 + 2 + 3").into_result(), Ok(6));
+    assert_eq!(expression("5 * 5").into_result(), Ok(25));
+    assert_eq!(expression("222 + 3333").into_result(), Ok(3555));
+    assert_eq!(expression("2 + 3 * 4").into_result(), Ok(14));
+    assert_eq!(expression("2 * 3 + 4").into_result(), Ok(10));
+    assert_eq!(expression("(2 + 2) * 3").into_result(), Ok(12));
+    assert!(expression("(22 + ) + 1").into_result().is_err());
+    assert!(expression("1 + + 1").into_result().is_err());
+    assert!(expression("3) + 1").into_result().is_err());
+
+    // Demonstrate that we spot the error, give a sensible message,
+    // and continue to give a result anyway.
+    //   offset: 1:          1         2         3         4
+    //              1234567890123456789012345678901234567890
+    assert_recovered(
+        expression("1 + 1 1"),
+        vec!["error at 1:7: unexpected content at end"],
+        2,
+    );
+    assert_recovered(
+        expression("(1 + 1 1)"),
+        vec!["error at 1:8: missing close paren"],
+        2,
+    );
+    assert_recovered(
+        expression("12 * (5 + 5 a) + 1"),
+        vec!["error at 1:13: missing close paren"],
+        121,
+    );
+    assert_recovered(
+        expression("12 * (5 + 5 + a) + 1"),
+        vec!["error at 1:15: expected atom"],
+        121,
+    );
+    assert_recovered(
+        expression("12 * (5 + 5 + atom) + 1"),
+        vec![
+            "error at 1:15: expected atom",
+            "error at 1:16: missing close paren",
+        ],
+        121,
+    );
+    // skips over nested parentheses
+    assert_recovered(
+        expression("12 * (5 + 5 a (thingy + wotsit) b) + 1"),
+        vec!["error at 1:13: missing close paren"],
+        121,
+    );
+    assert_recovered(
+        expression("12 * (5 + 5 (thingy + wotsit) b) + 1"),
+        vec!["error at 1:13: missing close paren"],
+        121,
+    );
+    // copes with unterminated parentheses
+    assert_recovered(
+        expression("12 * (5 + 5 (thingy + wotsit) + 1"),
+        vec!["error at 1:13: missing close paren"],
+        120,
+    );
+    assert_recovered(
+        expression("42 / 6"),
+        vec!["error at 1:4: unsupported operation"],
+        252,
+    );
+    assert_recovered(
+        expression(".1 + 10"),
+        vec![
+            "error at 1:1: expected atom",
+            "error at 1:2: unexpected content at end",
+        ],
+        0,
+    );
+    assert_recovered(
+        expression("+1"),
+        vec![
+            "error at 1:1: expected atom",
+            "error at 1:2: unexpected content at end",
+        ],
+        0,
+    );
+    assert_recovered(expression(""), vec!["error at 1:1: empty expression"], 0);
+    assert_recovered(expression(" "), vec!["error at 1:1: empty expression"], 0);
+}

--- a/tests/run-pass/arithmetic_with_left_recursion.rs
+++ b/tests/run-pass/arithmetic_with_left_recursion.rs
@@ -13,8 +13,8 @@ peg::parser!( grammar arithmetic() for str {
 });
 
 fn main() {
-    assert_eq!(sum("1"), Ok(1));
-    assert_eq!(sum("1+1"), Ok(2));
-    assert_eq!(sum("1+1+1"), Ok(3));
-    assert_eq!(sum("1+2+3"), Ok(6));
+    assert_eq!(sum("1").into_result(), Ok(1));
+    assert_eq!(sum("1+1").into_result(), Ok(2));
+    assert_eq!(sum("1+1+1").into_result(), Ok(3));
+    assert_eq!(sum("1+2+3").into_result(), Ok(6));
 }

--- a/tests/run-pass/borrow_from_input.rs
+++ b/tests/run-pass/borrow_from_input.rs
@@ -2,7 +2,7 @@ extern crate peg;
 
 peg::parser!(grammar borrows() for str {
     use std::borrow::{ToOwned, Cow};
-   
+
     pub rule borrowed() -> &'input str
         = $(['a'..='z']+)
 
@@ -14,7 +14,7 @@ peg::parser!(grammar borrows() for str {
 use self::borrows::*;
 
 fn main() {
-    assert_eq!(borrowed("abcd"), Ok("abcd"));
-    assert_eq!(&*lifetime_parameter("abcd").unwrap(), "abcd");
-    assert_eq!(&*lifetime_parameter("COW").unwrap(), "cow");
+    assert_eq!(borrowed("abcd").into_result(), Ok("abcd"));
+    assert_eq!(&*lifetime_parameter("abcd").into_result().unwrap(), "abcd");
+    assert_eq!(&*lifetime_parameter("COW").into_result().unwrap(), "cow");
 }

--- a/tests/run-pass/bytes.rs
+++ b/tests/run-pass/bytes.rs
@@ -9,5 +9,5 @@ parser!{
 }
 
 fn main() {
-    assert_eq!(byteparser::commands(b">asdf\0>xyz\0"), Ok(vec![&b"asdf"[..], &b"xyz"[..]]));
+    assert_eq!(byteparser::commands(b">asdf\0>xyz\0").into_result(), Ok(vec![&b"asdf"[..], &b"xyz"[..]]));
 }

--- a/tests/run-pass/conditional_block.rs
+++ b/tests/run-pass/conditional_block.rs
@@ -38,18 +38,18 @@ peg::parser!( grammar parse() for str {
 });
 
 fn main() {
-    assert_eq!(parse::dec_byte("0"), Ok(0));
-    assert_eq!(parse::dec_byte("255"), Ok(255));
-    assert_eq!(parse::dec_byte("1"), Ok(1));
-    assert!(parse::dec_byte("256").is_err());
-    assert!(parse::dec_byte("1234").is_err());
+    assert_eq!(parse::dec_byte("0").into_result(), Ok(0));
+    assert_eq!(parse::dec_byte("255").into_result(), Ok(255));
+    assert_eq!(parse::dec_byte("1").into_result(), Ok(1));
+    assert!(parse::dec_byte("256").into_result().is_err());
+    assert!(parse::dec_byte("1234").into_result().is_err());
 
-    assert!(parse::xml("<a></a>").is_ok());
-    assert!(parse::xml("<a><b></b><c></c></a>").is_ok());
-    assert!(parse::xml("<a><b><c></b></c></a>").is_err());
-    assert!(parse::xml("<a><b></c><c></b></a>").is_err());
+    assert!(parse::xml("<a></a>").into_result().is_ok());
+    assert!(parse::xml("<a><b></b><c></c></a>").into_result().is_ok());
+    assert!(parse::xml("<a><b><c></b></c></a>").into_result().is_err());
+    assert!(parse::xml("<a><b></c><c></b></a>").into_result().is_err());
 
-    assert!(parse::return_early("a").unwrap_err().expected.tokens().any(|e| e == "number"));
-    assert!(parse::return_early("123").unwrap_err().expected.tokens().any(|e| e == "smaller number"));
-    assert_eq!(parse::return_early("99").unwrap(), 99);
+    assert!(parse::return_early("a").into_result().unwrap_err().expected.tokens().any(|e| e == "number"));
+    assert!(parse::return_early("123").into_result().unwrap_err().expected.tokens().any(|e| e == "smaller number"));
+    assert_eq!(parse::return_early("99").into_result().unwrap(), 99);
 }

--- a/tests/run-pass/crate_import.rs
+++ b/tests/run-pass/crate_import.rs
@@ -16,5 +16,5 @@ mod types {
 
 
 fn main() {
-    assert_eq!(foo_parser::foo("foo"), Ok(crate::types::Foo));
+    assert_eq!(foo_parser::foo("foo").into_result(), Ok(crate::types::Foo));
 }

--- a/tests/run-pass/errors.rs
+++ b/tests/run-pass/errors.rs
@@ -15,9 +15,9 @@ peg::parser!{ grammar parser() for str {
 
 fn main() {
     // errors at eof
-    assert_eq!(parser::one_letter("t"), Ok(()));
+    assert_eq!(parser::one_letter("t").into_result(), Ok(()));
 
-    let err = parser::one_letter("tt").unwrap_err();
+    let err = parser::one_letter("tt").into_result().unwrap_err();
     assert_eq!(err.location.line, 1);
     assert_eq!(err.location.column, 2);
     assert_eq!(err.location.offset, 1);
@@ -28,7 +28,7 @@ fn main() {
 aaaa
 aaaaaa
 aaaabaaaa
-"#).unwrap_err();
+"#).into_result().unwrap_err();
 
     assert_eq!(err.location.line, 4);
     assert_eq!(err.location.column, 5);
@@ -36,27 +36,27 @@ aaaabaaaa
     assert_eq!(format!("{}", err.expected), r#"one of "\n", "a", EOF"#);
 
     // error position reporting
-    let err = parser::error_pos("aab\n").unwrap_err();
+    let err = parser::error_pos("aab\n").into_result().unwrap_err();
     assert_eq!(err.location.line, 1);
     assert_eq!(err.location.column, 3);
     assert_eq!(err.location.offset, 2);
     assert_eq!(err.expected.to_string(), r#"one of "\n", "\r", "a", EOF"#);
 
-    let err = parser::error_pos("aa\naaaa\nbaaa\n").unwrap_err();
+    let err = parser::error_pos("aa\naaaa\nbaaa\n").into_result().unwrap_err();
     assert_eq!(err.location.line, 3);
     assert_eq!(err.location.column, 1);
 
-    let err = parser::error_pos("aa\naaaa\naaab\naa").unwrap_err();
+    let err = parser::error_pos("aa\naaaa\naaab\naa").into_result().unwrap_err();
     assert_eq!(err.location.line, 3);
     assert_eq!(err.location.column, 4);
 
-    let err = parser::error_pos("aa\r\naaaa\r\naaab\r\naa").unwrap_err();
+    let err = parser::error_pos("aa\r\naaaa\r\naaab\r\naa").into_result().unwrap_err();
     assert_eq!(err.location.line, 3);
     assert_eq!(err.location.column, 4);
 
-    parser::q("a1").unwrap();
-    parser::q("a1b2").unwrap();
-    let err = parser::q("a1bb").unwrap_err();
+    parser::q("a1").into_result().unwrap();
+    parser::q("a1b2").into_result().unwrap();
+    let err = parser::q("a1bb").into_result().unwrap_err();
     assert_eq!(err.location.offset, 2);
     assert_eq!(err.expected.to_string(), "one of EOF, letter followed by number");
 }

--- a/tests/run-pass/keyval.rs
+++ b/tests/run-pass/keyval.rs
@@ -18,5 +18,5 @@ fn main() {
     let mut expected = HashMap::new();
     expected.insert(1, 3);
     expected.insert(2, 4);
-    assert_eq!(keyval::keyvals("1:3\n2:4"), Ok(expected));
+    assert_eq!(keyval::keyvals("1:3\n2:4").into_result(), Ok(expected));
 }

--- a/tests/run-pass/lifetimes.rs
+++ b/tests/run-pass/lifetimes.rs
@@ -25,7 +25,7 @@ fn main() {
     assert_eq!(
         tokenparser::program(
             &[Token(&input[0..1]), Token(&input[1..4]), Token(&input[4..5]), Token(&input[5..8]), Token(&input[8..9])],
-        ),
+        ).into_result(),
         Ok(vec!["one", "two"])
     );
 }

--- a/tests/run-pass/memoization.rs
+++ b/tests/run-pass/memoization.rs
@@ -11,5 +11,5 @@ peg::parser!{ grammar memo() for str {
 }}
 
 fn main() {
-    assert_eq!(memo::parse("abc zzz"), Ok(()));
+    assert_eq!(memo::parse("abc zzz").into_result(), Ok(()));
 }

--- a/tests/run-pass/no_eof.rs
+++ b/tests/run-pass/no_eof.rs
@@ -9,5 +9,5 @@ parser!{
 }
 
 fn main() {
-    assert_eq!(g::foo(b"foobar"), Ok(()));
+    assert_eq!(g::foo(b"foobar").into_result(), Ok(()));
 }

--- a/tests/run-pass/optional.rs
+++ b/tests/run-pass/optional.rs
@@ -10,7 +10,7 @@ peg::parser!( grammar test_grammar() for str {
 use self::test_grammar::*;
 
 fn main() {
-    assert_eq!(options("abc"), Ok(None));
-    assert_eq!(options("abcdef"), Ok(Some(())));
-    assert!(options("def").is_err());
+    assert_eq!(options("abc").into_result(), Ok(None));
+    assert_eq!(options("abcdef").into_result(), Ok(Some(())));
+    assert!(options("def").into_result().is_err());
 }

--- a/tests/run-pass/pattern.rs
+++ b/tests/run-pass/pattern.rs
@@ -7,12 +7,12 @@ peg::parser!( grammar test() for str {
 });
 
 fn main() {
-    assert!(test::alphanumeric("azAZ09").is_ok());
-    assert!(test::alphanumeric("@").is_err());
+    assert!(test::alphanumeric("azAZ09").into_result().is_ok());
+    assert!(test::alphanumeric("@").into_result().is_err());
 
-    assert_eq!(test::inverted_pat("(asdf)"), Ok("asdf"));
+    assert_eq!(test::inverted_pat("(asdf)").into_result(), Ok("asdf"));
 
-    assert_eq!(test::capture("x"), Ok('x'));
-    assert_eq!(test::capture2("a1"), Ok(('a', '1')));
+    assert_eq!(test::capture("x").into_result(), Ok('x'));
+    assert_eq!(test::capture2("a1").into_result(), Ok(('a', '1')));
 }
 

--- a/tests/run-pass/pos_neg_assert.rs
+++ b/tests/run-pass/pos_neg_assert.rs
@@ -12,15 +12,15 @@ peg::parser!( grammar lookahead() for str {
 
 fn main() {
     // negative lookahead
-    assert!(lookahead::consonants("qwrty").is_ok());
-    assert!(lookahead::consonants("rust").is_err());
+    assert!(lookahead::consonants("qwrty").into_result().is_ok());
+    assert!(lookahead::consonants("rust").into_result().is_err());
 
     // expected characters in negative lookahead should not be reported in parse error messages
-    let err = lookahead::neg_lookahead_err("ac").err().unwrap();
+    let err = lookahead::neg_lookahead_err("ac").into_result().err().unwrap();
     assert_eq!(err.expected.tokens().count(), 1, "expected set includes: {}", err.expected);
     assert_eq!(err.location.offset, 1);
 
     // positive lookahead
-    assert_eq!(lookahead::lookahead_result("abcd"), Ok("abc"));
-    assert!(lookahead::lookahead_result("abc").is_err());
+    assert_eq!(lookahead::lookahead_result("abcd").into_result(), Ok("abc"));
+    assert!(lookahead::lookahead_result("abc").into_result().is_err());
 }

--- a/tests/run-pass/position.rs
+++ b/tests/run-pass/position.rs
@@ -8,5 +8,5 @@ peg::parser!(grammar test_grammar() for str {
 use self::test_grammar::*;
 
 fn main() {
-    assert_eq!(position("aaaabbb").unwrap(), (0, 4, 7));
+    assert_eq!(position("aaaabbb").into_result().unwrap(), (0, 4, 7));
 }

--- a/tests/run-pass/recovery.rs
+++ b/tests/run-pass/recovery.rs
@@ -1,0 +1,106 @@
+extern crate peg;
+
+// The sample grammar from the paper https://arxiv.org/abs/1806.11150
+peg::parser!(grammar test_grammar() for str {
+    rule _ = quiet!{ [' ' | '\r' | '\n' | '\t']* }
+    rule name() = ['a'..='z' | 'A'..='Z' | '_'] ['a'..='z' | 'A'..='Z' | '0'..='9' | '_']*
+    rule number() = ['0'..='9']+
+    pub rule prog()
+        = "public" _ "class" _ name() _ "{" _ "public" _ "static" _ "void" _ "main" _ "(" _ "String" _ "[" _ "]" _ name() _ ")" _ block_stmt() _ "}" _
+    rule block_stmt() = "{" _ (stmt() _)* _ error_unless!{ "}" | "missing end of block" skip_to_rcur() }
+    rule skip_to_rcur() = ("{" skip_to_rcur() / [^ '{' | '}'])* "}"
+    rule stmt() = if_stmt() / while_stmt() / print_stmt() / dec_stmt() / assign_stmt() / block_stmt()
+    rule if_stmt() = "if" _ "(" _ exp() _ ")" _ stmt() _ ("else" _ stmt() _)?
+    rule while_stmt() = "while" _ "(" _ exp() _ ")" _ stmt()
+    rule dec_stmt() = "int" _ name() _ ( "=" _ exp() _)? ";"
+    rule assign_stmt() = name() _ "=" _ exp() _ error_unless!{ ";" | "missing semicolon in assignment" }
+    rule print_stmt() = "System.out.println" _ "(" _ exp() _ ")" _ ";" / "provoke_error" error!{"provoked error" [^';']* ";"}
+    rule exp() = rel_exp() _ ("==" _ rel_exp() _)*
+    rule rel_exp() = add_exp() _ ("<" _ add_exp() _)*
+    rule add_exp() = mul_exp() _ (['+' | '-'] _ mul_exp() _)*
+    rule mul_exp() = atom_exp() _ (['*' | '/'] _ atom_exp() _)*
+    rule atom_exp() = "(" _ exp() _ ")" / number() / name()
+});
+
+use std::fmt::Debug;
+use self::test_grammar::*;
+use peg::{ParseResults, ParseResult};
+use peg::error::{ParseError, ParseErr};
+
+fn expect_failed<T: Debug, L: Debug>(results: ParseResults<T, L>) -> (ParseError<L>, Vec<ParseErr<L>>) {
+    match results {
+        ParseResults { result: ParseResult::Failed(fail), errors } => (fail, errors),
+        r => panic!("Unexpected {:?}", r),
+    }
+}
+
+fn expect_error<T: Debug, L: Debug>(results: ParseResults<T, L>) -> (ParseErr<L>, Vec<ParseErr<L>>) {
+    match results {
+        ParseResults { result: ParseResult::Error(error), errors } => (error, errors),
+        r => panic!("Unexpected {:?}", r),
+    }
+}
+
+fn main() {
+    let input = concat!(
+        "public class Example {\n",
+        "  public static void main(String[] args) {\n",
+        "    int n = 5;\n",
+        "    int f = 1;\n",
+        "    while (0 < n) {\n",
+        "      f = f * n;\n",
+        "      n = n - 1\n",
+        "    };\n",
+        "    System.out.println(f);\n",
+        "  }\n",
+        "}\n"
+    );
+
+    // Parses successfully, but recovers from two errors.
+    let r = prog(input);
+    assert_eq!(r.clone().unwrap(), ());
+    assert_eq!(r.errors.len(), 2);
+    assert_eq!(r.errors[0].location.line, 8);
+    assert_eq!(r.errors[0].location.column, 5);
+    assert_eq!(r.errors[0].error, "missing semicolon in assignment");
+    assert_eq!(r.errors[1].location.line, 8);
+    assert_eq!(r.errors[1].location.column, 6);
+    assert_eq!(r.errors[1].error, "missing end of block");
+
+    // Alter input slightly to fail on first line.
+    // No rule to recover from this, so the parse fails.
+    let input2 = input.replace("public", "private");
+    let (fail, errors) = expect_failed(prog(&input2));
+    assert_eq!(fail.location.line, 1);
+    assert_eq!(fail.location.column, 1);
+    assert_eq!(format!("{}", fail.expected), r#""public""#);
+    assert_eq!(errors, vec![]);
+
+    // Alter input slightly to strip last two closing braces.
+    // Recovers from missing semicolon, but then when the block is not closed
+    // the recovery rule cannot find a '}' to close the block,
+    // so it returns an error.
+    let input3 = input.replace("}\n}\n", "");
+    let (error, errors) = expect_error(prog(&input3));
+    assert_eq!(error.location.line, 8);
+    assert_eq!(error.location.column, 6);
+    assert_eq!(error.error, "missing end of block");
+    assert_eq!(errors.len(), 1);
+    assert_eq!(errors[0].error, "missing semicolon in assignment");
+
+    // Provoke an error using the error! expression.
+    // Parses successfully, but recovers from three errors.
+    let input4 = input.replace("int f = 1", "provoke_error with a bunch of stuff that goes here");
+    let r = prog(&input4);
+    assert_eq!(r.clone().unwrap(), ());
+    assert_eq!(r.errors.len(), 3);
+    assert_eq!(r.errors[0].location.line, 4);
+    assert_eq!(r.errors[0].location.column, 18);
+    assert_eq!(r.errors[0].error, "provoked error");
+    assert_eq!(r.errors[1].location.line, 8);
+    assert_eq!(r.errors[1].location.column, 5);
+    assert_eq!(r.errors[1].error, "missing semicolon in assignment");
+    assert_eq!(r.errors[2].location.line, 8);
+    assert_eq!(r.errors[2].location.column, 6);
+    assert_eq!(r.errors[2].error, "missing end of block");
+}

--- a/tests/run-pass/renamed_imports.rs
+++ b/tests/run-pass/renamed_imports.rs
@@ -11,5 +11,5 @@ peg::parser!(grammar test_grammar() for str {
 use self::test_grammar::*;
 
 fn main() {
-    assert_eq!(renamed_imports("").unwrap(), (42, 42));
+    assert_eq!(renamed_imports("").into_result().unwrap(), (42, 42));
 }

--- a/tests/run-pass/repeats.rs
+++ b/tests/run-pass/repeats.rs
@@ -32,32 +32,32 @@ peg::parser!( grammar repeats() for str {
 use repeats::*;
 
 fn main() {
-    assert_eq!(list("5"), Ok(vec![5]));
-    assert_eq!(list("1,2,3,4"), Ok(vec![1,2,3,4]));
+    assert_eq!(list("5").into_result(), Ok(vec![5]));
+    assert_eq!(list("1,2,3,4").into_result(), Ok(vec![1,2,3,4]));
 
-    assert!(repeat_n("123").is_err());
-    assert_eq!(repeat_n("1234"), Ok(vec![1,2,3,4]));
-    assert!(repeat_n("12345").is_err());
+    assert!(repeat_n("123").into_result().is_err());
+    assert_eq!(repeat_n("1234").into_result(), Ok(vec![1,2,3,4]));
+    assert!(repeat_n("12345").into_result().is_err());
 
-    assert!(repeat_min("").is_err());
-    assert!(repeat_min("1").is_err());
-    assert_eq!(repeat_min("12"), Ok(vec![1,2]));
-    assert_eq!(repeat_min("123"), Ok(vec![1,2,3]));
+    assert!(repeat_min("").into_result().is_err());
+    assert!(repeat_min("1").into_result().is_err());
+    assert_eq!(repeat_min("12").into_result(), Ok(vec![1,2]));
+    assert_eq!(repeat_min("123").into_result(), Ok(vec![1,2,3]));
 
-    assert_eq!(repeat_max(""), Ok(vec![]));
-    assert_eq!(repeat_max("1"), Ok(vec![1]));
-    assert_eq!(repeat_max("12"), Ok(vec![1,2]));
-    assert!(repeat_max("123").is_err());
+    assert_eq!(repeat_max("").into_result(), Ok(vec![]));
+    assert_eq!(repeat_max("1").into_result(), Ok(vec![1]));
+    assert_eq!(repeat_max("12").into_result(), Ok(vec![1,2]));
+    assert!(repeat_max("123").into_result().is_err());
 
-    assert!(repeat_min_max("").is_err());
-    assert!(repeat_min_max("1").is_err());
-    assert_eq!(repeat_min_max("12"), Ok(vec![1,2]));
-    assert_eq!(repeat_min_max("123"), Ok(vec![1,2,3]));
-    assert!(repeat_min_max("1234").is_err());
+    assert!(repeat_min_max("").into_result().is_err());
+    assert!(repeat_min_max("1").into_result().is_err());
+    assert_eq!(repeat_min_max("12").into_result(), Ok(vec![1,2]));
+    assert_eq!(repeat_min_max("123").into_result(), Ok(vec![1,2,3]));
+    assert!(repeat_min_max("1234").into_result().is_err());
 
-    assert!(repeat_sep_3("1,2").is_err());
-    assert!(repeat_sep_3("1,2,3,4").is_err());
-    assert_eq!(repeat_sep_3("1,2,3"), Ok(vec![1,2,3]));
+    assert!(repeat_sep_3("1,2").into_result().is_err());
+    assert!(repeat_sep_3("1,2,3,4").into_result().is_err());
+    assert_eq!(repeat_sep_3("1,2,3").into_result(), Ok(vec![1,2,3]));
 
-    assert_eq!(repeat_variable("1a3abc222"), Ok(vec!["a", "abc", "22"]));
+    assert_eq!(repeat_variable("1a3abc222").into_result(), Ok(vec!["a", "abc", "22"]));
 }

--- a/tests/run-pass/rule_args.rs
+++ b/tests/run-pass/rule_args.rs
@@ -16,11 +16,11 @@ peg::parser!( grammar ra() for str {
     rule ident() = ['a'..='z']+
     rule _ = [' ']*
     pub rule ifelse() = keyword("if") _ ident() _ keyword("then") _ ident() _ keyword("else") _ ident()
-    
+
     pub rule repeated_a(i: usize) = ['a']*<{i}>
 
     rule i(literal: &'static str) = input:$([_]*<{literal.len()}>) {? if input.eq_ignore_ascii_case(literal) { Ok(()) } else { Err(literal) } }
-    
+
     pub rule test_i() = i("foo") i("bar")
 
     rule recursive(r: rule<()>) = " " recursive(r) // Issue #226
@@ -36,19 +36,19 @@ peg::parser!( grammar ra() for str {
 use ra::*;
 
 fn main() {
-    assert_eq!(list("1,2,3,4"), Ok(vec![1,2,3,4]));
-    assert_eq!(array("[1,1,2,3,5,]"), Ok(vec![1,1,2,3,5]));
+    assert_eq!(list("1,2,3,4").into_result(), Ok(vec![1,2,3,4]));
+    assert_eq!(array("[1,1,2,3,5,]").into_result(), Ok(vec![1,1,2,3,5]));
 
-    assert!(ifelse("if foo then x else y").is_ok());
-    assert!(ifelse("iffoothenxelsey").is_err());
+    assert!(ifelse("if foo then x else y").into_result().is_ok());
+    assert!(ifelse("iffoothenxelsey").into_result().is_err());
 
-    assert!(repeated_a("aa", 2).is_ok());
-    assert!(repeated_a("aaa", 2).is_err());
-    assert!(repeated_a("aaaaa", 5).is_ok());
+    assert!(repeated_a("aa", 2).into_result().is_ok());
+    assert!(repeated_a("aaa", 2).into_result().is_err());
+    assert!(repeated_a("aaaaa", 5).into_result().is_ok());
 
-    assert!(test_i("fOoBaR").is_ok());
-    assert!(test_i("fOoBaZ").is_err());
-    assert!(test_i("fOoX").is_err());
+    assert!(test_i("fOoBaR").into_result().is_ok());
+    assert!(test_i("fOoBaZ").into_result().is_err());
+    assert!(test_i("fOoX").into_result().is_err());
 
-    use_complex_args("").ok();
+    use_complex_args("").into_result().ok();
 }

--- a/tests/run-pass/test-hygiene.rs
+++ b/tests/run-pass/test-hygiene.rs
@@ -23,6 +23,6 @@ realpeg::parser!{
 }
 
 fn main() {
-    assert_eq!(p::number("12345"), Ok(12345.0))
+    assert_eq!(p::number("12345").into_result(), Ok(12345.0))
 }
 

--- a/tests/run-pass/tokens.rs
+++ b/tests/run-pass/tokens.rs
@@ -13,5 +13,5 @@ peg::parser!{
 }
 
 fn main() {
-    assert_eq!(tokenparser::list(&[Token::Open, Token::Number(5), Token::Comma, Token::Number(7), Token::Close]), Ok((5, 7)));
+    assert_eq!(tokenparser::list(&[Token::Open, Token::Number(5), Token::Comma, Token::Number(7), Token::Close]).into_result(), Ok((5, 7)));
 }

--- a/tests/run-pass/utf8.rs
+++ b/tests/run-pass/utf8.rs
@@ -11,5 +11,5 @@ use self::test_grammar::*;
 // threw an ugly panic!() when we compared unequal character
 // boundaries.. this popped up while parsing unicode
 fn main() {
-    assert!(boundaries("f↙↙↙↙").is_err());
+    assert!(boundaries("f↙↙↙↙").into_result().is_err());
 }


### PR DESCRIPTION
When using a parser in the context of an IDE or a compiler, it is desirable to be able to recover from errors, returning a best-efforts parse anyway and reporting all errors rather than just the first. This PR extends `rust-peg` with support for this, based on [_Syntax Error Recovery in Parsing Expression Grammars_](https://arxiv.org/abs/1806.11150) and [_Automatic Syntax Error Reporting and Recovery in Parsing Expression Grammars_](https://arxiv.org/abs/1905.02145).

@kevinmehall I'm not sure if multiple errors is something you want to support, and I'm not 100% confident I've chosen the best syntax, so I would be grateful for your feedback.

Adding error recovery necessarily introduces a breaking change - the public return type of a parser has to be able to include multiple errors. To ease upgrade, the new type has an `.into_result()` method which returns the original result type.

There are three expressions for raising an error:

* `error!{ "message" e2 }` is the simplest form. It reports an error with the given message at the current location, then attempts to recover by parsing `e2` instead.
* `error_if!{ e1 | "message" e2 }` allows the error to be reported at an earlier location. It attempts to parse `e1`; if it succeeds it reports an error with the given message at the start of `e1`, then attempts to recover by parsing `e2` instead.
* `error_unless!{ e1 | "message" e2 }` is shorthand for a choice expression. It is useful in order to report an error when an expression fails to match. It attempts to parse `e1`; if it fails it reports an error with the given message at the current location, then attempts to recover by parsing `e2` instead.

The result of the parser (`ParseResults`) contains the final value, failure, or error, along with a list of all errors we recovered from during the parse.

Full documentation is provided in src/lib.rs.

## Changes

* The new expression forms are represented in the AST by `RecoverIfExpr` and `RecoverUnlessExpr` (the simple `error!` form is sugar for `error_if!` with an empty `e1`).
* Most test and example code has been upgraded by inserting `.into_result()`.
* New tests are added as `recovery.rs` (the example from the paper) and `arithmetic_recovery.rs` (a worked example of how to use the power of the new features).
* In the parser, `RuleResult` now has a third alternative (beyond `Matched` and `Failed`): `Error`. This is handled largely following the rules from the papers cited, although a few improvements and optimizations have been added as noted in the comment in src/lib.rs.
* Similarly `ErrorState` gains a set of `errors` recovered from so far.
* I made a few renamings for clarity, since now "error" and "failure" are two different things - e.g., `into_parse_error` is now `into_failure`, since it creates a failure not an error, and `reparsing_on_error` becomes `reparsing_on_failure`. 
* In a few places in the code I added comments explaining the meaning of fields and methods (as I figured them out :-) ).

Let me know if you have any questions!

