### PR TITLE
Stop implicitly adding `&'input` to input type

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Parse a comma-separated list of numbers surrounded by brackets into a `Vec<u32>`
 
 ```rust
 peg::parser!{
-  grammar list_parser() for str {
+  grammar list_parser() for &str {
     rule number() -> u32
       = n:$(['0'..='9']+) {? n.parse().or(Err("u32")) }
 

--- a/benches/expr.rs
+++ b/benches/expr.rs
@@ -5,7 +5,7 @@ extern crate test;
 
 use test::Bencher;
 
-peg::parser!(grammar parser() for str {
+peg::parser!(grammar parser() for &str {
 crate rule expr() = eq()
 
 #[cache]

--- a/benches/json.rs
+++ b/benches/json.rs
@@ -5,7 +5,7 @@ extern crate test;
 
 use test::Bencher;
 
-peg::parser!(grammar parser() for str {
+peg::parser!(grammar parser() for &str {
 // JSON grammar (RFC 4627). Note that this only checks for valid JSON and does not build a syntax
 // tree.
 

--- a/peg-macros/grammar.rs
+++ b/peg-macros/grammar.rs
@@ -2,15 +2,13 @@
 pub mod peg {
     #[allow(unused_imports)]
     use super::*;
-    type Input = FlatTokenStream;
-    type PositionRepr = <Input as ::peg::Parse>::PositionRepr;
     #[allow(unused_parens)]
-    struct ParseState<'input> {
-        _phantom: ::std::marker::PhantomData<(&'input ())>,
+    struct ParseState {
+        _phantom: ::std::marker::PhantomData<()>,
         primary_cache: ::std::collections::HashMap<usize, ::peg::RuleResult<SpannedExpr>>,
     }
-    impl<'input> ParseState<'input> {
-        fn new() -> ParseState<'input> {
+    impl ParseState {
+        fn new() -> ParseState {
             ParseState {
                 _phantom: ::std::marker::PhantomData,
                 primary_cache: ::std::collections::HashMap::new(),
@@ -21,9 +19,12 @@ pub mod peg {
     use crate::ast::*;
     use crate::tokens::FlatTokenStream;
     use proc_macro2::{Delimiter, Group, Ident, Literal, Span, TokenStream};
-    pub fn peg_grammar<'input>(
-        __input: &'input Input,
-    ) -> ::std::result::Result<Grammar, ::peg::error::ParseError<PositionRepr>> {
+    pub fn peg_grammar(
+        __input: &FlatTokenStream,
+    ) -> ::std::result::Result<
+        Grammar,
+        ::peg::error::ParseError<<&FlatTokenStream as ::peg::Parse>::PositionRepr>,
+    > {
         #![allow(non_snake_case, unused)]
         let mut __err_state = ::peg::error::ErrorState::new(::peg::Parse::start(__input));
         let mut __state = ParseState::new();
@@ -63,9 +64,9 @@ pub mod peg {
         }
         Err(__err_state.into_parse_error(__input))
     }
-    fn __parse_peg_grammar<'input>(
-        __input: &'input Input,
-        __state: &mut ParseState<'input>,
+    fn __parse_peg_grammar(
+        __input: &FlatTokenStream,
+        __state: &mut ParseState,
         __err_state: &mut ::peg::error::ErrorState,
         __pos: usize,
     ) -> ::peg::RuleResult<Grammar> {
@@ -135,9 +136,9 @@ pub mod peg {
             }
         }
     }
-    fn __parse_rust_lifetime_params<'input>(
-        __input: &'input Input,
-        __state: &mut ParseState<'input>,
+    fn __parse_rust_lifetime_params(
+        __input: &FlatTokenStream,
+        __state: &mut ParseState,
         __err_state: &mut ::peg::error::ErrorState,
         __pos: usize,
     ) -> ::peg::RuleResult<Vec<TokenStream>> {
@@ -224,9 +225,9 @@ pub mod peg {
             }
         }
     }
-    fn __parse_grammar_args<'input>(
-        __input: &'input Input,
-        __state: &mut ParseState<'input>,
+    fn __parse_grammar_args(
+        __input: &FlatTokenStream,
+        __state: &mut ParseState,
         __err_state: &mut ::peg::error::ErrorState,
         __pos: usize,
     ) -> ::peg::RuleResult<Vec<(Ident, TokenStream)>> {
@@ -366,9 +367,9 @@ pub mod peg {
             }
         }
     }
-    fn __parse_peg_rule<'input>(
-        __input: &'input Input,
-        __state: &mut ParseState<'input>,
+    fn __parse_peg_rule(
+        __input: &FlatTokenStream,
+        __state: &mut ParseState,
         __err_state: &mut ::peg::error::ErrorState,
         __pos: usize,
     ) -> ::peg::RuleResult<Rule> {
@@ -477,9 +478,9 @@ pub mod peg {
             }
         }
     }
-    fn __parse_cacheflag<'input>(
-        __input: &'input Input,
-        __state: &mut ParseState<'input>,
+    fn __parse_cacheflag(
+        __input: &FlatTokenStream,
+        __state: &mut ParseState,
         __err_state: &mut ::peg::error::ErrorState,
         __pos: usize,
     ) -> ::peg::RuleResult<Option<Cache>> {
@@ -585,9 +586,9 @@ pub mod peg {
             }
         }
     }
-    fn __parse_no_eof_flag<'input>(
-        __input: &'input Input,
-        __state: &mut ParseState<'input>,
+    fn __parse_no_eof_flag(
+        __input: &FlatTokenStream,
+        __state: &mut ParseState,
         __err_state: &mut ::peg::error::ErrorState,
         __pos: usize,
     ) -> ::peg::RuleResult<bool> {
@@ -639,9 +640,9 @@ pub mod peg {
             }
         }
     }
-    fn __parse_rule_param_ty<'input>(
-        __input: &'input Input,
-        __state: &mut ParseState<'input>,
+    fn __parse_rule_param_ty(
+        __input: &FlatTokenStream,
+        __state: &mut ParseState,
         __err_state: &mut ::peg::error::ErrorState,
         __pos: usize,
     ) -> ::peg::RuleResult<RuleParamTy> {
@@ -737,9 +738,9 @@ pub mod peg {
             }
         }
     }
-    fn __parse_rule_params<'input>(
-        __input: &'input Input,
-        __state: &mut ParseState<'input>,
+    fn __parse_rule_params(
+        __input: &FlatTokenStream,
+        __state: &mut ParseState,
         __err_state: &mut ::peg::error::ErrorState,
         __pos: usize,
     ) -> ::peg::RuleResult<Vec<RuleParam>> {
@@ -838,9 +839,9 @@ pub mod peg {
             }
         }
     }
-    fn __parse_item<'input>(
-        __input: &'input Input,
-        __state: &mut ParseState<'input>,
+    fn __parse_item(
+        __input: &FlatTokenStream,
+        __state: &mut ParseState,
         __err_state: &mut ::peg::error::ErrorState,
         __pos: usize,
     ) -> ::peg::RuleResult<Item> {
@@ -871,9 +872,9 @@ pub mod peg {
             }
         }
     }
-    fn __parse_rust_doc_comment<'input>(
-        __input: &'input Input,
-        __state: &mut ParseState<'input>,
+    fn __parse_rust_doc_comment(
+        __input: &FlatTokenStream,
+        __state: &mut ParseState,
         __err_state: &mut ::peg::error::ErrorState,
         __pos: usize,
     ) -> ::peg::RuleResult<Option<TokenStream>> {
@@ -960,9 +961,9 @@ pub mod peg {
             ::peg::RuleResult::Failed => ::peg::RuleResult::Matched(__pos, None),
         }
     }
-    fn __parse_rust_visibility<'input>(
-        __input: &'input Input,
-        __state: &mut ParseState<'input>,
+    fn __parse_rust_visibility(
+        __input: &FlatTokenStream,
+        __state: &mut ParseState,
         __err_state: &mut ::peg::error::ErrorState,
         __pos: usize,
     ) -> ::peg::RuleResult<Option<TokenStream>> {
@@ -1031,9 +1032,9 @@ pub mod peg {
             ::peg::RuleResult::Failed => ::peg::RuleResult::Matched(__pos, None),
         }
     }
-    fn __parse_rust_use<'input>(
-        __input: &'input Input,
-        __state: &mut ParseState<'input>,
+    fn __parse_rust_use(
+        __input: &FlatTokenStream,
+        __state: &mut ParseState,
         __err_state: &mut ::peg::error::ErrorState,
         __pos: usize,
     ) -> ::peg::RuleResult<TokenStream> {
@@ -1125,9 +1126,9 @@ pub mod peg {
             }
         }
     }
-    fn __parse_rust_path<'input>(
-        __input: &'input Input,
-        __state: &mut ParseState<'input>,
+    fn __parse_rust_path(
+        __input: &FlatTokenStream,
+        __state: &mut ParseState,
         __err_state: &mut ::peg::error::ErrorState,
         __pos: usize,
     ) -> ::peg::RuleResult<()> {
@@ -1216,9 +1217,9 @@ pub mod peg {
             }
         }
     }
-    fn __parse_rust_type<'input>(
-        __input: &'input Input,
-        __state: &mut ParseState<'input>,
+    fn __parse_rust_type(
+        __input: &FlatTokenStream,
+        __state: &mut ParseState,
         __err_state: &mut ::peg::error::ErrorState,
         __pos: usize,
     ) -> ::peg::RuleResult<()> {
@@ -1459,9 +1460,9 @@ pub mod peg {
             }
         }
     }
-    fn __parse_rust_ty_path<'input>(
-        __input: &'input Input,
-        __state: &mut ParseState<'input>,
+    fn __parse_rust_ty_path(
+        __input: &FlatTokenStream,
+        __state: &mut ParseState,
         __err_state: &mut ::peg::error::ErrorState,
         __pos: usize,
     ) -> ::peg::RuleResult<()> {
@@ -1615,9 +1616,9 @@ pub mod peg {
             }
         }
     }
-    fn __parse_rust_ty_params<'input>(
-        __input: &'input Input,
-        __state: &mut ParseState<'input>,
+    fn __parse_rust_ty_params(
+        __input: &FlatTokenStream,
+        __state: &mut ParseState,
         __err_state: &mut ::peg::error::ErrorState,
         __pos: usize,
     ) -> ::peg::RuleResult<Vec<TokenStream>> {
@@ -1709,9 +1710,9 @@ pub mod peg {
             }
         }
     }
-    fn __parse_rust_generic_param<'input>(
-        __input: &'input Input,
-        __state: &mut ParseState<'input>,
+    fn __parse_rust_generic_param(
+        __input: &FlatTokenStream,
+        __state: &mut ParseState,
         __err_state: &mut ::peg::error::ErrorState,
         __pos: usize,
     ) -> ::peg::RuleResult<()> {
@@ -1947,18 +1948,18 @@ pub mod peg {
             }
         }
     }
-    fn __parse_expression<'input>(
-        __input: &'input Input,
-        __state: &mut ParseState<'input>,
+    fn __parse_expression(
+        __input: &FlatTokenStream,
+        __state: &mut ParseState,
         __err_state: &mut ::peg::error::ErrorState,
         __pos: usize,
     ) -> ::peg::RuleResult<SpannedExpr> {
         #![allow(non_snake_case, unused, clippy::redundant_closure_call)]
         __parse_choice(__input, __state, __err_state, __pos)
     }
-    fn __parse_choice<'input>(
-        __input: &'input Input,
-        __state: &mut ParseState<'input>,
+    fn __parse_choice(
+        __input: &FlatTokenStream,
+        __state: &mut ParseState,
         __err_state: &mut ::peg::error::ErrorState,
         __pos: usize,
     ) -> ::peg::RuleResult<SpannedExpr> {
@@ -2026,9 +2027,9 @@ pub mod peg {
             }
         }
     }
-    fn __parse_sequence<'input>(
-        __input: &'input Input,
-        __state: &mut ParseState<'input>,
+    fn __parse_sequence(
+        __input: &FlatTokenStream,
+        __state: &mut ParseState,
         __err_state: &mut ::peg::error::ErrorState,
         __pos: usize,
     ) -> ::peg::RuleResult<SpannedExpr> {
@@ -2091,9 +2092,9 @@ pub mod peg {
             }
         }
     }
-    fn __parse_labeled<'input>(
-        __input: &'input Input,
-        __state: &mut ParseState<'input>,
+    fn __parse_labeled(
+        __input: &FlatTokenStream,
+        __state: &mut ParseState,
         __err_state: &mut ::peg::error::ErrorState,
         __pos: usize,
     ) -> ::peg::RuleResult<TaggedExpr> {
@@ -2141,9 +2142,9 @@ pub mod peg {
             }
         }
     }
-    fn __parse_suffixed<'input>(
-        __input: &'input Input,
-        __state: &mut ParseState<'input>,
+    fn __parse_suffixed(
+        __input: &FlatTokenStream,
+        __state: &mut ParseState,
         __err_state: &mut ::peg::error::ErrorState,
         __pos: usize,
     ) -> ::peg::RuleResult<SpannedExpr> {
@@ -2370,9 +2371,9 @@ pub mod peg {
             }
         }
     }
-    fn __parse_repeatcount<'input>(
-        __input: &'input Input,
-        __state: &mut ParseState<'input>,
+    fn __parse_repeatcount(
+        __input: &FlatTokenStream,
+        __state: &mut ParseState,
         __err_state: &mut ::peg::error::ErrorState,
         __pos: usize,
     ) -> ::peg::RuleResult<BoundedRepeat> {
@@ -2495,9 +2496,9 @@ pub mod peg {
             }
         }
     }
-    fn __parse_repeatnum<'input>(
-        __input: &'input Input,
-        __state: &mut ParseState<'input>,
+    fn __parse_repeatnum(
+        __input: &FlatTokenStream,
+        __state: &mut ParseState,
         __err_state: &mut ::peg::error::ErrorState,
         __pos: usize,
     ) -> ::peg::RuleResult<TokenStream> {
@@ -2531,9 +2532,9 @@ pub mod peg {
             }
         }
     }
-    fn __parse_prefixed<'input>(
-        __input: &'input Input,
-        __state: &mut ParseState<'input>,
+    fn __parse_prefixed(
+        __input: &FlatTokenStream,
+        __state: &mut ParseState,
         __err_state: &mut ::peg::error::ErrorState,
         __pos: usize,
     ) -> ::peg::RuleResult<SpannedExpr> {
@@ -2659,9 +2660,9 @@ pub mod peg {
             }
         }
     }
-    fn __parse_primary<'input>(
-        __input: &'input Input,
-        __state: &mut ParseState<'input>,
+    fn __parse_primary(
+        __input: &FlatTokenStream,
+        __state: &mut ParseState,
         __err_state: &mut ::peg::error::ErrorState,
         __pos: usize,
     ) -> ::peg::RuleResult<SpannedExpr> {
@@ -2965,9 +2966,9 @@ pub mod peg {
         __state.primary_cache.insert(__pos, __rule_result.clone());
         __rule_result
     }
-    fn __parse_rule_arg<'input>(
-        __input: &'input Input,
-        __state: &mut ParseState<'input>,
+    fn __parse_rule_arg(
+        __input: &FlatTokenStream,
+        __state: &mut ParseState,
         __err_state: &mut ::peg::error::ErrorState,
         __pos: usize,
     ) -> ::peg::RuleResult<RuleArg> {
@@ -3043,9 +3044,9 @@ pub mod peg {
             }
         }
     }
-    fn __parse_precedence_level<'input>(
-        __input: &'input Input,
-        __state: &mut ParseState<'input>,
+    fn __parse_precedence_level(
+        __input: &FlatTokenStream,
+        __state: &mut ParseState,
         __err_state: &mut ::peg::error::ErrorState,
         __pos: usize,
     ) -> ::peg::RuleResult<PrecedenceLevel> {
@@ -3084,9 +3085,9 @@ pub mod peg {
             }
         }
     }
-    fn __parse_precedence_op<'input>(
-        __input: &'input Input,
-        __state: &mut ParseState<'input>,
+    fn __parse_precedence_op(
+        __input: &FlatTokenStream,
+        __state: &mut ParseState,
         __err_state: &mut ::peg::error::ErrorState,
         __pos: usize,
     ) -> ::peg::RuleResult<PrecedenceOperator> {
@@ -3138,18 +3139,18 @@ pub mod peg {
             }
         }
     }
-    fn __parse_sp<'input>(
-        __input: &'input Input,
-        __state: &mut ParseState<'input>,
+    fn __parse_sp(
+        __input: &FlatTokenStream,
+        __state: &mut ParseState,
         __err_state: &mut ::peg::error::ErrorState,
         __pos: usize,
     ) -> ::peg::RuleResult<Span> {
         #![allow(non_snake_case, unused, clippy::redundant_closure_call)]
         __input.next_span(__pos)
     }
-    fn __parse_KEYWORD<'input>(
-        __input: &'input Input,
-        __state: &mut ParseState<'input>,
+    fn __parse_KEYWORD(
+        __input: &FlatTokenStream,
+        __state: &mut ParseState,
         __err_state: &mut ::peg::error::ErrorState,
         __pos: usize,
     ) -> ::peg::RuleResult<()> {
@@ -3239,9 +3240,9 @@ pub mod peg {
             }
         }
     }
-    fn __parse_IDENT<'input>(
-        __input: &'input Input,
-        __state: &mut ParseState<'input>,
+    fn __parse_IDENT(
+        __input: &FlatTokenStream,
+        __state: &mut ParseState,
         __err_state: &mut ::peg::error::ErrorState,
         __pos: usize,
     ) -> ::peg::RuleResult<Ident> {
@@ -3273,45 +3274,45 @@ pub mod peg {
             }
         }
     }
-    fn __parse_LITERAL<'input>(
-        __input: &'input Input,
-        __state: &mut ParseState<'input>,
+    fn __parse_LITERAL(
+        __input: &FlatTokenStream,
+        __state: &mut ParseState,
         __err_state: &mut ::peg::error::ErrorState,
         __pos: usize,
     ) -> ::peg::RuleResult<Literal> {
         #![allow(non_snake_case, unused, clippy::redundant_closure_call)]
         __input.literal(__pos)
     }
-    fn __parse_PAREN_GROUP<'input>(
-        __input: &'input Input,
-        __state: &mut ParseState<'input>,
+    fn __parse_PAREN_GROUP(
+        __input: &FlatTokenStream,
+        __state: &mut ParseState,
         __err_state: &mut ::peg::error::ErrorState,
         __pos: usize,
     ) -> ::peg::RuleResult<Group> {
         #![allow(non_snake_case, unused, clippy::redundant_closure_call)]
         __input.group(__pos, Delimiter::Parenthesis)
     }
-    fn __parse_BRACE_GROUP<'input>(
-        __input: &'input Input,
-        __state: &mut ParseState<'input>,
+    fn __parse_BRACE_GROUP(
+        __input: &FlatTokenStream,
+        __state: &mut ParseState,
         __err_state: &mut ::peg::error::ErrorState,
         __pos: usize,
     ) -> ::peg::RuleResult<Group> {
         #![allow(non_snake_case, unused, clippy::redundant_closure_call)]
         __input.group(__pos, Delimiter::Brace)
     }
-    fn __parse_BRACKET_GROUP<'input>(
-        __input: &'input Input,
-        __state: &mut ParseState<'input>,
+    fn __parse_BRACKET_GROUP(
+        __input: &FlatTokenStream,
+        __state: &mut ParseState,
         __err_state: &mut ::peg::error::ErrorState,
         __pos: usize,
     ) -> ::peg::RuleResult<Group> {
         #![allow(non_snake_case, unused, clippy::redundant_closure_call)]
         __input.group(__pos, Delimiter::Bracket)
     }
-    fn __parse_LIFETIME<'input>(
-        __input: &'input Input,
-        __state: &mut ParseState<'input>,
+    fn __parse_LIFETIME(
+        __input: &FlatTokenStream,
+        __state: &mut ParseState,
         __err_state: &mut ::peg::error::ErrorState,
         __pos: usize,
     ) -> ::peg::RuleResult<()> {
@@ -3333,9 +3334,9 @@ pub mod peg {
             }
         }
     }
-    fn __parse_INTEGER<'input>(
-        __input: &'input Input,
-        __state: &mut ParseState<'input>,
+    fn __parse_INTEGER(
+        __input: &FlatTokenStream,
+        __state: &mut ParseState,
         __err_state: &mut ::peg::error::ErrorState,
         __pos: usize,
     ) -> ::peg::RuleResult<()> {

--- a/peg-macros/grammar.rustpeg
+++ b/peg-macros/grammar.rustpeg
@@ -1,4 +1,4 @@
-pub grammar peg() for FlatTokenStream {
+pub grammar peg() for &FlatTokenStream {
 
 use crate::ast::*;
 use crate::ast::Expr::*;

--- a/peg-macros/tokens.rs
+++ b/peg-macros/tokens.rs
@@ -111,25 +111,25 @@ impl ::std::fmt::Display for Sp {
     }
 }
 
-impl Parse for FlatTokenStream {
+impl Parse for &FlatTokenStream {
     type PositionRepr = Sp;
-    fn start(&self) -> usize {
+    fn start(self) -> usize {
         0
     }
 
-    fn is_eof(&self, pos: usize) -> bool {
+    fn is_eof(self, pos: usize) -> bool {
         pos >= self.tokens.len()
     }
 
-    fn position_repr(&self, pos: usize) -> Sp {
+    fn position_repr(self, pos: usize) -> Sp {
         Sp(self.tokens[pos].span(), pos)
     }
 }
 
-impl<'input> ParseElem<'input> for FlatTokenStream {
+impl<'input> ParseElem for &'input FlatTokenStream {
     type Element = &'input Token;
 
-    fn parse_elem(&'input self, pos: usize) -> RuleResult<&'input Token> {
+    fn parse_elem(self, pos: usize) -> RuleResult<&'input Token> {
         match self.tokens.get(pos) {
             Some(c) => RuleResult::Matched(pos + 1, c),
             None => RuleResult::Failed,
@@ -155,8 +155,8 @@ fn delimiter_end(d: Delimiter) -> &'static str {
     }
 }
 
-impl ParseLiteral for FlatTokenStream {
-    fn parse_string_literal(&self, pos: usize, literal: &str) -> RuleResult<()> {
+impl ParseLiteral for &FlatTokenStream {
+    fn parse_string_literal(self, pos: usize, literal: &str) -> RuleResult<()> {
         match self.tokens.get(pos) {
             Some(Token::Ident(i)) if i.to_string() == literal => RuleResult::Matched(pos + 1, ()),
             Some(Token::Punct(p)) if literal.starts_with(p.as_char()) => {
@@ -179,9 +179,9 @@ impl ParseLiteral for FlatTokenStream {
     }
 }
 
-impl<'input> ParseSlice<'input> for FlatTokenStream {
+impl<'input> ParseSlice for &FlatTokenStream {
     type Slice = TokenStream;
-    fn parse_slice(&'input self, p1: usize, p2: usize) -> TokenStream {
+    fn parse_slice(self, p1: usize, p2: usize) -> TokenStream {
         let mut ts = TokenStream::new();
         let mut pos = p1;
 

--- a/peg-macros/translate.rs
+++ b/peg-macros/translate.rs
@@ -66,8 +66,8 @@ pub(crate) fn compile_grammar(grammar: &Grammar) -> TokenStream {
         rules: &analysis.rules,
         rules_from_args: HashSet::new(),
         grammar_lifetime_params,
-        input_ty: quote!(&'input Input<#(#grammar_lifetime_params),*>),
-        parse_state_ty: quote!(&mut ParseState<'input #(, #grammar_lifetime_params)*>),
+        input_ty: grammar.input_type.clone(),
+        parse_state_ty: quote!(&mut ParseState<#(#grammar_lifetime_params),*>),
         extra_args_call: extra_args_call(grammar),
         extra_args_def: extra_args_def(grammar),
     };
@@ -120,7 +120,7 @@ pub(crate) fn compile_grammar(grammar: &Grammar) -> TokenStream {
     }
 
     let parse_state = make_parse_state(&grammar);
-    let Grammar { name, doc, input_type, visibility, .. } = grammar;
+    let Grammar { name, doc, visibility, .. } = grammar;
 
     let mut errors: Vec<TokenStream> = analysis.left_recursion.iter()
         .map(|rec| report_error(rec.span, rec.msg()))
@@ -134,8 +134,6 @@ pub(crate) fn compile_grammar(grammar: &Grammar) -> TokenStream {
         #visibility mod #name {
             #[allow(unused_imports)]
             use super::*;
-            type Input<#(#grammar_lifetime_params),*> = #input_type;
-            type PositionRepr<#(#grammar_lifetime_params),*> = <Input<#(#grammar_lifetime_params),*> as ::peg::Parse>::PositionRepr;
 
             #(#errors)*
             #parse_state
@@ -162,13 +160,13 @@ fn make_parse_state(grammar: &Grammar) -> TokenStream {
 
     quote_spanned! { span =>
         #[allow(unused_parens)]
-        struct ParseState<'input #(, #grammar_lifetime_params)*> {
-            _phantom: ::std::marker::PhantomData<(&'input () #(, &#grammar_lifetime_params ())*)>,
+        struct ParseState<#(#grammar_lifetime_params),*> {
+            _phantom: ::std::marker::PhantomData<(#(&#grammar_lifetime_params ()),*)>,
             #(#cache_fields_def),*
         }
 
-        impl<'input #(, #grammar_lifetime_params)*> ParseState<'input #(, #grammar_lifetime_params)*> {
-            fn new() -> ParseState<'input #(, #grammar_lifetime_params)*> {
+        impl<#(#grammar_lifetime_params),*> ParseState<#(#grammar_lifetime_params),*> {
+            fn new() -> ParseState<#(#grammar_lifetime_params),*> {
                 ParseState {
                     _phantom: ::std::marker::PhantomData,
                     #(#cache_fields: ::std::collections::HashMap::new()),*
@@ -298,7 +296,7 @@ fn compile_rule(context: &Context, rule: &Rule) -> TokenStream {
     };
 
     quote_spanned! { span =>
-        fn #name<'input #(, #grammar_lifetime_params)* #(, #ty_params)*>(__input: #input_ty, __state: #parse_state_ty, __err_state: &mut ::peg::error::ErrorState, __pos: usize #extra_args_def #(, #rule_params)*) -> ::peg::RuleResult<#ret_ty> {
+        fn #name<#(#grammar_lifetime_params,)* #(#ty_params,)*>(__input: #input_ty, __state: #parse_state_ty, __err_state: &mut ::peg::error::ErrorState, __pos: usize #extra_args_def #(, #rule_params)*) -> ::peg::RuleResult<#ret_ty> {
             #![allow(non_snake_case, unused, clippy::redundant_closure_call)]
             #fn_body
         }
@@ -331,7 +329,7 @@ fn compile_rule_export(context: &Context, rule: &Rule) -> TokenStream {
 
     quote_spanned! { span =>
         #doc
-        #visibility fn #name<'input #(, #grammar_lifetime_params)* #(, #ty_params)*>(__input: #input_ty #extra_args_def #(, #rule_params)*) -> ::std::result::Result<#ret_ty, ::peg::error::ParseError<PositionRepr<#(#grammar_lifetime_params),*>>> {
+        #visibility fn #name<#(#grammar_lifetime_params,)* #(#ty_params,)*>(__input: #input_ty #extra_args_def #(, #rule_params)*) -> ::std::result::Result<#ret_ty, ::peg::error::ParseError<<#input_ty as ::peg::Parse>::PositionRepr>> {
             #![allow(non_snake_case, unused)]
 
             let mut __err_state = ::peg::error::ErrorState::new(::peg::Parse::start(__input));

--- a/peg-runtime/error.rs
+++ b/peg-runtime/error.rs
@@ -108,7 +108,7 @@ impl ErrorState {
         RuleResult::Failed
     }
 
-    pub fn into_parse_error<I: Parse + ?Sized>(self, input: &I) -> ParseError<I::PositionRepr> {
+    pub fn into_parse_error<I: Parse + ?Sized>(self, input: I) -> ParseError<I::PositionRepr> {
         ParseError {
             location: Parse::position_repr(input, self.max_err_pos.into()),
             expected: self.expected,

--- a/peg-runtime/lib.rs
+++ b/peg-runtime/lib.rs
@@ -16,34 +16,34 @@ pub enum RuleResult<T> {
 
 /// A type that can be used as input to a parser.
 #[allow(clippy::needless_lifetimes)]
-pub trait Parse {
+pub trait Parse: Copy {
     type PositionRepr: Display;
-    fn start<'input>(&'input self) -> usize;
-    fn is_eof<'input>(&'input self, p: usize) -> bool;
-    fn position_repr<'input>(&'input self, p: usize) -> Self::PositionRepr;
+    fn start(self) -> usize;
+    fn is_eof(self, p: usize) -> bool;
+    fn position_repr(self, p: usize) -> Self::PositionRepr;
 }
 
 /// A parser input type supporting the `[...]` syntax.
-pub trait ParseElem<'input>: Parse {
+pub trait ParseElem: Parse {
     /// Type of a single atomic element of the input, for example a character or token
     type Element: Copy;
 
     /// Get the element at `pos`, or `Failed` if past end of input.
-    fn parse_elem(&'input self, pos: usize) -> RuleResult<Self::Element>;
+    fn parse_elem(self, pos: usize) -> RuleResult<Self::Element>;
 }
 
 /// A parser input type supporting the `"literal"` syntax.
 pub trait ParseLiteral: Parse {
     /// Attempt to match the `literal` string at `pos`, returning whether it
     /// matched or failed.
-    fn parse_string_literal(&self, pos: usize, literal: &str) -> RuleResult<()>;
+    fn parse_string_literal(self, pos: usize, literal: &str) -> RuleResult<()>;
 }
 
 /// A parser input type supporting the `$()` syntax.
-pub trait ParseSlice<'input>: Parse {
+pub trait ParseSlice: Parse {
     /// Type of a slice of the input.
     type Slice;
 
     /// Get a slice of input.
-    fn parse_slice(&'input self, p1: usize, p2: usize) -> Self::Slice;
+    fn parse_slice(self, p1: usize, p2: usize) -> Self::Slice;
 }

--- a/peg-runtime/slice.rs
+++ b/peg-runtime/slice.rs
@@ -1,24 +1,24 @@
 use super::{Parse, ParseElem, ParseLiteral, ParseSlice, RuleResult};
 
-impl<T> Parse for [T] {
+impl<'input, T> Parse for &'input [T] {
     type PositionRepr = usize;
-    fn start(&self) -> usize {
+    fn start(self) -> usize {
         0
     }
 
-    fn is_eof(&self, pos: usize) -> bool {
+    fn is_eof(self, pos: usize) -> bool {
         pos >= self.len()
     }
 
-    fn position_repr(&self, pos: usize) -> usize {
+    fn position_repr(self, pos: usize) -> usize {
         pos
     }
 }
 
-impl<'input, T: 'input + Copy> ParseElem<'input> for [T] {
+impl<'input, T: 'input + Copy> ParseElem for &'input [T] {
     type Element = T;
 
-    fn parse_elem(&'input self, pos: usize) -> RuleResult<T> {
+    fn parse_elem(self, pos: usize) -> RuleResult<T> {
         match self[pos..].first() {
             Some(c) => RuleResult::Matched(pos + 1, *c),
             None => RuleResult::Failed,
@@ -26,8 +26,8 @@ impl<'input, T: 'input + Copy> ParseElem<'input> for [T] {
     }
 }
 
-impl ParseLiteral for [u8] {
-    fn parse_string_literal(&self, pos: usize, literal: &str) -> RuleResult<()> {
+impl ParseLiteral for &[u8] {
+    fn parse_string_literal(self, pos: usize, literal: &str) -> RuleResult<()> {
         let l = literal.len();
         if self.len() >= pos + l && &self[pos..pos + l] == literal.as_bytes() {
             RuleResult::Matched(pos + l, ())
@@ -37,9 +37,9 @@ impl ParseLiteral for [u8] {
     }
 }
 
-impl<'input, T: 'input> ParseSlice<'input> for [T] {
+impl<'input, T: 'input> ParseSlice for &'input [T] {
     type Slice = &'input [T];
-    fn parse_slice(&'input self, p1: usize, p2: usize) -> &'input [T] {
+    fn parse_slice(self, p1: usize, p2: usize) -> &'input [T] {
         &self[p1..p2]
     }
 }

--- a/peg-runtime/str.rs
+++ b/peg-runtime/str.rs
@@ -22,17 +22,17 @@ impl Display for LineCol {
     }
 }
 
-impl Parse for str {
+impl Parse for &str {
     type PositionRepr = LineCol;
-    fn start(&self) -> usize {
+    fn start(self) -> usize {
         0
     }
 
-    fn is_eof(&self, pos: usize) -> bool {
+    fn is_eof(self, pos: usize) -> bool {
         pos >= self.len()
     }
 
-    fn position_repr(&self, pos: usize) -> LineCol {
+    fn position_repr(self, pos: usize) -> LineCol {
         let before = &self[..pos];
         let line = before.as_bytes().iter().filter(|&&c| c == b'\n').count() + 1;
         let column = before.chars().rev().take_while(|&c| c != '\n').count() + 1;
@@ -44,10 +44,10 @@ impl Parse for str {
     }
 }
 
-impl<'input> ParseElem<'input> for str {
+impl<'input> ParseElem for &'input str {
     type Element = char;
 
-    fn parse_elem(&'input self, pos: usize) -> RuleResult<char> {
+    fn parse_elem(self, pos: usize) -> RuleResult<char> {
         match self[pos..].chars().next() {
             Some(c) => RuleResult::Matched(pos + c.len_utf8(), c),
             None => RuleResult::Failed,
@@ -55,8 +55,8 @@ impl<'input> ParseElem<'input> for str {
     }
 }
 
-impl ParseLiteral for str {
-    fn parse_string_literal(&self, pos: usize, literal: &str) -> RuleResult<()> {
+impl ParseLiteral for &str {
+    fn parse_string_literal(self, pos: usize, literal: &str) -> RuleResult<()> {
         let l = literal.len();
         if self.len() >= pos + l && &self.as_bytes()[pos..pos + l] == literal.as_bytes() {
             RuleResult::Matched(pos + l, ())
@@ -66,9 +66,9 @@ impl ParseLiteral for str {
     }
 }
 
-impl<'input> ParseSlice<'input> for str {
+impl<'input> ParseSlice for &'input str {
     type Slice = &'input str;
-    fn parse_slice(&'input self, p1: usize, p2: usize) -> &'input str {
+    fn parse_slice(self, p1: usize, p2: usize) -> &'input str {
         &self[p1..p2]
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,7 +43,7 @@
 //!
 //! ```rust
 //! peg::parser!{
