### PR TITLE
Add unstable vector optimization options

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,18 @@
 version = 3
 
 [[package]]
+name = "arrayvec"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
+
+[[package]]
+name = "assert_matches"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
+
+[[package]]
 name = "basic-toml"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -33,8 +45,11 @@ checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
 name = "peg"
 version = "0.8.1"
 dependencies = [
+ "arrayvec",
+ "assert_matches",
  "peg-macros",
  "peg-runtime",
+ "smallvec",
  "trybuild",
 ]
 
@@ -42,14 +57,20 @@ dependencies = [
 name = "peg-macros"
 version = "0.8.1"
 dependencies = [
+ "arrayvec",
  "peg-runtime",
  "proc-macro2",
  "quote",
+ "smallvec",
 ]
 
 [[package]]
 name = "peg-runtime"
 version = "0.8.1"
+dependencies = [
+ "arrayvec",
+ "smallvec",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -102,6 +123,12 @@ dependencies = [
  "ryu",
  "serde",
 ]
+
+[[package]]
+name = "smallvec"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
 name = "syn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,9 @@ peg-macros = { path = "./peg-macros", version = "= 0.8.1" }
 peg-runtime = { path = "./peg-runtime", version = "= 0.8.1" }
 
 [dev-dependencies]
+arrayvec = "0.7.2"
+assert_matches = "1.5.0"
+smallvec = "1.10.0"
 trybuild = "1.0.80"
 
 [[test]]
@@ -29,4 +32,7 @@ harness = false
 default = ["std"]
 trace = ["peg-macros/trace"]
 std = ["peg-runtime/std"]
-unstable = ["peg-runtime/unstable"]
+alloc = ["peg-runtime/alloc", "peg-macros/alloc"]
+unstable = ["peg-runtime/unstable", "peg-macros/unstable"]
+arrayvec = ["peg-runtime/arrayvec", "peg-macros/arrayvec"]
+smallvec = ["peg-runtime/smallvec", "peg-macros/smallvec"]

--- a/peg-macros/Cargo.toml
+++ b/peg-macros/Cargo.toml
@@ -11,9 +11,15 @@ edition = "2018"
 quote = "1.0"
 proc-macro2 = "1.0.24"
 peg-runtime = { version = "= 0.8.1", path = "../peg-runtime" }
+smallvec = { version = "1.10.0", optional = true }
+arrayvec = { version = "0.7.2", optional = true }
 
 [features]
 trace = []
+unstable = []
+alloc = ["smallvec"]
+arrayvec = ["dep:arrayvec", "unstable"]
+smallvec = ["dep:smallvec", "unstable", "alloc"]
 
 [lib]
 proc-macro = true

--- a/peg-macros/grammar.rs
+++ b/peg-macros/grammar.rs
@@ -208,7 +208,7 @@ pub mod peg {
                     ::peg::RuleResult::Matched(__pos, p) => {
                         match ::peg::ParseLiteral::parse_string_literal(__input, __pos, ">") {
                             ::peg::RuleResult::Matched(__pos, __val) => {
-                                ::peg::RuleResult::Matched(__pos, (|| p)())
+                                ::peg::RuleResult::Matched(__pos, (|| p.to_vec())())
                             }
                             ::peg::RuleResult::Failed => {
                                 __err_state.mark_failure(__pos, "\">\"");
@@ -1693,7 +1693,7 @@ pub mod peg {
                     ::peg::RuleResult::Matched(__pos, p) => {
                         match ::peg::ParseLiteral::parse_string_literal(__input, __pos, ">") {
                             ::peg::RuleResult::Matched(__pos, __val) => {
-                                ::peg::RuleResult::Matched(__pos, (|| p)())
+                                ::peg::RuleResult::Matched(__pos, (|| p.to_vec())())
                             }
                             ::peg::RuleResult::Failed => {
                                 __err_state.mark_failure(__pos, "\">\"");
@@ -2016,7 +2016,7 @@ pub mod peg {
                                 if s.len() == 1 {
                                     s.into_iter().next().unwrap()
                                 } else {
-                                    ChoiceExpr(s).at(sp)
+                                    ChoiceExpr(s.to_vec()).at(sp)
                                 }
                             })(),
                         ),
@@ -2411,42 +2411,42 @@ pub mod peg {
                     ::peg::RuleResult::Matched(__pos, __value)
                 }
                 ::peg::RuleResult::Failed => {
-                    let __choice_res = match ::peg::ParseLiteral::parse_string_literal(
-                        __input, __pos, "<",
-                    ) {
-                        ::peg::RuleResult::Matched(__pos, __val) => {
-                            let __seq_res =
-                                match __parse_repeatnum(__input, __state, __err_state, __pos) {
-                                    ::peg::RuleResult::Matched(__newpos, __value) => {
-                                        ::peg::RuleResult::Matched(__newpos, Some(__value))
-                                    }
-                                    ::peg::RuleResult::Failed => {
-                                        ::peg::RuleResult::Matched(__pos, None)
-                                    }
-                                };
-                            match __seq_res {
-                                ::peg::RuleResult::Matched(__pos, min) => {
-                                    match ::peg::ParseLiteral::parse_string_literal(
-                                        __input, __pos, ",",
-                                    ) {
-                                        ::peg::RuleResult::Matched(__pos, __val) => {
-                                            let __seq_res = match __parse_repeatnum(
-                                                __input,
-                                                __state,
-                                                __err_state,
-                                                __pos,
-                                            ) {
-                                                ::peg::RuleResult::Matched(__newpos, __value) => {
+                    let __choice_res =
+                        match ::peg::ParseLiteral::parse_string_literal(__input, __pos, "<") {
+                            ::peg::RuleResult::Matched(__pos, __val) => {
+                                let __seq_res =
+                                    match __parse_repeatnum(__input, __state, __err_state, __pos) {
+                                        ::peg::RuleResult::Matched(__newpos, __value) => {
+                                            ::peg::RuleResult::Matched(__newpos, Some(__value))
+                                        }
+                                        ::peg::RuleResult::Failed => {
+                                            ::peg::RuleResult::Matched(__pos, None)
+                                        }
+                                    };
+                                match __seq_res {
+                                    ::peg::RuleResult::Matched(__pos, min) => {
+                                        match ::peg::ParseLiteral::parse_string_literal(
+                                            __input, __pos, ",",
+                                        ) {
+                                            ::peg::RuleResult::Matched(__pos, __val) => {
+                                                let __seq_res = match __parse_repeatnum(
+                                                    __input,
+                                                    __state,
+                                                    __err_state,
+                                                    __pos,
+                                                ) {
                                                     ::peg::RuleResult::Matched(
                                                         __newpos,
+                                                        __value,
+                                                    ) => ::peg::RuleResult::Matched(
+                                                        __newpos,
                                                         Some(__value),
-                                                    )
-                                                }
-                                                ::peg::RuleResult::Failed => {
-                                                    ::peg::RuleResult::Matched(__pos, None)
-                                                }
-                                            };
-                                            match __seq_res {
+                                                    ),
+                                                    ::peg::RuleResult::Failed => {
+                                                        ::peg::RuleResult::Matched(__pos, None)
+                                                    }
+                                                };
+                                                match __seq_res {
                                                 ::peg::RuleResult::Matched(__pos, max) => {
                                                     match ::peg::ParseLiteral::parse_string_literal(
                                                         __input, __pos, ">",
@@ -2469,21 +2469,21 @@ pub mod peg {
                                                     ::peg::RuleResult::Failed
                                                 }
                                             }
-                                        }
-                                        ::peg::RuleResult::Failed => {
-                                            __err_state.mark_failure(__pos, "\",\"");
-                                            ::peg::RuleResult::Failed
+                                            }
+                                            ::peg::RuleResult::Failed => {
+                                                __err_state.mark_failure(__pos, "\",\"");
+                                                ::peg::RuleResult::Failed
+                                            }
                                         }
                                     }
+                                    ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
                                 }
-                                ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,
                             }
-                        }
-                        ::peg::RuleResult::Failed => {
-                            __err_state.mark_failure(__pos, "\"<\"");
-                            ::peg::RuleResult::Failed
-                        }
-                    };
+                            ::peg::RuleResult::Failed => {
+                                __err_state.mark_failure(__pos, "\"<\"");
+                                ::peg::RuleResult::Failed
+                            }
+                        };
                     match __choice_res {
                         ::peg::RuleResult::Matched(__pos, __value) => {
                             ::peg::RuleResult::Matched(__pos, __value)
@@ -3078,7 +3078,7 @@ pub mod peg {
                 ::peg::RuleResult::Matched(__pos, operators) => ::peg::RuleResult::Matched(
                     __pos,
                     (|| PrecedenceLevel {
-                        operators: operators,
+                        operators: operators.to_vec(),
                     })(),
                 ),
                 ::peg::RuleResult::Failed => ::peg::RuleResult::Failed,

--- a/peg-macros/grammar.rustpeg
+++ b/peg-macros/grammar.rustpeg
@@ -10,7 +10,7 @@ pub rule peg_grammar() -> Grammar
         { Grammar { doc, visibility, name, lifetime_params, args, input_type, items } }
 
     rule rust_lifetime_params() -> Vec<TokenStream>
-        = "<" p:(($(LIFETIME())) ++ ",") ">" { p }
+        = "<" p:(($(LIFETIME())) ++ ",") ">" { p.to_vec() }
 
 rule grammar_args() -> Vec<(Ident, TokenStream)>
     = "(" args:((i:IDENT() ":" t:$(rust_type()) { (i, t) })**",") ","? ")" { args }
@@ -67,7 +67,7 @@ rule rust_ty_path()
     = "::"? (IDENT() ("::"? "<" (LIFETIME() / rust_type() / BRACE_GROUP() / LITERAL()) ++ "," ">")?) ++ "::"
 
 rule rust_ty_params() -> Vec<TokenStream>
-    = "<" p:($(rust_generic_param()) ++ ",") ">" { p }
+    = "<" p:($(rust_generic_param()) ++ ",") ">" { p.to_vec() }
 
 rule rust_generic_param()
     = LIFETIME() (":" LIFETIME() ++ "+")?
@@ -79,7 +79,7 @@ rule choice() -> SpannedExpr = sp:sp() s:sequence() ++ "/" {
     if s.len() == 1 {
         s.into_iter().next().unwrap()
     } else {
-        ChoiceExpr(s).at(sp)
+        ChoiceExpr(s.to_vec()).at(sp)
     }
 }
 
@@ -140,7 +140,7 @@ rule primary() -> SpannedExpr
 
 rule precedence_level() -> PrecedenceLevel
   = operators:precedence_op()+
-  { PrecedenceLevel{ operators: operators } }
+  { PrecedenceLevel{ operators: operators.to_vec() } }
 
 rule precedence_op() -> PrecedenceOperator
   = span:sp() elements:labeled()* action:BRACE_GROUP()

--- a/peg-runtime/Cargo.toml
+++ b/peg-runtime/Cargo.toml
@@ -11,5 +11,12 @@ edition = "2018"
 path = "lib.rs"
 
 [features]
-std = []
+std = ["arrayvec?/std"]
+alloc = ["smallvec"]
 unstable = []
+arrayvec = ["dep:arrayvec", "unstable"]
+smallvec = ["dep:smallvec", "unstable", "alloc"]
+
+[dependencies]
+arrayvec = { version = "0.7.2", optional = true, default-features = false }
+smallvec = { version = "1.10.0", optional = true }

--- a/peg-runtime/Cargo.toml
+++ b/peg-runtime/Cargo.toml
@@ -13,10 +13,11 @@ path = "lib.rs"
 [features]
 std = ["arrayvec?/std"]
 alloc = ["smallvec"]
-unstable = []
+unstable = ["scapegoat"]
 arrayvec = ["dep:arrayvec", "unstable"]
 smallvec = ["dep:smallvec", "unstable", "alloc"]
 
 [dependencies]
 arrayvec = { version = "0.7.2", optional = true, default-features = false }
+scapegoat = { version = "2.3.0", optional = true }
 smallvec = { version = "1.10.0", optional = true }

--- a/peg-runtime/lib.rs
+++ b/peg-runtime/lib.rs
@@ -69,7 +69,11 @@ pub trait ParseSlice<'input>: Parse {
     fn parse_slice(&'input self, p1: usize, p2: usize) -> Self::Slice;
 }
 
-#[cfg(not(feature = "std"))]
+// Requires `alloc` flag only if `unstable`, otherwise, requires `std` disabled
+#[cfg(any(
+    all(feature = "unstable", not(feature = "std"), feature = "alloc"),
+    not(any(feature = "unstable", feature = "std"))
+))]
 extern crate alloc;
 #[cfg(not(feature = "std"))]
 extern crate core as std;

--- a/peg-runtime/lib.rs
+++ b/peg-runtime/lib.rs
@@ -7,6 +7,21 @@ pub mod error;
 mod slice;
 pub mod str;
 
+#[cfg(feature = "unstable")]
+pub mod __private {
+    #[cfg(not(feature = "std"))]
+    pub use {alloc::vec, alloc::vec::Vec};
+
+    #[cfg(feature = "std")]
+    pub use {std::vec, std::vec::Vec};
+
+    #[cfg(feature = "arrayvec")]
+    pub use arrayvec::ArrayVec;
+
+    #[cfg(feature = "smallvec")]
+    pub use smallvec::SmallVec;
+}
+
 /// The result type used internally in the parser.
 ///
 /// You'll only need this if implementing the `Parse*` traits for a custom input

--- a/peg-runtime/lib.rs
+++ b/peg-runtime/lib.rs
@@ -9,7 +9,10 @@ pub mod str;
 
 #[cfg(feature = "unstable")]
 pub mod __private {
-    #[cfg(not(feature = "std"))]
+    #[cfg(all(
+        not(feature = "std"),
+        feature = "alloc"
+    ))]
     pub use {alloc::vec, alloc::vec::Vec};
 
     #[cfg(feature = "std")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -340,6 +340,8 @@
 //! ...
 //! ```
 
+#![cfg_attr(not(feature = "std"), no_std)]
+
 extern crate peg_macros;
 extern crate peg_runtime as runtime;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,7 +48,7 @@
 //!       = n:$(['0'..='9']+) {? n.parse().or(Err("u32")) }
 //!
 //!     pub rule list() -> Vec<u32>
-//!       = "[" l:(number() ** ",") "]" { l }
+//!       = "[" l:(number() ** ",") "]" { l.to_vec() }
 //!   }
 //! }
 //!
@@ -109,6 +109,12 @@
 //!     delimited with `delim` and return the results as a `Vec`. [(details)](#repeat-ranges)
 //!   * `expression ++ delim` - _Delimited repeat (one or more):_ match one or more repetitions of `expression`
 //!     delimited with `delim` and return the results as a `Vec`.
+//!
+//!   _unstable_: Relaxing `Vec` to `&[T]` of all the above operators respectively. This opens up certain optimizations and
+//!    even the possibility of removing `alloc` dependency.
+//!
+//!   _unstable_ and _arrayvec_: Treat `expression*<n,m>` and `expression **<n,m> delim` to use `ArrayVec` under the unstable assumption. **This does not require `alloc`**.
+//!   _unstable_ and _smallvec_: Treat `Vec` to use `SmallVec` under the unstable assumption. If _arrayvec_ is also enabled, _arrayvec_ precedes.
 //!
 //!  ### Special
 //!   * `$(e)` - _Slice:_ match the expression `e`, and return the slice of the input
@@ -230,7 +236,7 @@
 //! rule num_radix(radix: u32) -> u32
 //!   = n:$(['0'..='9']+) {? u32::from_str_radix(n, radix).or(Err("number")) }
 //!
-//! rule list<T>(x: rule<T>) -> Vec<T> = "[" v:(x() ** ",") ","? "]" {v}
+//! rule list<T>(x: rule<T>) -> Vec<T> = "[" v:(x() ** ",") ","? "]" { v.to_vec() }
 //!
 //! pub rule octal_list() -> Vec<u32> = list(<num_radix(8)>)
 //! # }}

--- a/tests/run-pass/repeats.rs
+++ b/tests/run-pass/repeats.rs
@@ -1,63 +1,64 @@
 extern crate peg;
+#[macro_use] extern crate assert_matches;
 
 peg::parser!( grammar repeats() for str {
     rule number() -> i64
         = n:$(['0'..='9']+) { n.parse().unwrap() }
 
     pub rule list() -> Vec<i64>
-        = number() ** ","
+        = n:(number() ** ",") { n.to_vec() }
 
     rule digit() -> i64
         = n:$(['0'..='9']) {n.parse().unwrap() }
 
     pub rule repeat_n() -> Vec<i64>
-        = digit()*<4>
+        = n:(digit()*<4>) { n.to_vec() }
 
     pub rule repeat_min() -> Vec<i64>
-        = digit()*<2,>
+        = n:(digit()*<2,>) { n.to_vec() }
 
     pub rule repeat_max() -> Vec<i64>
-        = digit()*<,2>
+        = n:(digit()*<,2>) { n.to_vec() }
 
     pub rule repeat_min_max() -> Vec<i64>
-        = digit()*<2,3>
+        = n:(digit()*<2,3>) { n.to_vec() }
 
     pub rule repeat_sep_3() -> Vec<i64>
-        = digit() **<3> ","
+        = n:(digit() **<3> ",") { n.to_vec() }
 
     pub rule repeat_variable() -> Vec<&'input str>
-        = (count:digit() s:$(['a'..='z'|'0'..='9']*<{count as usize}>) {s})*
+        = n:(count:digit() s:$(['a'..='z'|'0'..='9']*<{count as usize}>) {s})* { n.to_vec() }
 });
 
 use repeats::*;
 
 fn main() {
-    assert_eq!(list("5"), Ok(vec![5]));
-    assert_eq!(list("1,2,3,4"), Ok(vec![1,2,3,4]));
+    assert_matches!(list("5").as_deref(), Ok([5]));
+    assert_matches!(list("1,2,3,4").as_deref(), Ok([1,2,3,4]));
 
     assert!(repeat_n("123").is_err());
-    assert_eq!(repeat_n("1234"), Ok(vec![1,2,3,4]));
+    assert_matches!(repeat_n("1234").as_deref(), Ok([1,2,3,4]));
     assert!(repeat_n("12345").is_err());
 
     assert!(repeat_min("").is_err());
     assert!(repeat_min("1").is_err());
-    assert_eq!(repeat_min("12"), Ok(vec![1,2]));
-    assert_eq!(repeat_min("123"), Ok(vec![1,2,3]));
+    assert_matches!(repeat_min("12").as_deref(), Ok([1,2]));
+    assert_matches!(repeat_min("123").as_deref(), Ok([1,2,3]));
 
-    assert_eq!(repeat_max(""), Ok(vec![]));
-    assert_eq!(repeat_max("1"), Ok(vec![1]));
-    assert_eq!(repeat_max("12"), Ok(vec![1,2]));
+    assert_matches!(repeat_max("").as_deref(), Ok([]));
+    assert_matches!(repeat_max("1").as_deref(), Ok([1]));
+    assert_matches!(repeat_max("12").as_deref(), Ok([1,2]));
     assert!(repeat_max("123").is_err());
 
     assert!(repeat_min_max("").is_err());
     assert!(repeat_min_max("1").is_err());
-    assert_eq!(repeat_min_max("12"), Ok(vec![1,2]));
-    assert_eq!(repeat_min_max("123"), Ok(vec![1,2,3]));
+    assert_matches!(repeat_min_max("12").as_deref(), Ok([1,2]));
+    assert_matches!(repeat_min_max("123").as_deref(), Ok([1,2,3]));
     assert!(repeat_min_max("1234").is_err());
 
     assert!(repeat_sep_3("1,2").is_err());
     assert!(repeat_sep_3("1,2,3,4").is_err());
-    assert_eq!(repeat_sep_3("1,2,3"), Ok(vec![1,2,3]));
+    assert_matches!(repeat_sep_3("1,2,3").as_deref(), Ok([1,2,3]));
 
-    assert_eq!(repeat_variable("1a3abc222"), Ok(vec!["a", "abc", "22"]));
+    assert_matches!(repeat_variable("1a3abc222").as_deref(), Ok(["a", "abc", "22"]));
 }


### PR DESCRIPTION
This patch is of 3 features:

1. Vector size pre-allocation when `min` presents. If we know the minimum bound, we can safely assume we will need at least this much. This is handled by `SmallVec`, which will start from the stack, and spill the array to heap once it needs more. Requires `alloc`
2. Vector size pre-allocation when `max` presents. If we know the maximum bound, we can just make a stack of size of just `max`! We can just update the cursor and stop. It is guaranteed to require this much memory in any situations anyway. **This means `alloc` is no longer needed**. To be honest we could have just used a `mut [T; SIZE]` array but it does not have a `push` function -- I don't want to reinvent the `Vec` wheels.
3. However, sometimes there are edge cases where we cannot be sure if `min` and `max` are constant or not. We will fallback to using heap vector anyway, but we will leverage the information given to make sure the heap behavior would be more consistent. If you remember the old C++ days, you will know that preallocating a `std::vector` using `reserve` could cause a dramatic performance boost. This is especially popular during coding competitions. If you can't allocate this much memory, you will panic anyway, and it would also cause a partial parse. So no point to start the underlying memory from 0 and expanding to the top.
4. All of these features are gated behind `unstable`. Otherwise basically no change to the original behavior at all. **If `unstable` is enabled, that means repetition operators no longer produces `Vec<T>` -- It is relaxed to a `&[T]` instead**. This is the very 
basic ground assumption of why the stack array can be done, because it is not owned anymore. The end-user must be aware that it will have to be made owned manually, using such as `.to_vec()` or `.to_owned()` -- and this could cause surprising misuse and ABI breaking changes. hence why I decided to gate it behind `unstable`

All tests passed on my local machine by manually toggling the features. Parser self-bootstraping with `unstable,alloc` also works, however, this would require some parts of the original grammar to do `.to_vec()` manually -- and Rust would still do a copy to this day rather than moving the memory in far as I know, and also consider that since the code generated by procedural macro is up to the end user's environment, it is assumed some private crates on the runtime side is used to make sure the dependencies are consistent. This means enabling `unstable` loses the user's ability to choose their own macro, and is forced to use either `std::vec::Vec` or `alloc::vec::Vec` from the `peg-runtime` library using the private module.

Maybe the `unstable` feature need some rework. Both `arrayvec` and `smallvec` can actually run on stable. However, `staticvec` (https://docs.rs/staticvec/latest/staticvec/) is `unstable` because it uses const generics -- this is planned on a future expansion of the repetition optimization feature and is not done yet. StaticVec is useful if `min` == `max` but `arrayvec` should be able to satisfy most of the requirement now, it just eliminates an extra `length` pointer because the length is assumed in compile time.

Originally this is trying to use [tinyvec](https://github.com/Lokathor/tinyvec), but it has a strict requirement that the types need to have `Default` trait implemented which is nefariously hard. As such I'm also planning to fork the [tinyvec](https://github.com/Lokathor/tinyvec) crate, and make use of all of `staticvec`, `arrayvec` and `smallvec` at once, using [GAT](https://rust-lang.github.io/generic-associated-types-initiative/explainer/motivation.html).