### PR TITLE
fix: support generic argument in rule's return position

### DIFF
--- a/peg-macros/grammar.rs
+++ b/peg-macros/grammar.rs
@@ -50,7 +50,7 @@ pub mod peg {
             &mut __err_state,
             ::peg::Parse::start(__input),
         ) {
-            ::peg::RuleResult::Matched(__pos, __value) => {
+            ::peg::RuleResult::<Grammar>::Matched(__pos, __value) => {
                 if ::peg::Parse::is_eof(__input, __pos) {
                     panic!(
                         "Parser is nondeterministic: succeeded when reparsing for error position"

--- a/peg-macros/translate.rs
+++ b/peg-macros/translate.rs
@@ -389,7 +389,7 @@ fn compile_rule_export(context: &Context, rule: &Rule) -> TokenStream {
             __err_state.reparse_for_error();
 
             match #parse_fn(__input, &mut __state, &mut __err_state, ::peg::Parse::start(__input) #extra_args_call #(, #rule_params_call)*) {
-                ::peg::RuleResult::Matched(__pos, __value) => {
+                ::peg::RuleResult::<#ret_ty>::Matched(__pos, __value) => {
                     if #eof_check {
                         panic!("Parser is nondeterministic: succeeded when reparsing for error position");
                     } else {

--- a/tests/run-pass/rule_args.rs
+++ b/tests/run-pass/rule_args.rs
@@ -32,6 +32,7 @@ peg::parser!( grammar ra() for str {
     pub rule ty_arg<T>(x: &T) = ""
     pub rule ty_arg_bound<T: Copy>(x: T) = ""
     pub rule ty_arg_bound2<'a, T: std::marker::Copy + ?Sized + 'a>(x: T) = ""
+    pub rule ty_arg_bound_ret<T: std::str::FromStr>() -> T = {? "".parse().or(Err("oops")) }
 });
 
 use ra::*;


### PR DESCRIPTION
My use case is to parse a generic struct and require `FromStr` for that generic type.

```rust
struct Something<P>(P);

peg::parser! {
  grammar mu_grammar() for str {
    pub rule something<P: std::str::FromStr>() -> Something<P> {? ... }
  }
}
```

The issue occurs because the current generated code assumes that `P` is provided as an argument to the rule, but in this case, it isn't and must be inferred by the return type. The change is to help type inferrence in one position.