### PR TITLE
change some std types to core equivalent

### DIFF
--- a/peg-macros/grammar.rs
+++ b/peg-macros/grammar.rs
@@ -6,13 +6,13 @@ pub mod peg {
     type PositionRepr = <Input as ::peg::Parse>::PositionRepr;
     #[allow(unused_parens)]
     struct ParseState<'input> {
-        _phantom: ::std::marker::PhantomData<(&'input ())>,
+        _phantom: ::core::marker::PhantomData<(&'input ())>,
         primary_cache: ::std::collections::HashMap<usize, ::peg::RuleResult<SpannedExpr>>,
     }
     impl<'input> ParseState<'input> {
         fn new() -> ParseState<'input> {
             ParseState {
-                _phantom: ::std::marker::PhantomData,
+                _phantom: ::core::marker::PhantomData,
                 primary_cache: ::std::collections::HashMap::new(),
             }
         }
@@ -23,7 +23,7 @@ pub mod peg {
     use proc_macro2::{Delimiter, Group, Ident, Literal, Span, TokenStream};
     pub fn peg_grammar<'input>(
         __input: &'input Input,
-    ) -> ::std::result::Result<Grammar, ::peg::error::ParseError<PositionRepr>> {
+    ) -> ::core::result::Result<Grammar, ::peg::error::ParseError<PositionRepr>> {
         #![allow(non_snake_case, unused)]
         let mut __err_state = ::peg::error::ErrorState::new(::peg::Parse::start(__input));
         let mut __state = ParseState::new();

--- a/peg-macros/translate.rs
+++ b/peg-macros/translate.rs
@@ -171,14 +171,14 @@ fn make_parse_state(grammar: &Grammar) -> TokenStream {
     quote_spanned! { span =>
         #[allow(unused_parens)]
         struct ParseState<'input #(, #grammar_lifetime_params)*> {
-            _phantom: ::std::marker::PhantomData<(&'input () #(, &#grammar_lifetime_params ())*)>,
+            _phantom: ::core::marker::PhantomData<(&'input () #(, &#grammar_lifetime_params ())*)>,
             #(#cache_fields_def),*
         }
 
         impl<'input #(, #grammar_lifetime_params)*> ParseState<'input #(, #grammar_lifetime_params)*> {
             fn new() -> ParseState<'input #(, #grammar_lifetime_params)*> {
                 ParseState {
-                    _phantom: ::std::marker::PhantomData,
+                    _phantom: ::core::marker::PhantomData,
                     #(#cache_fields: ::std::collections::HashMap::new()),*
                 }
             }
@@ -369,7 +369,7 @@ fn compile_rule_export(context: &Context, rule: &Rule) -> TokenStream {
 
     quote_spanned! { span =>
         #doc
-        #visibility fn #name<'input #(, #grammar_lifetime_params)* #(, #ty_params)*>(__input: #input_ty #extra_args_def #(, #rule_params)*) -> ::std::result::Result<#ret_ty, ::peg::error::ParseError<PositionRepr<#(#grammar_lifetime_params),*>>> {
+        #visibility fn #name<'input #(, #grammar_lifetime_params)* #(, #ty_params)*>(__input: #input_ty #extra_args_def #(, #rule_params)*) -> ::core::result::Result<#ret_ty, ::peg::error::ParseError<PositionRepr<#(#grammar_lifetime_params),*>>> {
             #![allow(non_snake_case, unused)]
 
             let mut __err_state = ::peg::error::ErrorState::new(::peg::Parse::start(__input));


### PR DESCRIPTION
Part 2 of the #294 series, this PR just simply replace some `std` types that can use `core` as its substitution. This will greatly help `no_std` compatibility, although there are still some issue unresolved, for example, the `vec!` macro is subtlety used and this is undefined in `no_std` context -- although adding `use alloc::vec;` statement back in would compile well, but this would imply the use of `alloc`, and I think it is okay for most situations. 

My own anecdotal use case is for a core part of a language parser that I want it to be `no_std` so it can be embedded easily into a ESP32 target to parse some Lispy command from serial console for configurating sensor states and setup WiFi information in flash memory -- and I don't want to use LALR parser there because memory access time is slow on that MCU. Although I can have a memory allocator there because each ESP32 device have their memory map well-defined and a global allocator is usually provided for free using their SDK. This solved my problem well and I guess 99% of the people can relax nicely here.

...But I have another use case: I'm writing a kernel command-line parser and the existence of a global allocator is not guaranteed at all time, so I can't use `alloc` at all most of the time especially when this parser ran before the virtual memory heap is initialized yet.

To be honest the implicit `vec` problem comes from here:
```
expression* - Repeat: match zero or more repetitions of expression and return the results as a Vec.
expression+ - One-or-more: match one or more repetitions of expression and return the results as a Vec.
expression*<n,m> - Range repeat: match between n and m repetitions of expression return the results as a Vec. [(details)](https://docs.rs/peg/latest/peg/#repeat-ranges)
expression ** delim - Delimited repeat: match zero or more repetitions of expression delimited with delim and return the results as a Vec.
expression **<n,m> delim - Delimited repeat (range): match between n and m repetitions of expression delimited with delim and return the results as a Vec. [(details)](https://docs.rs/peg/latest/peg/#repeat-ranges)
expression ++ delim - Delimited repeat (one or more): match one or more repetitions of expression delimited with delim and return the results as a Vec.
```
These operators are merely tail-recursive optimization for the equivalent recursion expansion, and it can be worked-around by going back to doing recursive expansions instead. 

For now, any user that does not use `alloc` but `no_std` must be aware of this issue, since we cannot disable these operators as a feature. 

Maybe we should document it instead and tell any user who wants to preserve these operators, they must define their own `Vec` type and implement their own `vec` macro that does static size allocation -- you can wrap the peg grammar inside a mod, and do whatever customization you want, so the freedom is up to what you defined in the super crate.

However, if you are not using those repeating operators at all, you don't have to worry: your code is already `no_std` ready now.