### PR TITLE
Update lib.rs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -151,7 +151,7 @@
 //! ### Repeat ranges
 //!
 //! The repeat operators `*` and `**` can be followed by an optional range specification of the
-//! form `<n>` (exact), `<n,>` (min), `<,m>` (max) or `<n,m>` (range), where `n` and `m` are either
+//! form `<n>` (exact), `<n,>` (min-inclusive), `<,m>` (max-inclusive) or `<n,m>` (range-inclusive), where `n` and `m` are either
 //! integers, or a Rust `usize` expression enclosed in `{}`.
 //!
 //! ### Precedence climbing


### PR DESCRIPTION
Mention that range specifier is inclusive

Because rust-peg uses a different default versus Rust for the `max` range, being that `max` is `exclusive`, it is a good idea to mention this explicitly.