### PR TITLE
Modify the contents of the stderr file

### DIFF
--- a/tests/compile-fail/rust_action_type_error.stderr
+++ b/tests/compile-fail/rust_action_type_error.stderr
@@ -7,14 +7,9 @@ error[E0308]: mismatched types
   |                           expected struct `X`, found struct `Y`
   |                           arguments to this enum variant are incorrect
   |
-help: the type constructed contains `Y` due to the type of the argument passed
-  --> tests/compile-fail/rust_action_type_error.rs:7:27
-   |
-7  |     rule foo() -> X = "a" { Y } //~ ERROR
-   |                           ^^^^^ this argument influences the type of `{{root}}`
 note: tuple variant defined here
-  --> peg-runtime/lib.rs
-   |
-   |     Matched(usize, T),
-   |     ^^^^^^^
-   = note: this error originates in the macro `peg::parser` (in Nightly builds, run with -Z macro-backtrace for more info)
+ --> peg-runtime/lib.rs
+  |
+  |     Matched(usize, T),
+  |     ^^^^^^^
+  = note: this error originates in the macro `peg::parser` (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
Fixed the contents of the stderr file(`rust_action_type_error.stderr`) not matching the expected error message.