-//!   grammar list_parser() for str {
+//!   grammar list_parser() for &str {
 //!     rule number() -> u32
 //!       = n:$(['0'..='9']+) {? n.parse().or(Err("u32")) }
 //!
@@ -162,7 +162,7 @@
 //! algorithm.
 //!
 //! ```rust,no_run
-//! # peg::parser!{grammar doc() for str {
+//! # peg::parser!{grammar doc() for &str {
 //! # pub rule number() -> i64 = "..." { 0 }
 //! pub rule arithmetic() -> i64 = precedence!{
 //!   x:(@) "+" y:@ { x + y }
@@ -226,7 +226,7 @@
 //! For example:
 //! 
 //! ```rust,no_run
-//! # peg::parser!{grammar doc() for str {
+//! # peg::parser!{grammar doc() for &str {
 //! rule num_radix(radix: u32) -> u32
 //!   = n:$(['0'..='9']+) {? u32::from_str_radix(n, radix).or(Err("number")) }
 //! 
@@ -244,7 +244,7 @@
 //!
 //! Some rules should never appear in error messages, and can be suppressed with `quiet!{e}`:
 //! ```rust,no_run
-//! # peg::parser!{grammar doc() for str {
+//! # peg::parser!{grammar doc() for &str {
 //! rule whitespace() = quiet!{[' ' | '\n' | '\t']+}
 //! # }}
 //! # fn main() {}
