### PR TITLE
Add no_std support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,10 +3,47 @@
 version = 3
 
 [[package]]
+name = "ahash"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
+dependencies = [
+ "getrandom",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "getrandom"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9be70c98951c83b8d2f8f60d7065fa6d5146873094452a1008da8c2f1e4205ad"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
 name = "glob"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
+
+[[package]]
+name = "hashbrown"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c21d40587b92fa6a6c6e3c1bdbf87d75511db5672f9c93175574b3a00df1758"
+dependencies = [
+ "ahash",
+]
 
 [[package]]
 name = "itoa"
@@ -21,9 +58,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
+name = "libc"
+version = "0.2.123"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb691a747a7ab48abc15c5b42066eaafde10dc427e3b6ee2a1cf43db04c763bd"
+
+[[package]]
+name = "once_cell"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87f3e037eac156d1775da914196f0f37741a274155e34a0b7e427c35d2a2ecb9"
+
+[[package]]
 name = "peg"
 version = "0.8.0"
 dependencies = [
+ "hashbrown",
  "peg-macros",
  "peg-runtime",
  "trybuild",
@@ -33,6 +83,7 @@ dependencies = [
 name = "peg-macros"
 version = "0.8.0"
 dependencies = [
+ "cfg-if",
  "peg-runtime",
  "proc-macro2",
  "quote",
@@ -145,6 +196,18 @@ name = "unicode-xid"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
+
+[[package]]
+name = "version_check"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "wasi"
+version = "0.10.2+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "winapi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
+hashbrown = { version = "0.12.0", optional = true }
 peg-macros = { path = "./peg-macros", version = "= 0.8.0" }
 peg-runtime = { path = "./peg-runtime", version = "= 0.8.0" }
 
@@ -26,6 +27,5 @@ path = "tests/trybuild.rs"
 harness = false
 
 [features]
-default = ["std"]
-std = []
 trace = ["peg-macros/trace"]
+no_std = ["peg-macros/no_std", "peg-runtime/no_std"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,4 +26,6 @@ path = "tests/trybuild.rs"
 harness = false
 
 [features]
+default = ["std"]
+std = []
 trace = ["peg-macros/trace"]

--- a/benches/expr.rs
+++ b/benches/expr.rs
@@ -3,6 +3,8 @@ extern crate peg;
 
 extern crate test;
 
+#[cfg(feature = "no_std")] #[macro_use] extern crate alloc;
+
 use test::Bencher;
 
 peg::parser!(grammar parser() for str {

--- a/benches/json.rs
+++ b/benches/json.rs
@@ -3,6 +3,8 @@ extern crate peg;
 
 extern crate test;
 
+#[cfg(feature = "no_std")] #[macro_use] extern crate alloc;
+
 use test::Bencher;
 
 peg::parser!(grammar parser() for str {

--- a/peg-macros/Cargo.toml
+++ b/peg-macros/Cargo.toml
@@ -11,9 +11,12 @@ edition = "2018"
 quote = "1.0"
 proc-macro2 = "1.0.24"
 peg-runtime = { version = "= 0.8.0", path = "../peg-runtime" }
+cfg-if = "1.0.0"
 
 [features]
 trace = []
+no_std = []
+hashbrown = []
 
 [lib]
 proc-macro = true

--- a/peg-macros/bin.rs
+++ b/peg-macros/bin.rs
@@ -15,6 +15,10 @@ use std::process;
 // requires `::peg` paths.
 extern crate peg_runtime as peg;
 
+#[cfg(feature = "no_std")] 
+#[macro_use] 
+extern crate alloc;
+
 mod analysis;
 mod ast;
 mod grammar;

--- a/peg-macros/lib.rs
+++ b/peg-macros/lib.rs
@@ -14,6 +14,8 @@ mod grammar;
 mod tokens;
 mod translate;
 
+#[cfg(feature = "no_std")] extern crate alloc;
+
 /// The main macro for creating a PEG parser.
 ///
 /// For the grammar syntax, see the `peg` crate documentation.

--- a/peg-runtime/Cargo.toml
+++ b/peg-runtime/Cargo.toml
@@ -9,3 +9,6 @@ edition = "2018"
 
 [lib]
 path = "lib.rs"
+
+[features]
+no_std = []

--- a/peg-runtime/error.rs
+++ b/peg-runtime/error.rs
@@ -1,13 +1,15 @@
 //! Parse error reporting
 
 use crate::{Parse, RuleResult};
-use std::collections::HashSet;
-use std::fmt::{self, Debug, Display};
+use core::fmt::{self, Debug, Display};
+
+#[cfg(feature = "no_std")] use alloc::{collections::btree_set::BTreeSet, vec::Vec};
+#[cfg(not(feature = "no_std"))] use std::collections::BTreeSet;
 
 /// A set of literals or names that failed to match
 #[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ExpectedSet {
-    expected: HashSet<&'static str>,
+    expected: BTreeSet<&'static str>,
 }
 
 impl ExpectedSet {
@@ -49,7 +51,7 @@ pub struct ParseError<L> {
 }
 
 impl<L: Display> Display for ParseError<L> {
-    fn fmt(&self, fmt: &mut ::std::fmt::Formatter) -> ::std::result::Result<(), ::std::fmt::Error> {
+    fn fmt(&self, fmt: &mut ::core::fmt::Formatter) -> ::core::result::Result<(), ::core::fmt::Error> {
         write!(
             fmt,
             "error at {}: expected {}",
@@ -58,6 +60,8 @@ impl<L: Display> Display for ParseError<L> {
     }
 }
 
+// Unfortuantely, std::error::Error never made it into core::error
+#[cfg(not(feature = "no_std"))]
 impl<L: Display + Debug> ::std::error::Error for ParseError<L> {
     fn description(&self) -> &str {
         "parse error"
@@ -79,7 +83,7 @@ impl ErrorState {
             suppress_fail: 0,
             reparsing_on_error: false,
             expected: ExpectedSet {
-                expected: HashSet::new(),
+                expected: BTreeSet::new(),
             },
         }
     }

--- a/peg-runtime/lib.rs
+++ b/peg-runtime/lib.rs
@@ -1,4 +1,8 @@
-use std::fmt::Display;
+#![cfg_attr(feature = "no_std", no_std)]
+
+#[cfg(feature = "no_std")] extern crate alloc;
+
+use core::fmt::Display;
 
 pub mod error;
 mod slice;
@@ -7,7 +11,7 @@ pub mod str;
 /// The result type used internally in the parser.
 ///
 /// You'll only need this if implementing the `Parse*` traits for a custom input
-/// type. The public API of a parser adapts errors to `std::result::Result`.
+/// type. The public API of a parser adapts errors to `core::result::Result`.
 #[derive(Clone, PartialEq, PartialOrd, Eq, Ord, Debug, Hash)]
 pub enum RuleResult<T> {
     Matched(usize, T),

--- a/peg-runtime/str.rs
+++ b/peg-runtime/str.rs
@@ -1,7 +1,7 @@
 //! Utilities for `str` input
 
 use super::{Parse, ParseElem, ParseLiteral, ParseSlice, RuleResult};
-use std::fmt::Display;
+use core::fmt::Display;
 
 /// Line and column within a string
 #[derive(PartialEq, Eq, Debug, Clone)]
@@ -17,7 +17,7 @@ pub struct LineCol {
 }
 
 impl Display for LineCol {
-    fn fmt(&self, fmt: &mut ::std::fmt::Formatter) -> ::std::result::Result<(), ::std::fmt::Error> {
+    fn fmt(&self, fmt: &mut ::core::fmt::Formatter) -> ::core::result::Result<(), ::core::fmt::Error> {
         write!(fmt, "{}:{}", self.line, self.column)
     }
 }


### PR DESCRIPTION
This patch will replace the use of `std` crate to their `no_std` equivalent. One notable change is that `peg_runtime::error::ExpectedSet` would use BTreeSet instead of HashSet before, as I observed that the expected set order is random during a parser debug. 

I did not add a HashSet shim for `peg_runtime::error::ExpectedSet` that and replaced it because this technically means the ABI is changed. Although it wouldn't hurt that much since it is not exposed. This does imply that the expected order will be based on [lexicographical order](https://doc.rust-lang.org/std/primitive.str.html#impl-Ord) and I do think this would make it more stable which is a nice thing.