### PR TITLE
Bootstrap-Based Cargo `fmt`

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -9,7 +9,7 @@ cp peg-macros/grammar_new.rs peg-macros/grammar.rs
 if cargo run -p peg-macros -- peg-macros/grammar.rustpeg > peg-macros/grammar_new.rs
 then
     diff -qs peg-macros/grammar.rs peg-macros/grammar_new.rs
-    rustfmt peg-macros/grammar.rs
+    cargo fmt
 else
     echo "Failed"
 fi

--- a/peg-macros/analysis.rs
+++ b/peg-macros/analysis.rs
@@ -52,7 +52,10 @@ impl LeftRecursionError {
 }
 
 impl<'a> LeftRecursionVisitor<'a> {
-    fn check(grammar: &'a Grammar, rules: &HashMap<String, &'a Rule>) -> (HashMap<String, bool>, Vec<LeftRecursionError>) {
+    fn check(
+        grammar: &'a Grammar,
+        rules: &HashMap<String, &'a Rule>,
+    ) -> (HashMap<String, bool>, Vec<LeftRecursionError>) {
         let mut visitor = LeftRecursionVisitor {
             rules,
             errors: Vec::new(),
@@ -64,7 +67,9 @@ impl<'a> LeftRecursionVisitor<'a> {
         for rule in grammar.iter_rules() {
             let nullable = visitor.walk_rule(rule);
             debug_assert!(visitor.stack.is_empty());
-            rule_nullability.entry(rule.name.to_string()).or_insert(nullable);
+            rule_nullability
+                .entry(rule.name.to_string())
+                .or_insert(nullable);
         }
 
         (rule_nullability, visitor.errors)
@@ -98,20 +103,18 @@ impl<'a> LeftRecursionVisitor<'a> {
                         let mut recursive_loop = self.stack[loop_start..].to_vec();
                         recursive_loop.push(name.clone());
                         match rule.cache {
-                            None | Some(Cache::Simple) =>
-                                self.errors.push(LeftRecursionError {
-                                    path: recursive_loop,
-                                    span: rule_ident.span(),
-                                }),
-                            _ => ()
-
+                            None | Some(Cache::Simple) => self.errors.push(LeftRecursionError {
+                                path: recursive_loop,
+                                span: rule_ident.span(),
+                            }),
+                            _ => (),
                         }
                         return false;
                     }
                     self.walk_rule(rule)
                 } else {
                     // Missing rule would have already been reported
-                   false
+                    false
                 }
             }
 
@@ -138,7 +141,11 @@ impl<'a> LeftRecursionVisitor<'a> {
                 true
             }
 
-            Repeat { ref inner, ref bound, .. } => {
+            Repeat {
+                ref inner,
+                ref bound,
+                ..
+            } => {
                 let inner_nullable = self.walk_expr(inner);
                 inner_nullable | !bound.has_lower_bound()
             }
@@ -161,10 +168,12 @@ impl<'a> LeftRecursionVisitor<'a> {
                     }
                 }
 
-               nullable
+                nullable
             }
 
-            LiteralExpr(_) | PatternExpr(_) | MethodExpr(_, _) | FailExpr(_) | MarkerExpr(_) => false,
+            LiteralExpr(_) | PatternExpr(_) | MethodExpr(_, _) | FailExpr(_) | MarkerExpr(_) => {
+                false
+            }
 
             PositionExpr => true,
         }
@@ -188,9 +197,11 @@ impl LoopNullabilityError {
     }
 }
 
