### PR TITLE
Allow inlining standard Parse* trait impls

### DIFF
--- a/peg-runtime/slice.rs
+++ b/peg-runtime/slice.rs
@@ -2,14 +2,17 @@ use super::{Parse, ParseElem, ParseLiteral, ParseSlice, RuleResult};
 
 impl<T> Parse for [T] {
     type PositionRepr = usize;
+    #[inline]
     fn start(&self) -> usize {
         0
     }
 
+    #[inline]
     fn is_eof(&self, pos: usize) -> bool {
         pos >= self.len()
     }
 
+    #[inline]
     fn position_repr(&self, pos: usize) -> usize {
         pos
     }
@@ -18,6 +21,7 @@ impl<T> Parse for [T] {
 impl<'input, T: 'input + Copy> ParseElem<'input> for [T] {
     type Element = T;
 
+    #[inline]
     fn parse_elem(&'input self, pos: usize) -> RuleResult<T> {
         match self[pos..].first() {
             Some(c) => RuleResult::Matched(pos + 1, *c),
@@ -27,6 +31,7 @@ impl<'input, T: 'input + Copy> ParseElem<'input> for [T] {
 }
 
 impl ParseLiteral for [u8] {
+    #[inline]
     fn parse_string_literal(&self, pos: usize, literal: &str) -> RuleResult<()> {
         let l = literal.len();
         if self.len() >= pos + l && &self[pos..pos + l] == literal.as_bytes() {
@@ -39,6 +44,7 @@ impl ParseLiteral for [u8] {
 
 impl<'input, T: 'input> ParseSlice<'input> for [T] {
     type Slice = &'input [T];
+    #[inline]
     fn parse_slice(&'input self, p1: usize, p2: usize) -> &'input [T] {
         &self[p1..p2]
     }

--- a/peg-runtime/str.rs
+++ b/peg-runtime/str.rs
@@ -24,10 +24,12 @@ impl Display for LineCol {
 
 impl Parse for str {
     type PositionRepr = LineCol;
+    #[inline]
     fn start(&self) -> usize {
         0
     }
 
+    #[inline]
     fn is_eof(&self, pos: usize) -> bool {
         pos >= self.len()
     }
@@ -47,6 +49,7 @@ impl Parse for str {
 impl<'input> ParseElem<'input> for str {
     type Element = char;
 
+    #[inline]
     fn parse_elem(&'input self, pos: usize) -> RuleResult<char> {
         match self[pos..].chars().next() {
             Some(c) => RuleResult::Matched(pos + c.len_utf8(), c),
@@ -56,6 +59,7 @@ impl<'input> ParseElem<'input> for str {
 }
 
 impl ParseLiteral for str {
+    #[inline]
     fn parse_string_literal(&self, pos: usize, literal: &str) -> RuleResult<()> {
         let l = literal.len();
         if self.len() >= pos + l && &self.as_bytes()[pos..pos + l] == literal.as_bytes() {
@@ -68,6 +72,7 @@ impl ParseLiteral for str {
 
 impl<'input> ParseSlice<'input> for str {
     type Slice = &'input str;
+    #[inline]
     fn parse_slice(&'input self, p1: usize, p2: usize) -> &'input str {
         &self[p1..p2]
     }


### PR DESCRIPTION
Trait impl methods need to be marked with #[inline] to allow cross-crate inlining.

As many of these functions are trivial, but they are called for every single position of the input, this has major impact:

- Performance of the new parse-rosetta-rs JSON parser example I recently contributed ([1]) increases by almost 40% on my machine, making it slightly faster than winnow (and possibly the fastest full-featured parser listed there)
- For a simple tokenizer I built for one of my projects, I measured a performance gain of ~94%, almost doubling the throughput!

[1] https://github.com/rosetta-rs/parse-rosetta-rs/blob/main/examples/peg-app/parser.rs