### PR TITLE
Fix identifier example in top-level docs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -256,7 +256,7 @@
 //! ```rust,no_run
 //! # peg::parser!{grammar doc() for str {
 //! rule identifier()
-//!   = quiet!{[ 'a'..='z' | 'A'..='Z']['a'..='z' | 'A'..='Z' | '0'..='9' ]+}
+//!   = quiet!{[ 'a'..='z' | 'A'..='Z']['a'..='z' | 'A'..='Z' | '0'..='9' ]*}
 //!   / expected!("identifier")
 //! # }}
 //! # fn main() {}


### PR DESCRIPTION
Formerly this example wouldn't parse single-letter identifiers, which might confuse someone using it directly.

If you'd like, another possible improvement is to make the doc test run and add the following to main:

```rust
fn main() {
    doc::identifier("a").expect("a");
    doc::identifier("foo1").expect("foo1");
    doc::identifier("1up").expect_err("starts with number");
    doc::identifier("hello there").expect_err("has a space");
}
```