### PR TITLE
Remove `Vec` requirement

### DIFF
--- a/peg-macros/translate.rs
+++ b/peg-macros/translate.rs
@@ -670,7 +670,7 @@ fn compile_expr(context: &Context, e: &SpannedExpr, result_used: bool) -> TokenS
             let match_sep = if let Some(sep) = sep {
                 let sep_inner = compile_expr(context, sep, false);
                 quote_spanned! { span=>
-                    let __pos = if __repeat_value.is_empty() { __pos } else {
+                    let __pos = if __repeat_count == 0 { __pos } else {
                         let __sep_res = #sep_inner;
                         match __sep_res {
                             ::peg::RuleResult::Matched(__newpos, _) => { __newpos },
@@ -688,23 +688,24 @@ fn compile_expr(context: &Context, e: &SpannedExpr, result_used: bool) -> TokenS
                 quote!(())
             };
 
-            let (repeat_vec, repeat_step) =
-                if result_used || min.is_some() || max.is_some() || sep.is_some() {
-                    (
-                        Some(quote_spanned! { span => let mut __repeat_value = vec!(); }),
-                        Some(quote_spanned! { span => __repeat_value.push(__value); }),
-                    )
-                } else {
-                    (None, None)
-                };
+            let (repeat_vec, repeat_step) = if result_used {
+                (
+                    Some(quote_spanned! { span => let mut __repeat_value = Default::default(); }),
+                    Some(
+                        quote_spanned! { span => core::iter::Extend::extend(&mut __repeat_value, Some(__value)); },
+                    ),
+                )
+            } else {
+                (None, None)
+            };
 
             let max_check = max.map(|max| {
-                quote_spanned! { span=> if __repeat_value.len() >= #max { break } }
+                quote_spanned! { span=> if __repeat_count >= #max { break } }
             });
 
             let result_check = if let Some(min) = min {
                 quote_spanned! { span=>
-                    if __repeat_value.len() >= #min {
+                    if __repeat_count >= #min {
                         ::peg::RuleResult::Matched(__repeat_pos, #result)
                     } else {
                         ::peg::RuleResult::Failed
@@ -718,6 +719,7 @@ fn compile_expr(context: &Context, e: &SpannedExpr, result_used: bool) -> TokenS
                 let mut __repeat_pos = __pos;
                 #repeat_vec
 
+                let mut __repeat_count = 0usize;
                 loop {
                     let __pos = __repeat_pos;
 
@@ -734,6 +736,8 @@ fn compile_expr(context: &Context, e: &SpannedExpr, result_used: bool) -> TokenS
                             break;
                         }
                     }
+
+                    __repeat_count += 1;
                 }
 
                 #result_check

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,18 +97,18 @@
 //! ### Repetition
 //!   * `expression?` - _Optional:_ match zero or one repetitions of `expression`. Returns an
 //!     `Option`.
-//!   * `expression*` - _Repeat:_ match zero or more repetitions of `expression` and return the
-//!     results as a `Vec`.
-//!   * `expression+` - _One-or-more:_ match one or more repetitions of `expression` and return the
-//!     results as a `Vec`.
+//!   * `expression*` - _Repeat:_ match zero or more repetitions of `expression` and stores the
+//!     results in any collection implementing `Default` and `Extend`.
+//!   * `expression+` - _One-or-more:_ match one or more repetitions of `expression` and stores the
+//!     results in any collection implementing `Default` and `Extend`.
 //!   * `expression*<n,m>` - _Range repeat:_ match between `n` and `m` repetitions of `expression`
-//!     return the results as a `Vec`. [(details)](#repeat-ranges)
+//!     store the results in any collection implementing `Default` and `Extend`. [(details)](#repeat-ranges)
 //!   * `expression ** delim` - _Delimited repeat:_ match zero or more repetitions of `expression`
-//!     delimited with `delim` and return the results as a `Vec`.
+//!     delimited with `delim` and stores the results in any collection implementing `Default` and `Extend`.
 //!   * `expression **<n,m> delim` - _Delimited repeat (range):_ match between `n` and `m` repetitions of `expression`
-//!     delimited with `delim` and return the results as a `Vec`. [(details)](#repeat-ranges)
+//!     delimited with `delim` and stores the results in any collection implementing `Default` and `Extend`)
 //!   * `expression ++ delim` - _Delimited repeat (one or more):_ match one or more repetitions of `expression`
-//!     delimited with `delim` and return the results as a `Vec`.
+//!     delimited with `delim` and stores the results in any collection implementing `Default` and `Extend`.
 //!
 //!  ### Special
 //!   * `$(e)` - _Slice:_ match the expression `e`, and return the slice of the input

--- a/tests/run-pass/errors.rs
+++ b/tests/run-pass/errors.rs
@@ -4,7 +4,10 @@ peg::parser!{ grammar parser() for str {
     pub rule one_letter() = ['a'..='z']
 
     pub rule parse() -> usize
-        = v:( "a" / "\n" )* { v.len() }
+        = v:( "a" / "\n" )* {
+            let counter: ItemCounter = v;
+            counter.count()
+        }
 
     pub rule error_pos() = ("a" / "\n" / "\r")*
 
@@ -14,6 +17,26 @@ peg::parser!{ grammar parser() for str {
 
     pub rule var(s: &'static str) = expected!(s)
 }}
+
+struct ItemCounter {
+    count: usize,
+}
+impl Default for ItemCounter {
+    fn default() -> Self {
+        Self { count: 0 }
+    }
+}
+impl ItemCounter {
+    pub fn count(&self) -> usize {
+        self.count
+    }
+}
+impl Extend<()> for ItemCounter {
+    #[inline]
+    fn extend<T: IntoIterator<Item = ()>>(&mut self, into_iter: T) {
+        self.count += into_iter.into_iter().count();
+    }
+}
 
 fn main() {
     // errors at eof

--- a/tests/run-pass/keyval.rs
+++ b/tests/run-pass/keyval.rs
@@ -6,9 +6,7 @@ peg::parser!( grammar keyval() for str {
         = n:$(['0'..='9']+) { n.parse().unwrap() }
 
     pub rule keyvals() -> HashMap<i64, i64>
-        = kvs:keyval() ++ "\n" {
-            kvs.iter().cloned().collect::<HashMap<i64, i64>>()
-        }
+        = kvs:keyval() ++ "\n" { kvs }
 
     rule keyval() -> (i64, i64)
         = k:number() ":" + v:number() { (k, v) }


### PR DESCRIPTION
Hi,

I've wanted to be able to store repeated values into a structure of my choosing, instead of a `Vec`.

This change does that, without needing a temporary intermediate `Vec`. I believe it will also improve performance as expressions like `$(expression ** delim)` will currently create a temporary `Vec`.

Two examples from the tests of how this may improve some usage:
```diff
-        = v:( "a" / "\n" )* { v.len() }
+        = v:( "a" / "\n" )* {
+            // Does not store the items.
+            let counter: ItemCounter = v;
+            counter.count()
+        }
```
```diff
     pub rule keyvals() -> HashMap<i64, i64>
-        = kvs:keyval() ++ "\n" {
-            kvs.iter().cloned().collect::<HashMap<i64, i64>>()
-        }
+        = kvs:keyval() ++ "\n" { kvs }
```

Currently this works by requiring the collection the values are stored into to implement `Default` and `Extend`. It may sometimes be necessary to be explicit about the type like the `ItemCounter` example above. It also may not be able to infer the type of the `Extend<T>`'s `T` if it implements it for multiple types, in which case the new-type pattern might be necessary. I don't imagine that will be common though.