-
 impl<'a> LoopNullabilityVisitor<'a> {
-    fn check(grammar: &'a Grammar, rule_nullability: &HashMap<String, bool>) -> Vec<LoopNullabilityError> {
+    fn check(
+        grammar: &'a Grammar,
+        rule_nullability: &HashMap<String, bool>,
+    ) -> Vec<LoopNullabilityError> {
         let mut visitor = LoopNullabilityVisitor {
             rule_nullability,
             errors: Vec::new(),
@@ -202,7 +213,6 @@ impl<'a> LoopNullabilityVisitor<'a> {
 
         visitor.errors
     }
-
 
     /// Walk an expr and its children analyzing the nullability of loop bodies.
     ///
@@ -220,7 +230,7 @@ impl<'a> LoopNullabilityVisitor<'a> {
                 let name = rule_ident.to_string();
                 *self.rule_nullability.get(&name).unwrap_or(&false)
             }
-            
+
             ActionExpr(ref elems, ..) => {
                 let mut nullable = true;
                 for elem in elems {
@@ -242,15 +252,21 @@ impl<'a> LoopNullabilityVisitor<'a> {
                 true
             }
 
-            Repeat { ref inner, ref bound, ref sep } => {
+            Repeat {
+                ref inner,
+                ref bound,
+                ref sep,
+            } => {
                 let inner_nullable = self.walk_expr(inner);
                 let sep_nullable = sep.as_ref().map_or(true, |sep| self.walk_expr(sep));
 
                 // The entire purpose of this analysis: report errors if the loop body is nullable
                 if inner_nullable && sep_nullable && !bound.has_upper_bound() {
-                    self.errors.push(LoopNullabilityError { span: this_expr.span });
+                    self.errors.push(LoopNullabilityError {
+                        span: this_expr.span,
+                    });
                 }
-                
+
                 inner_nullable | !bound.has_lower_bound()
             }
 
@@ -269,10 +285,12 @@ impl<'a> LoopNullabilityVisitor<'a> {
                     }
                 }
 
-                nullable 
+                nullable
             }
 
-            LiteralExpr(_) | PatternExpr(_) | MethodExpr(_, _) | FailExpr(_) | MarkerExpr(_) => false,
+            LiteralExpr(_) | PatternExpr(_) | MethodExpr(_, _) | FailExpr(_) | MarkerExpr(_) => {
+                false
+            }
             PositionExpr => true,
         }
     }

--- a/peg-macros/ast.rs
+++ b/peg-macros/ast.rs
@@ -29,7 +29,7 @@ pub enum Item {
 #[derive(Debug)]
 pub enum Cache {
     Simple,
-    Recursive
+    Recursive,
 }
 
 #[derive(Debug)]
@@ -77,7 +77,11 @@ pub enum Expr {
     MethodExpr(Ident, TokenStream),
     ChoiceExpr(Vec<SpannedExpr>),
     OptionalExpr(Box<SpannedExpr>),
-    Repeat { inner: Box<SpannedExpr>, bound: BoundedRepeat, sep: Option<Box<SpannedExpr>> },
+    Repeat {
+        inner: Box<SpannedExpr>,
+        bound: BoundedRepeat,
+        sep: Option<Box<SpannedExpr>>,
+    },
     PosAssertExpr(Box<SpannedExpr>),
     NegAssertExpr(Box<SpannedExpr>),
     ActionExpr(Vec<TaggedExpr>, Option<Group>),
@@ -93,7 +97,10 @@ pub enum Expr {
 
 impl Expr {
     pub fn at(self, sp: Span) -> SpannedExpr {
-        SpannedExpr { expr: self, span:sp }
+        SpannedExpr {
+            expr: self,
+            span: sp,
+        }
     }
 }
 
@@ -127,14 +134,14 @@ impl BoundedRepeat {
     pub fn has_lower_bound(&self) -> bool {
         match self {
             BoundedRepeat::None | BoundedRepeat::Both(None, _) => false,
-            BoundedRepeat::Plus | BoundedRepeat::Exact(_) | BoundedRepeat::Both(Some(_), _) => true
+            BoundedRepeat::Plus | BoundedRepeat::Exact(_) | BoundedRepeat::Both(Some(_), _) => true,
         }
     }
 
     pub fn has_upper_bound(&self) -> bool {
         match self {
-            BoundedRepeat::None |  BoundedRepeat::Plus | BoundedRepeat::Both(_, None) => false,
-            BoundedRepeat::Exact(_) | BoundedRepeat::Both(_, Some(_)) => true
+            BoundedRepeat::None | BoundedRepeat::Plus | BoundedRepeat::Both(_, None) => false,
+            BoundedRepeat::Exact(_) | BoundedRepeat::Both(_, Some(_)) => true,
         }
     }
 }

--- a/peg-macros/grammar.rs
+++ b/peg-macros/grammar.rs
@@ -2410,42 +2410,42 @@ pub mod peg {
                     ::peg::RuleResult::Matched(__pos, __value)
                 }
                 ::peg::RuleResult::Failed => {
-                    let __choice_res = match ::peg::ParseLiteral::parse_string_literal(
-                        __input, __pos, "<",
-                    ) {
-                        ::peg::RuleResult::Matched(__pos, __val) => {
-                            let __seq_res =
-                                match __parse_repeatnum(__input, __state, __err_state, __pos) {
-                                    ::peg::RuleResult::Matched(__newpos, __value) => {
-                                        ::peg::RuleResult::Matched(__newpos, Some(__value))
-                                    }
-                                    ::peg::RuleResult::Failed => {
-                                        ::peg::RuleResult::Matched(__pos, None)
-                                    }
-                                };
-                            match __seq_res {
-                                ::peg::RuleResult::Matched(__pos, min) => {
-                                    match ::peg::ParseLiteral::parse_string_literal(
-                                        __input, __pos, ",",
-                                    ) {
-                                        ::peg::RuleResult::Matched(__pos, __val) => {
-                                            let __seq_res = match __parse_repeatnum(
-                                                __input,
-                                                __state,
-                                                __err_state,
-                                                __pos,
-                                            ) {
-                                                ::peg::RuleResult::Matched(__newpos, __value) => {
+                    let __choice_res =
+                        match ::peg::ParseLiteral::parse_string_literal(__input, __pos, "<") {
+                            ::peg::RuleResult::Matched(__pos, __val) => {
+                                let __seq_res =
+                                    match __parse_repeatnum(__input, __state, __err_state, __pos) {
+                                        ::peg::RuleResult::Matched(__newpos, __value) => {
+                                            ::peg::RuleResult::Matched(__newpos, Some(__value))
+                                        }
+                                        ::peg::RuleResult::Failed => {
+                                            ::peg::RuleResult::Matched(__pos, None)
+                                        }
+                                    };
+                                match __seq_res {
+                                    ::peg::RuleResult::Matched(__pos, min) => {
+                                        match ::peg::ParseLiteral::parse_string_literal(
+                                            __input, __pos, ",",
+                                        ) {
+                                            ::peg::RuleResult::Matched(__pos, __val) => {
+                                                let __seq_res = match __parse_repeatnum(
+                                                    __input,
+                                                    __state,
+                                                    __err_state,
+                                                    __pos,
+                                                ) {
                                                     ::peg::RuleResult::Matched(
                                                         __newpos,
+                                                        __value,
+                                                    ) => ::peg::RuleResult::Matched(
+                                                        __newpos,
                                                         Some(__value),
-                                                    )
-                                                }
-                                                ::peg::RuleResult::Failed => {
-                                                    ::peg::RuleResult::Matched(__pos, None)
-                                                }
-                                            };
-                                            match __seq_res {
+                                                    ),
+                                                    ::peg::RuleResult::Failed => {
+                                                        ::peg::RuleResult::Matched(__pos, None)
+                                                    }
+                                                };
+                                                match __seq_res {
                                                 ::peg::RuleResult::Matched(__pos, max) => {
                                                     match ::peg::ParseLiteral::parse_string_literal(
                                                         __input, __pos, ">",
@@ -2468,21 +2468,21 @@ pub mod peg {
                                                     ::peg::RuleResult::Failed
                                                 }
                                             }
-                                        }
-                                        ::peg::RuleResult::Failed => {
-                                            __err_state.mark_failure(__pos, "\",\"");
-                                            ::peg::RuleResult::Failed
+                                            }
+                                            ::peg::RuleResult::Failed => {
+                                                __err_state.mark_failure(__pos, "\",\"");
+                                                ::peg::RuleResult::Failed
+                                            }
                                         }
                                     }
+                                    ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
                                 }
-                                ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
                             }
-                        }
-                        ::peg::RuleResult::Failed => {
-                            __err_state.mark_failure(__pos, "\"<\"");
-                            ::peg::RuleResult::Failed
-                        }
-                    };
+                            ::peg::RuleResult::Failed => {
+                                __err_state.mark_failure(__pos, "\"<\"");
+                                ::peg::RuleResult::Failed
+                            }
+                        };
                     match __choice_res {
                         ::peg::RuleResult::Matched(__pos, __value) => {
                             ::peg::RuleResult::Matched(__pos, __value)


### PR DESCRIPTION
This PR introduces the following changes:

* replaces the `rustfmt` with a project wide `cargo fmt`
* updates missing formatted source code files from the path `peg-macros`

Background of this PR:

* I've noticed that some files are not corresponding to the `rust` format and I want to provide some additions and changes to your project in the near future and in order to keep the change set at minimal level IMHO the current `master` state should be updated.
