### PR TITLE
Add tracing support

### DIFF
--- a/peg-macros/Cargo.toml
+++ b/peg-macros/Cargo.toml
@@ -11,9 +11,10 @@ edition = "2018"
 quote = "1.0"
 proc-macro2 = "1.0.24"
 peg-runtime = { version = "= 0.8.1", path = "../peg-runtime" }
+tracing = { version = "0.1.37", optional = true, features = ["attributes"] }
 
 [features]
-trace = []
+trace = ["dep:tracing"]
 
 [lib]
 proc-macro = true

--- a/peg-runtime/error.rs
+++ b/peg-runtime/error.rs
@@ -71,6 +71,7 @@ impl<L: Display + Debug> ::std::error::Error for ParseError<L> {
 }
 
 #[doc(hidden)]
+#[derive(Debug)]
 pub struct ErrorState {
     /// Furthest failure we've hit so far.
     pub max_err_pos: usize,


### PR DESCRIPTION
This PR will address #344 but there is a catch: for some reason the macro just crash saying that something beyond my control:

```
PS E:\Git\github.com\stevefan1999-personal\rust-peg> cargo run -p peg-macros --features trace -- peg-macros/grammar.rustpeg > peg-macros/grammar_new.rs
    Finished dev [unoptimized + debuginfo] target(s) in 0.02s
     Running `target\debug\rust-peg.exe peg-macros/grammar.rustpeg`
thread 'main' panicked at 'index out of bounds: the len is 1994 but the index is 1994', peg-macros\tokens.rs:125:12
stack backtrace:
   0: std::panicking::begin_panic_handler
             at /rustc/23ee2af2f7669d521ad39ef8a506a4fa3d37ea5a/library\std\src\panicking.rs:577
   1: core::panicking::panic_fmt
             at /rustc/23ee2af2f7669d521ad39ef8a506a4fa3d37ea5a/library\core\src\panicking.rs:67
   2: core::panicking::panic_bounds_check
             at /rustc/23ee2af2f7669d521ad39ef8a506a4fa3d37ea5a/library\core\src\panicking.rs:162
   3: core::slice::index::impl$2::index<enum2$<rust_peg::tokens::Token> >
             at /rustc/23ee2af2f7669d521ad39ef8a506a4fa3d37ea5a\library\core\src\slice\index.rs:261
   4: alloc::vec::impl$13::index<enum2$<rust_peg::tokens::Token>,usize,alloc::alloc::Global>
             at /rustc/23ee2af2f7669d521ad39ef8a506a4fa3d37ea5a\library\alloc\src\vec\mod.rs:2694
   5: rust_peg::tokens::impl$3::position_repr
             at .\peg-macros\tokens.rs:125
   6: rust_peg::grammar::peg::__parse_peg_grammar
             at .\peg-macros\grammar.rs:155
   7: rust_peg::grammar::peg::peg_grammar
             at .\peg-macros\grammar.rs:32
   8: rust_peg::main
             at .\peg-macros\bin.rs:45
   9: core::ops::function::FnOnce::call_once<void (*)(),tuple$<> >
             at /rustc/23ee2af2f7669d521ad39ef8a506a4fa3d37ea5a\library\core\src\ops\function.rs:250
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
error: process didn't exit successfully: `target\debug\rust-peg.exe peg-macros/grammar.rustpeg` (exit code: 101) 
```

I'm not sure but does that looks like we have a memory constraint in procedural macros? I'm not aware of this, but so far the PR just added rule instrumentation and I tried to keep the original intent as much as possible. 

Not only instrumentation can let us get rid of another hidden `std` requirement, but that it will nested context -- the level of calling of functions that is very valuable in debugging recursive call by providing a tree-like structure for diagnostic. To print the tracings is now left up to the users, say like either I want to print it directly in stdout, or I could make a super fancy web app that sends the data to a remote server with WebSocket and display it in a canvas that actively traces the input value for replaying (_cough_ Jaeger)! Now I just showed one bizarre usage on how now the tracing's sky would be limitless.

But before I can pass the macro bootstrapping test, I would suggest keeping this in draft state.