@@ -254,7 +254,7 @@
 //! can use `quiet!{}` and `expected!()` together:
 //!
 //! ```rust,no_run
-//! # peg::parser!{grammar doc() for str {
+//! # peg::parser!{grammar doc() for &str {
 //! rule identifier()
 //!   = quiet!{[ 'a'..='z' | 'A'..='Z']['a'..='z' | 'A'..='Z' | '0'..='9' ]+}
 //!   / expected!("identifier")
@@ -269,7 +269,7 @@
 //!    pub struct Expr;
 //! }
 //!
-//! peg::parser!{grammar doc() for str {
+//! peg::parser!{grammar doc() for &str {
 //!     use self::ast::Expr;
 //! }}
 //! # fn main() {}
@@ -285,7 +285,7 @@
 //! module or function:
 //!
 //! ```rust,no_run
-//! # peg::parser!{grammar doc() for str {
+//! # peg::parser!{grammar doc() for &str {
 //! /// Parse an array expression.
 //! pub rule array() -> Vec<i32> = "[...]" { vec![] }
 //! # }}

--- a/tests/compile-fail/cache_with_args.rs
+++ b/tests/compile-fail/cache_with_args.rs
@@ -1,6 +1,6 @@
 extern crate peg;
 
-peg::parser!(grammar foo() for str { 
+peg::parser!(grammar foo() for &str {
     #[cache]
     rule foo(x: u32) = "foo" //~ ERROR
 

--- a/tests/compile-fail/duplicate_rule.rs
+++ b/tests/compile-fail/duplicate_rule.rs
@@ -1,6 +1,6 @@
 extern crate peg;
 
-peg::parser!(grammar foo() for str { //~ ERROR  the name `__parse_foo` is defined multiple times [E0428]
+peg::parser!(grammar foo() for &str { //~ ERROR  the name `__parse_foo` is defined multiple times [E0428]
     rule foo() = "foo"
 
     rule foo() = "xyz" //~ ERROR duplicate rule `foo`

--- a/tests/compile-fail/left_recursion_without_cache.rs
+++ b/tests/compile-fail/left_recursion_without_cache.rs
@@ -1,6 +1,6 @@
 extern crate peg;
 
-peg::parser!(grammar foo() for str {
+peg::parser!(grammar foo() for &str {
     rule rec() = rec() //~ ERROR left recursive rules create an infinite loop: rec -> rec
 
     rule foo()

--- a/tests/compile-fail/nullable_loop.rs
+++ b/tests/compile-fail/nullable_loop.rs
@@ -1,4 +1,4 @@
-peg::parser!(grammar e() for str {
+peg::parser!(grammar e() for &str {
     rule nested() = ("a"*)* //~ ERROR
 
     rule nested_ok() = ("a"+)*

--- a/tests/compile-fail/rule_args_errors.rs
+++ b/tests/compile-fail/rule_args_errors.rs
@@ -1,6 +1,6 @@
 extern crate peg;
 
-peg::parser!(grammar foo() for str {
+peg::parser!(grammar foo() for &str {
     rule foo(x: i32, y: rule<()>) = "foo"
     rule ok() = foo(1, <[_] {}>) 
 

--- a/tests/compile-fail/rust_action_syntax_error.rs
+++ b/tests/compile-fail/rust_action_syntax_error.rs
@@ -1,6 +1,6 @@
 extern crate peg;
 
-peg::parser!(grammar foo() for str {
+peg::parser!(grammar foo() for &str {
     rule foo() = { + } //~ ERROR expected expression, found `+`
 });
 

--- a/tests/compile-fail/rust_action_type_error.rs
+++ b/tests/compile-fail/rust_action_type_error.rs
@@ -3,7 +3,7 @@ extern crate peg;
 struct X;
 struct Y;
 
-peg::parser!(grammar foo() for str {
+peg::parser!(grammar foo() for &str {
     rule foo() -> X = "a" { Y } //~ ERROR
 });
 

--- a/tests/compile-fail/syntax_error.rs
+++ b/tests/compile-fail/syntax_error.rs
@@ -1,6 +1,6 @@
 extern crate peg;
 
-peg::parser!(grammar foo() for str {
+peg::parser!(grammar foo() for &str {
     fn asdf() {} //~ ERROR expected one of "#", "crate", "pub", "rule", "use", "}"
 });
 

--- a/tests/compile-fail/use_undefined_result.rs
+++ b/tests/compile-fail/use_undefined_result.rs
@@ -1,6 +1,6 @@
 extern crate peg;
 
-peg::parser!(grammar foo() for str {
+peg::parser!(grammar foo() for &str {
     rule foo() = "asdf"
 
     rule bar() -> u32 = x:foo() { 0 } //~ ERROR using result of rule `foo`, which does not return a value

--- a/tests/compile-fail/use_undefined_rule.rs
+++ b/tests/compile-fail/use_undefined_rule.rs
@@ -1,6 +1,6 @@
 extern crate peg;
 
-peg::parser!(grammar foo() for str {
+peg::parser!(grammar foo() for &str {
     rule bar() = foo() //~ ERROR undefined rule `foo`
 });
 

--- a/tests/run-pass/arithmetic.rs
+++ b/tests/run-pass/arithmetic.rs
@@ -1,7 +1,7 @@
 extern crate peg;
 use arithmetic::expression;
 
-peg::parser!( grammar arithmetic() for str {
+peg::parser!( grammar arithmetic() for &str {
     pub rule expression() -> i64
         = sum()
 

--- a/tests/run-pass/arithmetic_ast.rs
+++ b/tests/run-pass/arithmetic_ast.rs
@@ -10,7 +10,7 @@ pub enum Expression {
 
 parser!{
 /// Doc comment
-grammar arithmetic() for str {
+grammar arithmetic() for &str {
     /// Top level parser rule
     /// This doc comment has multiple lines to test support for that as well
     pub rule expression() -> Expression

--- a/tests/run-pass/arithmetic_infix.rs
+++ b/tests/run-pass/arithmetic_infix.rs
@@ -1,7 +1,7 @@
 
 extern crate peg;
 
-peg::parser!( grammar arithmetic() for str {
+peg::parser!( grammar arithmetic() for &str {
     rule number() -> i64
         = n:$(['0'..='9']+) { n.parse().unwrap() }
 

--- a/tests/run-pass/arithmetic_infix_ast.rs
+++ b/tests/run-pass/arithmetic_infix_ast.rs
@@ -1,7 +1,7 @@
 extern crate peg;
 
-peg::parser!( grammar arithmetic() for str {
-    rule ident() -> &'input str = $(['a'..='z']+)
+peg::parser!( grammar arithmetic<'a>() for &'a str {
+    rule ident() -> &'a str = $(['a'..='z']+)
     rule haskell_op() -> String = "`" i:ident() "`" [' '|'\n']* { i.to_owned() }
     rule plus() = "+" [' '|'\n']*
 

--- a/tests/run-pass/arithmetic_infix_ast_span.rs
+++ b/tests/run-pass/arithmetic_infix_ast_span.rs
@@ -1,7 +1,7 @@
 extern crate peg;
 
-peg::parser!( grammar arithmetic() for str {
-    rule ident() -> &'input str = $(['a'..='z']+)
+peg::parser!( grammar arithmetic<'a>() for &'a str {
+    rule ident() -> &'a str = $(['a'..='z']+)
 
     pub rule expression() -> Node = precedence!{
         start:position!() node:@ end:position!() { Node { start, node, end} }

--- a/tests/run-pass/arithmetic_with_left_recursion.rs
+++ b/tests/run-pass/arithmetic_with_left_recursion.rs
@@ -2,7 +2,7 @@ extern crate peg;
 
 use arithmetic::sum;
 
-peg::parser!( grammar arithmetic() for str {
+peg::parser!( grammar arithmetic() for &str {
     #[cache_left_rec]
     pub rule sum() -> i64
         = l:sum() "+" r:number() { l+r }

--- a/tests/run-pass/borrow_from_input.rs
+++ b/tests/run-pass/borrow_from_input.rs
@@ -1,6 +1,6 @@
 extern crate peg;
 
-peg::parser!(grammar borrows() for str {
+peg::parser!(grammar borrows<'input>() for &'input str {
     use std::borrow::{ToOwned, Cow};
    
     pub rule borrowed() -> &'input str

--- a/tests/run-pass/bytes.rs
+++ b/tests/run-pass/bytes.rs
@@ -2,7 +2,7 @@ extern crate peg;
 use peg::parser;
 
 parser!{
-    grammar byteparser() for [u8] {
+    grammar byteparser<'input>() for &'input [u8] {
         pub rule commands() -> Vec<&'input[u8]> = command()*
         rule command() -> &'input [u8] = ">" val:$([b' ' ..= b'~']+) [0] { val }
     }

--- a/tests/run-pass/conditional_block.rs
+++ b/tests/run-pass/conditional_block.rs
@@ -1,6 +1,6 @@
 extern crate peg;
 
-peg::parser!( grammar parse() for str {
+peg::parser!( grammar parse<'input>() for &'input str {
 
     pub rule dec_byte() -> u8
         = match_str:$(['0'..='9']*<,3>) {?

--- a/tests/run-pass/crate_import.rs
+++ b/tests/run-pass/crate_import.rs
@@ -1,7 +1,7 @@
 extern crate peg;
 
 peg::parser!{
-    pub grammar foo_parser() for str {
+    pub grammar foo_parser() for &str {
         use crate::types::Foo;
 
         pub rule foo() -> Foo

--- a/tests/run-pass/errors.rs
+++ b/tests/run-pass/errors.rs
@@ -1,6 +1,6 @@
 extern crate peg;
 
-peg::parser!{ grammar parser() for str {
+peg::parser!{ grammar parser() for &str {
     pub rule one_letter() = ['a'..='z']
 
     pub rule parse() -> usize

--- a/tests/run-pass/grammar_with_args_and_cache.rs
+++ b/tests/run-pass/grammar_with_args_and_cache.rs
@@ -1,7 +1,7 @@
 extern crate peg;
 
 peg::parser! {
-    grammar lol(config: bool) for str {
+    grammar lol(config: bool) for &str {
         #[cache_left_rec]
         rule one() -> ()
             = one() / "foo"

--- a/tests/run-pass/keyval.rs
+++ b/tests/run-pass/keyval.rs
@@ -1,7 +1,7 @@
 extern crate peg;
 use std::collections::HashMap;
 
-peg::parser!( grammar keyval() for str {
+peg::parser!( grammar keyval() for &str {
     rule number() -> i64
         = n:$(['0'..='9']+) { n.parse().unwrap() }
 

--- a/tests/run-pass/lifetimes.rs
+++ b/tests/run-pass/lifetimes.rs
@@ -2,7 +2,7 @@
 pub struct Token<'text>(&'text str);
 
 peg::parser!{
-    grammar tokenparser<'t>() for [Token<'t>] {
+    grammar tokenparser<'t>() for &'t [Token<'t>] {
         pub rule program() -> Vec<&'t str> = list()
 
         // add this indirection to ensure that rule args work with a global lifetime

--- a/tests/run-pass/memoization.rs
+++ b/tests/run-pass/memoization.rs
@@ -1,6 +1,6 @@
 extern crate peg;
 
-peg::parser!{ grammar memo() for str {
+peg::parser!{ grammar memo<'input>() for &'input str {
     #[cache]
     rule r() -> &'input str
         = s:$(['a'..='z']+) { s }

--- a/tests/run-pass/no_eof.rs
+++ b/tests/run-pass/no_eof.rs
@@ -2,7 +2,7 @@ extern crate peg;
 use peg::parser;
 
 parser!{
-    pub grammar g() for [u8] {
+    pub grammar g() for &[u8] {
         #[no_eof]
         pub rule foo() = "foo"
     }

--- a/tests/run-pass/optional.rs
+++ b/tests/run-pass/optional.rs
@@ -1,6 +1,6 @@
 extern crate peg;
 
-peg::parser!( grammar test_grammar() for str {
+peg::parser!( grammar test_grammar() for &str {
     pub rule options() -> Option<()>
         = "abc" v:"def"? {v}
 

--- a/tests/run-pass/pattern.rs
+++ b/tests/run-pass/pattern.rs
@@ -1,6 +1,6 @@
-peg::parser!( grammar test() for str {
+peg::parser!( grammar test<'i>() for &'i str {
     pub rule alphanumeric() = ['a'..='z' | 'A'..='Z' | '0'..='9']*
-    pub rule inverted_pat() -> &'input str = "(" s:$([^')']*) ")" {s}
+    pub rule inverted_pat() -> &'i str = "(" s:$([^')']*) ")" {s}
 
     pub rule capture() -> char = ['a'..='z']
     pub rule capture2() -> (char, char) = a:['a'..='z'] b:['0'..='9'] { (a, b) }

--- a/tests/run-pass/pos_neg_assert.rs
+++ b/tests/run-pass/pos_neg_assert.rs
@@ -1,6 +1,6 @@
 extern crate peg;
 
-peg::parser!( grammar lookahead() for str {
+peg::parser!( grammar lookahead<'input>() for &'input str {
     pub rule consonants()
         = (!['a'|'e'|'i'|'o'|'u']['a'..='z'])+
 

--- a/tests/run-pass/position.rs
+++ b/tests/run-pass/position.rs
@@ -1,6 +1,6 @@
 extern crate peg;
 
-peg::parser!(grammar test_grammar() for str {
+peg::parser!(grammar test_grammar() for &str {
     pub rule position() -> (usize, usize, usize)
         = start:position!() ['a']* middle:position!() ['b']* end:position!() { (start, middle, end) }
 });

--- a/tests/run-pass/renamed_imports.rs
+++ b/tests/run-pass/renamed_imports.rs
@@ -2,7 +2,7 @@ extern crate peg;
 
 const FOO: i32 = 42;
 
-peg::parser!(grammar test_grammar() for str {
+peg::parser!(grammar test_grammar() for &str {
     use super::FOO as F1;
     use super::{FOO as F2};
     pub rule renamed_imports() -> (i32, i32) = { (F1, F2) }

--- a/tests/run-pass/repeats.rs
+++ b/tests/run-pass/repeats.rs
@@ -1,6 +1,6 @@
 extern crate peg;
 
-peg::parser!( grammar repeats() for str {
+peg::parser!( grammar repeats<'i>() for &'i str {
     rule number() -> i64
         = n:$(['0'..='9']+) { n.parse().unwrap() }
 
@@ -25,7 +25,7 @@ peg::parser!( grammar repeats() for str {
     pub rule repeat_sep_3() -> Vec<i64>
         = digit() **<3> ","
 
-    pub rule repeat_variable() -> Vec<&'input str>
+    pub rule repeat_variable() -> Vec<&'i str>
         = (count:digit() s:$(['a'..='z'|'0'..='9']*<{count as usize}>) {s})*
 });
 

--- a/tests/run-pass/rule_args.rs
+++ b/tests/run-pass/rule_args.rs
@@ -1,6 +1,6 @@
 extern crate peg;
 
-peg::parser!( grammar ra() for str {
+peg::parser!( grammar ra() for &str {
     use peg::ParseLiteral;
 
     rule number() -> i64
@@ -28,7 +28,7 @@ peg::parser!( grammar ra() for str {
     pub rule use_complex_args() = complex_args(u32::max(5, 10), [1,1,3,5,8,13].iter().cloned().find(|x| { x % 2 == 0 }))
 
     pub rule lt_arg<'a>() = ""
-    pub rule ty_arg<T>(x: &T) = ""
+    pub rule ty_arg<T>(x: std::marker::PhantomData<T>) = ""
     pub rule ty_arg_bound<T: Copy>(x: T) = ""
     pub rule ty_arg_bound2<'a, T: std::marker::Copy + ?Sized + 'a>(x: T) = ""
 });

--- a/tests/run-pass/test-hygiene.rs
+++ b/tests/run-pass/test-hygiene.rs
@@ -10,7 +10,7 @@ struct HashMap;
 mod peg {}
 
 realpeg::parser!{
-    grammar p() for str {
+    grammar p() for &str {
         pub rule number() -> f64 = n:$(['0'..='9']+) { n.parse().unwrap() }
 
         #[cache]

--- a/tests/run-pass/tokens.rs
+++ b/tests/run-pass/tokens.rs
@@ -7,7 +7,7 @@ pub enum Token {
 }
 
 peg::parser!{
-    grammar tokenparser() for [Token] {
+    grammar tokenparser() for &[Token] {
         pub rule list() -> (i32, i32) = [Token::Open] [Token::Number(a)] [Token::Comma] [Token::Number(b)] [Token::Close] { (a, b) }
     }
 }

--- a/tests/run-pass/utf8.rs
+++ b/tests/run-pass/utf8.rs
@@ -1,6 +1,6 @@
 extern crate peg;
 
-peg::parser!(grammar test_grammar() for str {
+peg::parser!(grammar test_grammar() for &str {
     pub rule boundaries() -> String
         = n:$("foo") { n.to_string() }
 });


### PR DESCRIPTION
Rust-peg currently adds `&'input` to the specified input type. The `'input` lifetime violates macro hygiene and is confusing to use along with other explicitly-declared lifetimes used in the input type.

This change also allows `Copy` input wrapper types like [`SliceByRef`](https://github.com/kevinmehall/rust-peg/discussions/287#discussioncomment-2072856) to be zero-cost, instead of adding another layer of pointer indirection.

### Breaking change

All grammars must add  `&` to their input type, and if they use the `'input` lifetime, must explicitly declare it.

Before:
```rust
grammar g() for str {
```
After:
```rust
grammar g() for &str {
```
or
```rust
grammar g<'input>() for &'input str {
```

Additionally, the signatures of the `Parse`, `ParseElem`, `ParseLiteral`, and `ParseSlice` traits have changed. If you implement these traits for custom input types, you'll need to make changes to implement these traits for `&T` rather than `T`, and take `self` rather than `&self`.

### To Do
* [ ] Detect unfixed `str` and `[T]` input types and either automatically do the right thing or give an error message that is more actionable than the one Rust gives.
